### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -11,6 +11,8 @@ import json
 import sys
 from typing import Any
 
+from ..utils.secret_redaction import secret_violations_in_text
+
 from ..agent.graph_dispatch import (
     dispatch_lint,
     dispatch_mutate,
@@ -181,12 +183,29 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _redact_text_if_sensitive(text: str) -> str:
+    if secret_violations_in_text(text):
+        return "[REDACTED: sensitive content]"
+    return text
+
+
+def _sanitize_for_output(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _sanitize_for_output(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_for_output(item) for item in value]
+    if isinstance(value, str):
+        return _redact_text_if_sensitive(value)
+    return value
+
+
 def _emit_result(result: str | dict[str, Any]) -> None:
     if isinstance(result, dict):
-        sys.stdout.write(json.dumps(result, ensure_ascii=False, indent=2))
+        safe_result = _sanitize_for_output(result)
+        sys.stdout.write(json.dumps(safe_result, ensure_ascii=False, indent=2))
         sys.stdout.write("\n")
     else:
-        sys.stdout.write(result)
+        sys.stdout.write(_redact_text_if_sensitive(result))
         if not result.endswith("\n"):
             sys.stdout.write("\n")
 


### PR DESCRIPTION
Potential fix for [https://github.com/MarcoPorcellato/matryca-plumber/security/code-scanning/3](https://github.com/MarcoPorcellato/matryca-plumber/security/code-scanning/3)

General fix: redact sensitive-looking values from outgoing CLI payloads before serializing/printing them, especially for error-bearing dictionaries returned from mutate/refactor/read/search dispatchers.

Best fix here (without changing core functionality): in `src/cli/__init__.py`, add a small recursive sanitizer that walks dict/list/string values and masks known secret patterns using the existing `secret_violations_in_text` helper. Then use this sanitizer in `_emit_result` before `json.dumps(...)`. This preserves the JSON shape and existing command behavior, while preventing clear-text secret disclosure in stdout.

Changes needed in `src/cli/__init__.py`:
- Add import: `secret_violations_in_text` from `..utils.secret_redaction`.
- Add helper methods near `_emit_result`:
  - `_redact_text_if_sensitive(text: str) -> str`
  - `_sanitize_for_output(value: Any) -> Any` (recursive for dict/list/str)
- Update `_emit_result` to serialize sanitized data instead of raw `result` dict.

No behavior change for non-sensitive output; only sensitive strings are replaced with a generic redaction marker.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
