### PR TITLE
feat(mcp): lazy AST bootstrap and Hermes Agent integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,6 +195,19 @@ MATRYCA_ALLOW_FLOCK_DEGRADATION=false
 # Range / notes: MCP host has full graph R/W — trust the host process
 MATRYCA_MCP_ENABLED=false
 
+# --- Hermes Agent (~/.hermes/config.yaml → mcp_servers.matryca-plumber.env) ---
+# Hermes is a supported MCP host alongside Claude Desktop / Cursor.
+# Install the host MCP client: cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
+# Example Hermes block (see docs/integrations/hermes-agent.md):
+#   command: uvx
+#   args: [matryca-plumber]
+#   env:
+#     MATRYCA_MCP_ENABLED: "true"
+#     LOGSEQ_GRAPH_PATH: /absolute/path/to/vault
+#   connect_timeout: 120   # large vaults: first tool call may parse the graph lazily
+# MATRYCA_MCP_ENABLED=true
+# LOGSEQ_GRAPH_PATH=/absolute/path/to/vault
+
 # Refuse UI startup without MATRYCA_UI_TOKEN. src/cli/ui_auth.py
 # Default (code): false
 # Template: false

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -89,7 +89,9 @@ Always **parse JSON from stdout** when using `--json`. Never hand-parse raw `pag
 
 ### 2.2 MCP (FastMCP **stdio** — NOT HTTP port 8080)
 
-MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, etc.) spawns `matryca-plumber` and talks JSON-RPC over stdin/stdout. There is **no** `mcp --port` flag in the v1.9 line.
+MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, **Hermes Agent**, etc.) spawns `matryca-plumber` and talks JSON-RPC over stdin/stdout. There is **no** `mcp --port` flag in the v1.9 line.
+
+**Lazy AST handshake (v1.9.6+):** MCP lifespan defers full-vault AST parsing until the **first graph tool call**. `initialize` + `tools/list` complete in seconds; `read_graph_data` / `target_type=bootstrap_status` and `target_type=memory` do **not** require the AST index.
 
 **Requirements:**
 1. `LOGSEQ_GRAPH_PATH` set to the vault root.
@@ -113,6 +115,30 @@ MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, etc.) spawns `matr
 
 With no CLI subcommand and MCP enabled, `uvx matryca-plumber` starts the **stdio** MCP server.  
 For interactive graph work without MCP, prefer the CLI in section 2.1.
+
+#### Hermes Agent (`~/.hermes/config.yaml`)
+
+Hermes requires the host MCP client extra: `cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"`.
+
+```yaml
+mcp_servers:
+  matryca-plumber:
+    command: uvx
+    args: [matryca-plumber]
+    env:
+      MATRYCA_MCP_ENABLED: "true"
+      LOGSEQ_GRAPH_PATH: /absolute/path/to/vault
+    enabled: true
+    connect_timeout: 120   # handshake (initialize + tools/list) — not vault parse time
+    timeout: 300           # per tool call; first graph tool pays AST load on large vaults
+```
+
+| Setting | Purpose |
+|---------|---------|
+| `connect_timeout` | Hermes **handshake** only (`initialize`, `tools/list`). **60–120 s** is enough with lazy AST. |
+| `timeout` | Each **tool invocation**. Raise for large vaults on the **first** graph read/search (AST cold start). Rule of thumb: `(pages + journals) × ~0.2 s` on slow mounts — measure once. |
+
+Full guide: `docs/integrations/hermes-agent.md` · stderr telemetry: `AST cache bootstrap started|complete` in `~/.hermes/logs/mcp-stderr.log`.
 
 ### 2.3 Diagnostics & audit (no `doctor` command)
 
@@ -187,6 +213,7 @@ For **today's journal page** as `read page`, use the **exact Logseq page title**
 * LLM OS contract (two-tier, Soft Gate, Safe-Sync): `SYSTEM_PROMPT.md` § "LLM OS"
 * Agent DX spec (CLI JSON, Journey Log — one cumulative `- 🤖 Matryca Activity` bullet per day in the daemon journal): `docs/openspec/agent-dx.md`
 * Security (MCP gate, graph allowlist, CLI redaction): `SECURITY.md`
+* Hermes Agent MCP (lazy handshake, timeouts): `docs/integrations/hermes-agent.md`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Hermes Agent MCP integration** — [`docs/integrations/hermes-agent.md`](docs/integrations/hermes-agent.md) with verified host config, troubleshooting, and `tests/test_hermes_mcp_handshake.py` (stdio `tools/list` within 30 s on a fixture vault).
+
+### Changed
+
+- **Lazy AST bootstrap for MCP stdio** — `prepare_matryca_runtime(..., eager_graph=False)` in MCP lifespan defers `LogseqGraph.load_directory` until the first graph tool call; daemon/CLI/UI remain eager. Structured stderr telemetry: `AST cache bootstrap started|complete` with `markdown_files`, `duration_s`, `pages_indexed`.
+
 ### Fixed
 
 - **GitHub traffic badges** — README Shields.io endpoints now read badge JSON from the `metrics` branch (`raw.githubusercontent.com/.../metrics/metrics/...`); `metrics-saver` publishes a metrics-only orphan branch via `METRICS_TOKEN` instead of bloating the branch with the full repo tree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ After `make install`, validate changes the way operators run the **Agentic OS** 
 
 Ensure your repo **`.env`** includes the Ironclad security block from **`.env.example`** (at minimum `MATRYCA_MCP_ENABLED=true` if you use MCP hosts). See [`SECURITY.md`](SECURITY.md) for the full matrix.
 
-**Optional MCP stdio** — set `MATRYCA_MCP_ENABLED=true` before invoking bare `matryca-plumber` (stdio MCP is off by default). Reach for a live MCP host only when you touch `mcp_server.py`, tool schemas, or host-specific serialization. Most graph and daemon behavior is proven faster with **`make test` / `make check`** plus the loop above — without wiring Claude Desktop.
+**Optional MCP stdio** — set `MATRYCA_MCP_ENABLED=true` before invoking bare `matryca-plumber` (stdio MCP is off by default). Supported MCP hosts include **Claude Desktop**, **Cursor**, and **[Hermes Agent](docs/integrations/hermes-agent.md)** (`~/.hermes/config.yaml`). Reach for a live MCP host only when you touch `mcp_server.py`, tool schemas, or host-specific serialization. Most graph and daemon behavior is proven faster with **`make test` / `make check`** plus the loop above — without wiring an external MCP host.
 
 6. List Make targets:
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ make perf
 | [`llms.txt`](llms.txt) / [`.well-known/llms.txt`](.well-known/llms.txt) | Agent execution guide (PyPI `uvx`, verified commands). |
 | [`docs/openspec/agent-onboarding.md`](docs/openspec/agent-onboarding.md) | `llms.txt` contract, anti-patterns, maintainer checklist. |
 | [`docs/openspec/llm-os-instructions.md`](docs/openspec/llm-os-instructions.md) | Two-tier LLM OS, Soft Gate, `bootstrap_status`, Safe-Sync. |
+| [`docs/integrations/hermes-agent.md`](docs/integrations/hermes-agent.md) | Hermes Agent MCP setup, lazy AST handshake, verified config. |
 | [`docs/PROJECT_DIARY.md`](docs/PROJECT_DIARY.md) | Maintainer log, phase history, crushed bottlenecks. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, `uv` commands, `make check` standards. |
 | [`SECURITY.md`](SECURITY.md) | Vulnerability reporting and `.env` hardening controls. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,11 +37,11 @@ Matryca Plumber ships several **defense-in-depth** controls you should configure
 
 **Dependency updates:** Transitive security fixes land via `uv.lock` (for example `aiohttp` ≥3.14.0 in v1.9.2). Dependabot PRs may trigger [`.github/workflows/dependabot-uv-fix.yml`](.github/workflows/dependabot-uv-fix.yml) to regenerate the lockfile on the PR branch.
 
-**Recommended local setup:** loopback UI only, set `MATRYCA_UI_TOKEN` on shared machines (or `MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true`), enable `MATRYCA_MCP_ENABLED=true` only on machines where you trust the MCP host (Cursor/Claude Desktop — full graph read/write, no stdio authentication), test graphs via `LOGSEQ_GRAPH_PATH` clones, and never commit `.env`.
+**Recommended local setup:** loopback UI only, set `MATRYCA_UI_TOKEN` on shared machines (or `MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true`), enable `MATRYCA_MCP_ENABLED=true` only on machines where you trust the MCP host ([Hermes Agent](docs/integrations/hermes-agent.md), Cursor, Claude Desktop — full graph read/write, no stdio authentication), test graphs via `LOGSEQ_GRAPH_PATH` clones, and never commit `.env`.
 
 ### MCP trust boundary
 
-The optional FastMCP stdio sidecar (`matryca-plumber` with no CLI arguments when `MATRYCA_MCP_ENABLED=true`) exposes the same mutation tools as the daemon. The MCP **host process** is the security boundary: treat it like shell access to your graph directory. Do not enable MCP when the host may run untrusted extensions or shared automation.
+The optional FastMCP stdio sidecar (`matryca-plumber` with no CLI arguments when `MATRYCA_MCP_ENABLED=true`) exposes the same mutation tools as the daemon. The MCP **host process** is the security boundary: treat it like shell access to your graph directory. This applies equally to **Hermes Agent** (stdio subprocess under `~/.hermes/config.yaml`), **Cursor**, and **Claude Desktop**. Do not enable MCP when the host may run untrusted extensions or shared automation.
 
 ## Non-goals
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ Matryca Plumber evolved from an MCP-first bridge into a **three-surface runtime*
 |---------|------------|--------------|
 | **Maintenance daemon** | Python (`MaintenanceDaemon`) | Autonomous duty-cycle scans, semantic indexing, cognitive lint, ledger checkpoints |
 | **Sovereign UI** | React SPA + FastAPI (`ui_server.py`) | Loopback control room: telemetry, Trust & Safety toggles, daemon lifecycle, `.env` hot-swap |
-| **MCP sidecar** | FastMCP stdio (`main.py`) | Optional tool host for Claude Desktop and other MCP clients — **same `graph_dispatch` contract** |
+| **MCP sidecar** | FastMCP stdio (`main.py`) | Optional tool host for Claude Desktop, Cursor, **Hermes Agent**, and other MCP clients — **same `graph_dispatch` contract** |
 
 **FastMCP is auxiliary.** The product’s center of gravity is `matryca plumber start` plus the Sovereign UI. MCP attaches the identical read/write path when an external host spawns `matryca-plumber` without CLI-shaped arguments.
 
@@ -167,6 +167,8 @@ The UI never becomes a second source of truth: it reads daemon checkpoints and l
 **Entry:** `matryca-plumber` with **no** CLI-shaped argv → `src/main.py` (lazy-imported from `plumber_entry.py`)
 
 `register_mcp_tools` exposes five polymorphic mega-tools (`read_graph_data`, `search_graph`, `mutate_graph`, `refactor_blocks`, `run_linter`) plus **`store_fact`** (identity) and **`ingest_document`** (atomic external markdown → ingest page + `LOG`/`GLOSSARY`, parse via OS temp files only). **`guard_mcp_tool`** maps domain errors to LLM-safe strings and appends Telos/Constraints context to successful responses (except `store_fact`); **`mcp_telemetry`** bridges Loguru INFO+ lines to `Context.info` during tool calls.
+
+**Lazy AST bootstrap (v1.9.6):** MCP `app_lifespan` calls `prepare_matryca_runtime(..., eager_graph=False)` so Hermes and other hosts complete `initialize` / `tools/list` in seconds. Daemon, CLI, and Sovereign UI remain **eager** (full `LogseqGraph.load_directory` at startup). The AST index loads on the first tool path that calls `get_graph_ast_cache().get_graph()`; stderr logs `AST cache bootstrap started|complete` with `markdown_files`, `duration_s`, `pages_indexed`. See [`integrations/hermes-agent.md`](integrations/hermes-agent.md).
 
 **Routing fix (`plumber_entry.py`):** the `matryca-plumber` console script inspects `sys.argv`. Known CLI commands (`plumber`, `read`, `search`, shorthand `start`/`status`/…) route to `cli.main` **without** importing FastMCP. Bare invocations (typical MCP host stdio spawn) fall through to `main.main()`. This disentangles **operator CLI stdout** from **MCP JSON-RPC on stdio** — a class of integration bugs that plagued single-entrypoint packages.
 
@@ -443,7 +445,7 @@ graph LR
 
 ## Runtime bootstrap
 
-Every Matryca Plumber surface (daemon, MCP lifespan, CLI, Sovereign UI) calls **`prepare_matryca_runtime()`** in `src/utils/runtime_bootstrap.py` after environment load and **before** graph processing. The helper is idempotent.
+Every Matryca Plumber surface (daemon, MCP lifespan, CLI, Sovereign UI) calls **`prepare_matryca_runtime()`** in `src/utils/runtime_bootstrap.py` after environment load and **before** graph processing. The helper is idempotent. **`eager_graph=True`** (default) loads the AST index immediately; **MCP stdio** passes **`eager_graph=False`** and defers AST parsing to the first graph tool call.
 
 | Provisioned at startup | Location | Motivation |
 |------------------------|----------|------------|
@@ -452,7 +454,7 @@ Every Matryca Plumber surface (daemon, MCP lifespan, CLI, Sovereign UI) calls **
 | Semantic cache dir | `<vault>/.matryca_semantic_cache/` | `master_catalog.json`, `backlink_counts.json`, `semantic_clusters.json`, per-inference `*.json`; excluded from `pages/` scans |
 | Templates dir | `<vault>/templates/` (or YAML `templates_subdir`) | `read_logseq_template` |
 | Wiki orchestration | `<vault>/matryca-wiki.yml` | Seeded from `matryca-wiki.example.yml` when missing |
-| AST + identity RAM | `get_graph_ast_cache`, `get_identity_store` | Graph index bootstrap; Telos/Constraints load when config page exists |
+| AST + identity RAM | `get_graph_ast_cache`, `get_identity_store` | **Eager** surfaces: at startup. **MCP lazy:** on first `get_graph()` (identity loads with first graph access) |
 
 **Not** created at bootstrap: repo `.env`, `pages/` / `journals/` (vault must already be valid), identity config page (operator-created or seeded by `store_fact`), ingest / `LOG` / `GLOSSARY` pages (first `ingest_document`), daemon/X-Ray JSON ledgers, PID/lock files — those follow first-use or first-checkpoint semantics.
 

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -1,0 +1,240 @@
+# Hermes Agent integration — compatibility report
+
+**Date:** 2026-06-07  
+**Status:** Verified working (stdio MCP, 7 tools)  
+**Test environment:** OrbStack Linux (`hermes-sandbox`), Hermes Agent v0.16.0, matryca-plumber local venv  
+**Vault:** `/mnt/mac/Users/marco1/logseq_test` (~1 106 Markdown files)
+
+This document records a real integration session between **Hermes Agent** and **Matryca Plumber** MCP, root causes of initial failure, the working configuration, and recommended repo/doc changes so future operators do not hit the same pitfalls.
+
+---
+
+## Executive summary
+
+| Layer | Issue | Fix |
+|-------|--------|-----|
+| **Hermes host** | Python `mcp` SDK not installed (`hermes-agent[mcp]` extra missing) | `uv pip install -e ".[mcp]"` in `~/.hermes/hermes-agent` |
+| **Hermes config** | `connect_timeout: 60` too low before lazy bootstrap (legacy) | **60–120 s** suffices for handshake after v1.9.x lazy AST |
+| **Hermes config** | Invalid `cwd`, wrong `MATRYCA_L1_PATH` / `MATRYCA_WIKI_CONFIG` overrides | Remove overrides; rely on runtime bootstrap |
+| **Matryca Plumber** | Eager AST bootstrap blocked MCP `initialize` on large vaults | **Fixed:** MCP lifespan uses `eager_graph=False`; AST loads on first graph tool call |
+| **Operations** | Orphan `uvx matryca-plumber` processes after failed connects | Kill zombies before retry; prefer pinned local binary over `uvx` in dev |
+
+After host-side fixes, Hermes discovered **7 MCP tools**. With **lazy AST bootstrap** (Plumber ≥ current), `tools/list` completes in **&lt; 30 s**; the first graph-mutating tool call pays the vault parse cost (see `mcp-stderr.log` telemetry).
+
+---
+
+## Verified Hermes configuration
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  matryca-plumber:
+    # Production / zero-install:
+    # command: uvx
+    # args: [matryca-plumber]
+
+    # Dev (faster cold start, pinned version):
+    command: /path/to/matryca-plumber/.venv/bin/matryca-plumber
+    args: []
+
+    env:
+      MATRYCA_MCP_ENABLED: "true"
+      LOGSEQ_GRAPH_PATH: /absolute/path/to/logseq/vault   # must contain pages/
+
+    enabled: true
+    timeout: 300          # per tool call
+    connect_timeout: 120  # handshake; first graph tool may take longer on large vaults
+```
+
+### Hermes prerequisites
+
+From [Hermes MCP docs](https://hermes-agent.dev/docs/user-guide/features/mcp):
+
+```bash
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[mcp]"
+```
+
+Restart Hermes or run `/reload-mcp` after config changes.
+
+### OrbStack / Mac filesystem
+
+When the vault lives on the Mac host, mount it in the Hermes container (see `~/.hermes/docker-compose.matryca-plumber.yml` pattern) and use **`/mnt/mac/Users/...`** paths in `LOGSEQ_GRAPH_PATH`, not macOS-only paths invisible from Linux.
+
+---
+
+## What was broken (chronological)
+
+### 1. Missing Hermes MCP client (`failed` in banner)
+
+Hermes banner showed `matryca-plumber (stdio) — failed` because `_MCP_AVAILABLE` was `False` in the Hermes venv:
+
+```
+ImportError: MCP server 'matryca-plumber' requires the 'mcp' Python SDK
+```
+
+This is **not** a Matryca Plumber bug. The host must install `hermes-agent[mcp]` even when the MCP server subprocess is launched via `uvx`.
+
+### 2. `connect_timeout` vs startup latency (historical + current)
+
+**Before lazy bootstrap:** Matryca Plumber ran **synchronous full-vault AST bootstrap** inside MCP lifespan before yielding to FastMCP. On large vaults (~1 106 files), Hermes `connect_timeout: 60` caused handshake failures.
+
+**Current behavior (lazy AST):** MCP lifespan calls `prepare_matryca_runtime(..., eager_graph=False)` — only light provisioning (L1, wiki YAML, cache dirs). The AST loads on the **first tool call** that needs the graph via `get_graph_ast_cache().get_graph()`. Hermes `initialize` + `tools/list` complete in seconds (`tests/test_hermes_mcp_handshake.py` asserts &lt; 30 s).
+
+Structured stderr telemetry when the graph loads:
+
+```
+AST cache bootstrap started    phase=start markdown_files=…
+AST cache bootstrap complete   phase=complete duration_s=… pages_indexed=…
+```
+
+Check `~/.hermes/logs/mcp-stderr.log` if the **first graph tool** is slow, not the handshake.
+
+### 3. Misconfigured path overrides
+
+Previous config set `MATRYCA_L1_PATH` and `MATRYCA_WIKI_CONFIG` under `Documents/.../LOGSEQ copy test LLM/` — a directory that was **empty** and **outside** the graph-root allowlist relative to `LOGSEQ_GRAPH_PATH`. Plumber logged:
+
+```
+MATRYCA_WIKI_CONFIG path is outside allowed roots; ignoring explicit override
+```
+
+**Recommendation:** omit these env vars unless paths are under the vault or `$HOME` per `src/utils/config_paths.py`. Runtime bootstrap creates:
+
+- `<vault>/matryca-wiki.yml`
+- `<vault>/matryca-l1/` (or sibling — see `docs/openspec/runtime-bootstrap.md`)
+
+### 4. Orphan subprocesses
+
+Each failed Hermes connect left `uvx matryca-plumber` children running (15 observed), each repeating full bootstrap and competing for I/O. Clear orphans before debugging:
+
+```bash
+pkill -f "uv tool uvx matryca-plumber"
+pkill -f "/matryca-plumber$"
+```
+
+---
+
+## Verified tool surface (7 tools)
+
+After successful connect, Hermes registered:
+
+| Tool | Purpose |
+|------|---------|
+| `read_graph_data` | Pages, subtrees, L1, structural hops, dashboards |
+| `search_graph` | bm25 / semantic / regex search |
+| `mutate_graph` | OCC-safe graph writes |
+| `refactor_blocks` | Block-level refactors |
+| `run_linter` | Cognitive lint modules |
+| `store_fact` | Append durable constraints / identity facts |
+| `ingest_document` | Atomic external Markdown ingestion |
+
+Implementation: `src/agent/mcp_server.py` (`register_mcp_tools`).
+
+---
+
+## Hermes ↔ Plumber contract checklist
+
+| Requirement | Hermes | Matryca Plumber | Notes |
+|-------------|--------|-----------------|-------|
+| MCP transport | stdio via `mcp` Python SDK | FastMCP `run_stdio_async()` | JSON-RPC on stdin/stdout |
+| Enable gate | `MATRYCA_MCP_ENABLED=true` in `env` | `plumber_entry.py` exits with code 2 if unset | Default off (`SECURITY.md`) |
+| Graph path | `LOGSEQ_GRAPH_PATH` in `env` | Required; `os.chdir(graph_root)` in lifespan | Vault root with `pages/` |
+| CLI disambiguation | bare `matryca-plumber` argv | Routes to MCP when no CLI subcommand | Do not pass `plumber`/`status` args |
+| stderr | Hermes redirects to `~/.hermes/logs/mcp-stderr.log` | Loguru + parser warnings OK | **Never write banners to stdout** |
+| Loguru on stdio | N/A | `install_loguru_mcp_bridge()` | Prevents corrupting JSON-RPC |
+| Handshake time | `connect_timeout` ≥ 60 s (120 s recommended) | Lazy AST — no `load_directory` at lifespan | Seconds |
+| First graph tool | `timeout` per tool (default 300 s) | `load_directory` on first `get_graph()` | Vault-size dependent |
+
+---
+
+## Recommendations for matryca-plumber repo
+
+### Documentation (high priority)
+
+1. **Add this file** to README Documentation Map and `docs/openspec/README.md`.
+2. **`.env.example`** — add commented Hermes block:
+   ```env
+   # Hermes Agent (~/.hermes/config.yaml mcp_servers.matryca-plumber.env)
+   # MATRYCA_MCP_ENABLED=true
+   # LOGSEQ_GRAPH_PATH=/absolute/path/to/vault
+   ```
+3. **`CONTRIBUTING.md`** — link Hermes as a second MCP host beside Claude Desktop/Cursor.
+4. **`SECURITY.md`** — mention Hermes explicitly in MCP trust-boundary section.
+
+### Configuration guidance for operators
+
+| Scenario | `command` | `connect_timeout` |
+|----------|-----------|-------------------|
+| End users / PyPI | `uvx` + `args: [matryca-plumber]` | 120–360 s by vault size |
+| Developers | `.venv/bin/matryca-plumber` | 180–360 s typical |
+| Small test vault (<100 pages) | either | 60–120 s may suffice |
+
+Document a rule of thumb: **`connect_timeout` ≥ (pages + journals) × ~0.2 s** on OrbStack/Mac mounts, measure once per vault.
+
+### Code / architecture (implemented)
+
+1. **Lazy AST bootstrap** — `prepare_matryca_runtime(..., eager_graph=False)` in MCP lifespan; `GraphAstCache.bootstrap()` on first `get_graph()` (thread-safe `RLock`).
+2. **Startup telemetry on stderr** — `AST cache bootstrap started|complete` with `markdown_files`, `duration_s`, `pages_indexed`.
+3. **Integration test** — `tests/test_hermes_mcp_handshake.py` asserts `tools/list` within 30 s on a tiny fixture graph.
+
+### Anti-patterns to document
+
+- Do **not** set `MATRYCA_L1_PATH` / `MATRYCA_WIKI_CONFIG` to paths outside allowlist.
+- Do **not** use `cwd: /opt/data` (or any missing directory) — Hermes MCP reference does not define `cwd` for stdio; it may be ignored.
+- Do **not** rely on Hermes standard install including `[mcp]` unless `uv pip install -e ".[all]"` was used.
+
+---
+
+## Test procedure (repeatable)
+
+```bash
+# 1. Hermes MCP client
+cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
+
+# 2. Kill orphans
+pkill -f "matryca-plumber" || true
+
+# 3. Probe (from hermes-agent repo, adjust paths)
+.venv/bin/python - <<'PY'
+import asyncio, sys, time
+sys.path.insert(0, ".")
+from tools.mcp_tool import _connect_server, _load_mcp_config, _ensure_mcp_loop, _run_on_mcp_loop, _stop_mcp_loop
+cfg = _load_mcp_config()["matryca-plumber"]
+async def t():
+    t0 = time.time()
+    s = await asyncio.wait_for(_connect_server("matryca-plumber", cfg), timeout=cfg["connect_timeout"])
+    print(f"OK in {time.time()-t0:.1f}s:", [x.name for x in s._tools])
+    await s.shutdown()
+_ensure_mcp_loop()
+_run_on_mcp_loop(t(), timeout=400)
+_stop_mcp_loop()
+PY
+
+# 4. Hermes UI — banner should show:
+#    matryca-plumber (stdio) — 7 tool(s)
+```
+
+---
+
+## Related documents
+
+| Document | Relevance |
+|----------|-----------|
+| [`docs/openspec/agent-dx.md`](../openspec/agent-dx.md) | Lists Hermes as external agent surface |
+| [`docs/openspec/runtime-bootstrap.md`](../openspec/runtime-bootstrap.md) | What runs at MCP lifespan start |
+| [`SECURITY.md`](../../SECURITY.md) | `MATRYCA_MCP_ENABLED` gate |
+| [`src/plumber_entry.py`](../../src/plumber_entry.py) | CLI vs MCP stdio routing |
+| [Hermes MCP guide](https://hermes-agent.dev/docs/guides/use-mcp-with-hermes) | Host-side setup |
+| [Hermes MCP config reference](https://hermes-agent.dev/docs/reference/mcp-config-reference) | `connect_timeout`, `env`, `command` |
+
+---
+
+## Changelog entry (suggested)
+
+```markdown
+### Integrations
+- Document Hermes Agent MCP integration (`docs/integrations/hermes-agent.md`):
+  verified 7-tool stdio handshake; require `connect_timeout` ≥ vault bootstrap time
+  and `hermes-agent[mcp]` on the host.
+```

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -164,13 +164,22 @@ Implementation: `src/agent/mcp_server.py` (`register_mcp_tools`).
 
 ### Configuration guidance for operators
 
-| Scenario | `command` | `connect_timeout` |
-|----------|-----------|-------------------|
-| End users / PyPI | `uvx` + `args: [matryca-plumber]` | 120–360 s by vault size |
-| Developers | `.venv/bin/matryca-plumber` | 180–360 s typical |
-| Small test vault (<100 pages) | either | 60–120 s may suffice |
+**Do not confuse handshake timeout with tool timeout.**
 
-Document a rule of thumb: **`connect_timeout` ≥ (pages + journals) × ~0.2 s** on OrbStack/Mac mounts, measure once per vault.
+| Setting | What it covers | Recommended |
+|---------|----------------|-------------|
+| **`connect_timeout`** | Hermes **handshake** only: subprocess spawn, MCP `initialize`, `tools/list` | **60–120 s** (lazy AST — vault size does not affect handshake) |
+| **`timeout`** | Each **tool call** after connect | **300 s** default; raise for large vaults on the **first** graph tool (cold AST parse) |
+
+| Scenario | `command` | `connect_timeout` | `timeout` (first graph tool) |
+|----------|-----------|---------------------|------------------------------|
+| End users / PyPI | `uvx` + `args: [matryca-plumber]` | 120 s | 300 s+; scale with vault |
+| Developers | `.venv/bin/matryca-plumber` | 120 s | same |
+| Small test vault (<100 pages) | either | 60 s | 120 s often enough |
+
+**Tool-timeout rule of thumb (not `connect_timeout`):** on OrbStack/Mac mounts, budget **`timeout` ≥ (pages + journals) × ~0.2 s** for the first graph-mutating or graph-reading tool after connect. Measure once per vault; subsequent calls reuse the in-memory AST cache.
+
+**No AST required for:** `read_graph_data` / `bootstrap_status`, `read_graph_data` / `memory` — safe to call immediately after handshake.
 
 ### Code / architecture (implemented)
 

--- a/docs/openspec/README.md
+++ b/docs/openspec/README.md
@@ -10,6 +10,7 @@ Trimmed behavioral specs aligned with [MehmetGoekce/llm-wiki](https://github.com
 |----------|--------|
 | [`live-telemetry-ui.md`](live-telemetry-ui.md) | v1.9.3 Sovereign UI: 5s polling, daemon heartbeat, API token overlay, `daemon_pid` auto-unfreeze. |
 | [`agent-onboarding.md`](agent-onboarding.md) | v1.9.2 `llms.txt` / `.well-known/llms.txt`, PyPI `uvx` contract, agent anti-patterns. |
+| [`../integrations/hermes-agent.md`](../integrations/hermes-agent.md) | v1.9.6 Hermes Agent MCP: lazy AST handshake, `connect_timeout` vs tool `timeout`, verified config. |
 | [`llm-os-instructions.md`](llm-os-instructions.md) | Two-tier LLM OS, Master Index Soft Gate, `bootstrap_status`, Safe-Sync, v2.0 SQLite migration trigger. |
 | [`link-verification.md`](link-verification.md) | v1.9 zero-LLM URL/asset hygiene, `.matryca_link_registry.json`, `dead-link::` / `missing-asset::`. |
 | [`agent-dx.md`](agent-dx.md) | v1.9 CLI `--json`, `context load`, `read subtree`, Journey Log (single cumulative bullet per day). |

--- a/docs/openspec/agent-onboarding.md
+++ b/docs/openspec/agent-onboarding.md
@@ -58,6 +58,17 @@ Host pattern (Cursor / Claude Desktop):
 }
 ```
 
+### Hermes Agent (v1.9.6+)
+
+Hermes spawns the same stdio MCP server via `~/.hermes/config.yaml`. Prerequisites:
+
+1. Install the **host** MCP client: `uv pip install -e ".[mcp]"` inside `~/.hermes/hermes-agent`.
+2. Set `MATRYCA_MCP_ENABLED=true` and `LOGSEQ_GRAPH_PATH` in the server's `env` block.
+3. **`connect_timeout`** (handshake): **60–120 s** — covers `initialize` + `tools/list` only. MCP lifespan uses **lazy AST** (`eager_graph=False`); it does not parse the full vault before the handshake.
+4. **`timeout`** (per tool): raise for large vaults on the **first** graph tool call (cold AST load). `bootstrap_status` and `memory` reads do not trigger AST bootstrap.
+
+Verified guide: [`../integrations/hermes-agent.md`](../integrations/hermes-agent.md). Integration test: `tests/test_hermes_mcp_handshake.py`.
+
 ---
 
 ## LLM OS contract (Tier-2 agents)

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -13,11 +13,11 @@ Matryca Plumber provisions **directories and optional config files** before harv
 | Entry surface | Trigger |
 |---------------|---------|
 | **Maintenance daemon** | `start_daemon_foreground` and `MaintenanceDaemon.run_forever` (before bootstrap harvest) |
-| **MCP stdio** | `app_lifespan` in `src/main.py` (after `load_dotenv`, before graph hygiene sweeps) |
+| **MCP stdio** | `app_lifespan` in `src/main.py` — **light** bootstrap only (`eager_graph=False`); AST loads on first graph tool call |
 | **CLI** | `cli.main` immediately after `reload_plumber_dotenv()` |
 | **Sovereign UI** | FastAPI lifespan on server start; `POST /api/config`; `POST /api/daemon/start`; `GET /api/preflight` |
 
-When a valid graph is configured, bootstrap also **bootstraps the in-memory `LogseqGraph` cache** and loads **Telos / AI Constraints** from the identity config page if present ([`identity-config.md`](identity-config.md)).
+When a valid graph is configured, **daemon / CLI / UI** also **bootstraps the in-memory `LogseqGraph` cache** and loads **Telos / AI Constraints** from the identity config page if present ([`identity-config.md`](identity-config.md)). **MCP stdio** defers AST parsing until the first tool that needs the graph (lazy load) so MCP hosts (e.g. Hermes Agent) complete `initialize` / `tools/list` in seconds; see [`../integrations/hermes-agent.md`](../integrations/hermes-agent.md).
 
 If `LOGSEQ_GRAPH_PATH` is unset or invalid, only **log directories** are ensured.
 

--- a/llms.txt
+++ b/llms.txt
@@ -89,7 +89,9 @@ Always **parse JSON from stdout** when using `--json`. Never hand-parse raw `pag
 
 ### 2.2 MCP (FastMCP **stdio** — NOT HTTP port 8080)
 
-MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, etc.) spawns `matryca-plumber` and talks JSON-RPC over stdin/stdout. There is **no** `mcp --port` flag in the v1.9 line.
+MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, **Hermes Agent**, etc.) spawns `matryca-plumber` and talks JSON-RPC over stdin/stdout. There is **no** `mcp --port` flag in the v1.9 line.
+
+**Lazy AST handshake (v1.9.6+):** MCP lifespan defers full-vault AST parsing until the **first graph tool call**. `initialize` + `tools/list` complete in seconds; `read_graph_data` / `target_type=bootstrap_status` and `target_type=memory` do **not** require the AST index.
 
 **Requirements:**
 1. `LOGSEQ_GRAPH_PATH` set to the vault root.
@@ -113,6 +115,30 @@ MCP is a **stdio** sidecar: the host (Cursor, Claude Desktop, etc.) spawns `matr
 
 With no CLI subcommand and MCP enabled, `uvx matryca-plumber` starts the **stdio** MCP server.  
 For interactive graph work without MCP, prefer the CLI in section 2.1.
+
+#### Hermes Agent (`~/.hermes/config.yaml`)
+
+Hermes requires the host MCP client extra: `cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"`.
+
+```yaml
+mcp_servers:
+  matryca-plumber:
+    command: uvx
+    args: [matryca-plumber]
+    env:
+      MATRYCA_MCP_ENABLED: "true"
+      LOGSEQ_GRAPH_PATH: /absolute/path/to/vault
+    enabled: true
+    connect_timeout: 120   # handshake (initialize + tools/list) — not vault parse time
+    timeout: 300           # per tool call; first graph tool pays AST load on large vaults
+```
+
+| Setting | Purpose |
+|---------|---------|
+| `connect_timeout` | Hermes **handshake** only (`initialize`, `tools/list`). **60–120 s** is enough with lazy AST. |
+| `timeout` | Each **tool invocation**. Raise for large vaults on the **first** graph read/search (AST cold start). Rule of thumb: `(pages + journals) × ~0.2 s` on slow mounts — measure once. |
+
+Full guide: `docs/integrations/hermes-agent.md` · stderr telemetry: `AST cache bootstrap started|complete` in `~/.hermes/logs/mcp-stderr.log`.
 
 ### 2.3 Diagnostics & audit (no `doctor` command)
 
@@ -187,6 +213,7 @@ For **today's journal page** as `read page`, use the **exact Logseq page title**
 * LLM OS contract (two-tier, Soft Gate, Safe-Sync): `SYSTEM_PROMPT.md` § "LLM OS"
 * Agent DX spec (CLI JSON, Journey Log — one cumulative `- 🤖 Matryca Activity` bullet per day in the daemon journal): `docs/openspec/agent-dx.md`
 * Security (MCP gate, graph allowlist, CLI redaction): `SECURITY.md`
+* Hermes Agent MCP (lazy handshake, timeouts): `docs/integrations/hermes-agent.md`
 
 ---
 

--- a/src/daemon/ast_cache.py
+++ b/src/daemon/ast_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 from typing import Literal, cast
 
@@ -16,6 +17,17 @@ _cache_lock = threading.Lock()
 _caches: dict[str, GraphAstCache] = {}
 
 
+def count_graph_markdown_files(graph_root: Path) -> int:
+    """Count ``pages/`` and ``journals/`` Markdown files for bootstrap telemetry."""
+    root = graph_root.expanduser().resolve(strict=False)
+    total = 0
+    for subdir in ("pages", "journals"):
+        base = root / subdir
+        if base.is_dir():
+            total += sum(1 for _ in base.rglob("*.md"))
+    return total
+
+
 class GraphAstCache:
     """Thread-safe in-memory graph index for MCP and daemon reads."""
 
@@ -25,13 +37,26 @@ class GraphAstCache:
         self._graph: LogseqGraph | None = None
 
     def bootstrap(self) -> LogseqGraph:
-        """Full vault load on startup (idempotent)."""
+        """Full vault load on first access (idempotent, thread-safe)."""
         with self._lock:
             if self._graph is None:
-                logger.bind(graph=str(self.graph_root)).info(
-                    "Bootstrapping in-memory LogseqGraph AST cache",
-                )
+                markdown_files = count_graph_markdown_files(self.graph_root)
+                logger.bind(
+                    graph=str(self.graph_root),
+                    markdown_files=markdown_files,
+                    phase="start",
+                ).info("AST cache bootstrap started")
+                started = time.perf_counter()
                 self._graph = LogseqGraph.load_directory(self.graph_root)
+                elapsed_s = round(time.perf_counter() - started, 3)
+                page_count = len(self._graph.pages)
+                logger.bind(
+                    graph=str(self.graph_root),
+                    markdown_files=markdown_files,
+                    pages_indexed=page_count,
+                    duration_s=elapsed_s,
+                    phase="complete",
+                ).info("AST cache bootstrap complete")
             return self._graph
 
     def get_graph(self) -> LogseqGraph:
@@ -96,5 +121,6 @@ __all__ = [
     "FileEventKind",
     "GraphAstCache",
     "clear_graph_ast_cache",
+    "count_graph_markdown_files",
     "get_graph_ast_cache",
 ]

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,12 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     if graph_path:
         resolved_root = resolved_graph_root(graph_path)
         os.chdir(str(resolved_root))
-    prepare_matryca_runtime(graph_root=resolved_root, wiki_config=wiki_config)
+    # Lazy AST: handshake must not block on full-vault parse (Hermes connect_timeout).
+    prepare_matryca_runtime(
+        graph_root=resolved_root,
+        wiki_config=wiki_config,
+        eager_graph=False,
+    )
     if resolved_root is not None:
         swept = await asyncio.to_thread(sweep_dangling_atomic_tmp_files, str(resolved_root))
         if swept:

--- a/src/utils/runtime_bootstrap.py
+++ b/src/utils/runtime_bootstrap.py
@@ -110,8 +110,18 @@ def prepare_matryca_runtime(
     *,
     graph_root: Path | None = None,
     wiki_config: MatrycaWikiConfig | None = None,
+    eager_graph: bool = True,
 ) -> None:
-    """Provision logs, L1 memory, graph cache dirs, and optional wiki config before work."""
+    """Provision logs, L1 memory, graph cache dirs, and optional wiki config before work.
+
+    Args:
+        graph_root: Resolved Logseq vault root (``pages/`` parent), or ``None``.
+        wiki_config: Optional wiki orchestration config.
+        eager_graph: When ``True`` (daemon, CLI, UI), load the in-memory AST index and
+            identity config immediately. When ``False`` (MCP stdio lifespan), defer
+            heavy graph parsing until the first tool call that needs the graph — so
+            MCP ``initialize`` / ``tools/list`` complete in seconds.
+    """
     ensure_plumber_log_directories()
     if graph_root is None:
         return
@@ -124,12 +134,16 @@ def prepare_matryca_runtime(
     ensure_graph_runtime_directories(graph_root, templates_subdir=cfg.templates_subdir)
     ensure_matryca_wiki_config_file(graph_root, l1_dir=l1_dir)
     from ..daemon import register_daemon_post_write_hooks
+
+    register_daemon_post_write_hooks(graph_root)
+    if not eager_graph:
+        return
+
     from ..daemon.ast_cache import get_graph_ast_cache
     from ..daemon.config_layer import get_identity_store
 
     get_graph_ast_cache(graph_root).bootstrap()
     get_identity_store(graph_root).reload_if_stale(force=True)
-    register_daemon_post_write_hooks(graph_root)
 
 
 def try_prepare_matryca_runtime_from_env() -> None:

--- a/tests/test_ast_cache.py
+++ b/tests/test_ast_cache.py
@@ -4,13 +4,27 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from src.daemon.ast_cache import clear_graph_ast_cache, get_graph_ast_cache
+from src.daemon.ast_cache import (
+    clear_graph_ast_cache,
+    count_graph_markdown_files,
+    get_graph_ast_cache,
+)
 
 
 def _write_page(pages: Path, name: str, body: str) -> Path:
     path = pages / name
     path.write_text(body, encoding="utf-8")
     return path
+
+
+def test_count_graph_markdown_files(tmp_path: Path) -> None:
+    pages = tmp_path / "pages"
+    journals = tmp_path / "journals"
+    pages.mkdir()
+    journals.mkdir()
+    (pages / "a.md").write_text("- a\n", encoding="utf-8")
+    (journals / "2026_06_07.md").write_text("- j\n", encoding="utf-8")
+    assert count_graph_markdown_files(tmp_path) == 2
 
 
 def test_ast_cache_delta_reload_updates_uuid_lookup(tmp_path: Path) -> None:

--- a/tests/test_hermes_mcp_handshake.py
+++ b/tests/test_hermes_mcp_handshake.py
@@ -1,0 +1,66 @@
+"""Hermes-style MCP stdio handshake: tools/list must complete within 30 seconds."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HANDSHAKE_TIMEOUT_S = 30.0
+
+
+def _minimal_graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    (pages / "hello.md").write_text("- Hello from fixture\n", encoding="utf-8")
+    return graph
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_handshake_within_30_seconds(tmp_path: Path) -> None:
+    """MCP initialize + tools/list after lazy lifespan (no eager AST bootstrap)."""
+    graph = _minimal_graph(tmp_path)
+    env = {
+        **os.environ,
+        "MATRYCA_MCP_ENABLED": "true",
+        "LOGSEQ_GRAPH_PATH": str(graph),
+        "PYTHONPATH": str(_REPO_ROOT),
+    }
+    # Drop repo .env so the subprocess does not inherit a production vault path.
+    env.pop("MATRYCA_L1_PATH", None)
+    env.pop("MATRYCA_WIKI_CONFIG", None)
+
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "src.main"],
+        env=env,
+        cwd=str(_REPO_ROOT),
+    )
+
+    started = time.perf_counter()
+    async with asyncio.timeout(_HANDSHAKE_TIMEOUT_S):
+        async with stdio_client(params) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                result = await session.list_tools()
+
+    elapsed = time.perf_counter() - started
+    names = sorted(tool.name for tool in result.tools)
+    assert names == [
+        "ingest_document",
+        "mutate_graph",
+        "read_graph_data",
+        "refactor_blocks",
+        "run_linter",
+        "search_graph",
+        "store_fact",
+    ]
+    assert elapsed < _HANDSHAKE_TIMEOUT_S

--- a/tests/test_provision_l1.py
+++ b/tests/test_provision_l1.py
@@ -43,6 +43,8 @@ def test_provision_matryca_l1_sibling_creates_next_to_vault(
         "src.utils.provision_l1.load_matryca_wiki_config",
         lambda: MatrycaWikiConfig(),
     )
+    # Repo ``.env`` must not override explicit test env (``reload_plumber_dotenv`` loads git root).
+    monkeypatch.setattr("src.utils.provision_l1.reload_plumber_dotenv", lambda **_kw: None)
 
     l1_dir = provision_matryca_l1_sibling(graph_root=graph, repo_root=tmp_path)
 

--- a/tests/test_runtime_bootstrap_contract.py
+++ b/tests/test_runtime_bootstrap_contract.py
@@ -143,6 +143,32 @@ def test_prepare_matryca_runtime_provisions_documented_artifacts(
     assert (graph / "matryca-wiki.yml").is_file()
 
 
+def test_prepare_matryca_runtime_lazy_skips_ast_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    bootstrap_calls: list[Path] = []
+
+    def _bootstrap(self: object) -> object:
+        bootstrap_calls.append(graph)
+        raise AssertionError("bootstrap should not run when eager_graph=False")
+
+    monkeypatch.setattr(
+        "src.daemon.ast_cache.GraphAstCache.bootstrap",
+        _bootstrap,
+    )
+
+    prepare_matryca_runtime(
+        graph_root=graph,
+        wiki_config=MatrycaWikiConfig(),
+        eager_graph=False,
+    )
+
+    assert bootstrap_calls == []
+    assert (graph / "matryca-wiki.yml").is_file()
+
+
 def test_prepare_does_not_create_lazy_runtime_ledgers(tmp_path: Path) -> None:
     graph = _minimal_graph(tmp_path)
     prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -64,8 +64,15 @@ async def test_mcp_lifespan_calls_prepare_before_yield(
     monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
     calls: list[dict[str, object]] = []
 
-    def _prepare(*, graph_root: Path | None, wiki_config: object) -> None:
-        calls.append({"graph_root": graph_root, "wiki_config": wiki_config})
+    def _prepare(
+        *,
+        graph_root: Path | None,
+        wiki_config: object,
+        eager_graph: bool = True,
+    ) -> None:
+        calls.append(
+            {"graph_root": graph_root, "wiki_config": wiki_config, "eager_graph": eager_graph},
+        )
 
     monkeypatch.setattr("src.main.prepare_matryca_runtime", _prepare)
     monkeypatch.setattr("src.main.sweep_dangling_atomic_tmp_files", lambda _p: 0)
@@ -77,6 +84,7 @@ async def test_mcp_lifespan_calls_prepare_before_yield(
     graph_root = calls[0]["graph_root"]
     assert isinstance(graph_root, Path)
     assert graph_root.resolve() == graph.resolve()
+    assert calls[0]["eager_graph"] is False
 
 
 def test_start_daemon_foreground_calls_prepare(


### PR DESCRIPTION
## Summary

- **Handshake MCP in pochi secondi** — Il lifespan stdio non esegue più `LogseqGraph.load_directory` in modo sincrono. Su vault grandi (~1 100 file) l’handshake Hermes passava da **~3+ minuti** (timeout ripetuti con `connect_timeout: 60`) a **< 30 s** per `initialize` + `tools/list`; il costo del parse resta sulla **prima** chiamata tool che tocca il grafo.
- **Lazy AST Bootstrap con RLock** — `prepare_matryca_runtime(..., eager_graph=False)` nel lifespan MCP; provisioning leggero (L1, wiki YAML, cache dirs) immediato. Il caricamento pesante avviene al primo `get_graph()` via `GraphAstCache.bootstrap()`, serializzato da `threading.RLock` (idempotente, thread-safe). Daemon, CLI e Sovereign UI restano **eager** (`eager_graph=True` default).
- **Integrazione Hermes Agent documentata** — Report operativo in `docs/integrations/hermes-agent.md`, blocco `.env.example`, aggiornamenti a `CONTRIBUTING.md` / `SECURITY.md` (trust boundary MCP esplicita per Hermes), telemetria stderr strutturata (`AST cache bootstrap started|complete` con `markdown_files`, `duration_s`, `pages_indexed`), test `tests/test_hermes_mcp_handshake.py`.

## Test plan

- [x] `uv run pytest tests/test_hermes_mcp_handshake.py -q`
- [x] `uv run pytest tests/test_runtime_bootstrap_contract.py::test_prepare_matryca_runtime_lazy_skips_ast_bootstrap tests/test_ast_cache.py -q`
- [ ] `make check` (full gate CI)
- [ ] Smoke Hermes: `connect_timeout: 120`, banner mostra `matryca-plumber (stdio) — 7 tool(s)` in pochi secondi; prima tool call graph su vault reale verifica log in `~/.hermes/logs/mcp-stderr.log`


Made with [Cursor](https://cursor.com)