### PR TITLE
Refactor: Security Hardening & Lenient Sandbox Resolution (v1.9.9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,9 +209,9 @@ MATRYCA_MCP_ENABLED=false
 # LOGSEQ_GRAPH_PATH=/absolute/path/to/vault
 
 # Refuse UI startup without MATRYCA_UI_TOKEN. src/cli/ui_auth.py
-# Default (code): false
-# Template: false
-MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=false
+# Default (code): false (unset env → ephemeral token still allowed at runtime)
+# Template: true — new installs must set MATRYCA_UI_TOKEN explicitly
+MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true
 
 # Expose FastAPI /docs and /openapi.json. src/cli/ui_server.py
 # Default (code): false
@@ -255,8 +255,14 @@ MATRYCA_PLUMBER_LOG_REDACT_SECRETS=true
 
 # NDJSON trace for JSON resilience debugging. src/utils/agent_debug_log.py
 # Default (code): false
+# Path must lie under graph root, repo, home, or temp (see config_paths).
+# Secrets in payloads are redacted before write when log redaction is enabled.
 # MATRYCA_LLM_DEBUG_JSON=false
 # MATRYCA_LLM_DEBUG_LOG_PATH=.cursor/debug-llm.jsonl
+
+# Max bytes for graph-local JSON checkpoints (registry, catalog, daemon state). src/utils/bounded_json.py
+# Default (code): 64000000 (64 MiB)
+# MATRYCA_JSON_MAX_BYTES=64000000
 
 # Cap Ermes cluster neighborhood injection (clamp 1000–24000).
 # Default (code): 8000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Link verification sandbox** — `_resolve_asset_path` and link-registry `page_relpath` values are validated with `path_sandbox` before any read; traversal refs and tampered registry rows are treated as missing/invalid ([#27](https://github.com/MarcoPorcellato/matryca-plumber/issues/27), [#28](https://github.com/MarcoPorcellato/matryca-plumber/issues/28)).
+- **Bounded JSON checkpoints** — graph-local JSON loaders use `read_bounded_json()` with `MATRYCA_JSON_MAX_BYTES` (default 64 MiB) to prevent local memory DoS ([#31](https://github.com/MarcoPorcellato/matryca-plumber/issues/31)).
+- **wiki_lint symlink filter** — prefixed page lint skips non-scannable paths via `is_scannable_graph_markdown()` ([#32](https://github.com/MarcoPorcellato/matryca-plumber/issues/32)).
+- **LLM debug log hardening** — `MATRYCA_LLM_DEBUG_LOG_PATH` must lie under allowed roots; NDJSON payloads are secret-redacted before append ([#29](https://github.com/MarcoPorcellato/matryca-plumber/issues/29)).
+- **UI explicit token default** — `.env.example` templates `MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true`; ephemeral-token startup warning cites `/api/config` risk ([#30](https://github.com/MarcoPorcellato/matryca-plumber/issues/30)).
+- **Defense-in-depth graph reads** — graph/agent/rag modules migrate to `read_graph_file_text()`; CI `sandbox-read-check` blocks new direct `read_text()` bypasses ([#33](https://github.com/MarcoPorcellato/matryca-plumber/issues/33)).
+
 ## [1.9.8] - 2026-06-07
 
 **Documentation harmonization — AX Robustness aligned with code**

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ lint: ## Run ruff to check for linting errors
 typecheck: ## Run mypy for strict type checking
 	uv run mypy src/ tests/
 
+sandbox-read-check: ## Ensure graph reads use read_graph_file_text (v1.9.9 security)
+	uv run python scripts/check_graph_read_sandbox.py
+
 test: ## Run the pytest suite (parallel via pytest-xdist)
 	uv run pytest -n auto -q
 
@@ -34,9 +37,9 @@ perf: ## Run slow performance/memory tests (no coverage gate)
 format-check: ## Verify formatting without modifying files
 	uv run ruff format --check .
 
-check: lint typecheck test ## Run linting, typechecking, and tests (no auto-format)
+check: lint typecheck sandbox-read-check test ## Run linting, typechecking, sandbox read gate, and tests
 
-ci: format-check lint typecheck test ## CI gate: format check + lint + types + tests
+ci: format-check lint typecheck sandbox-read-check test ## CI gate: format check + lint + types + sandbox + tests
 
 clean: ## Remove python caches, virtual envs, and build artifacts
 	rm -rf .venv/

--- a/scripts/check_graph_read_sandbox.py
+++ b/scripts/check_graph_read_sandbox.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Fail CI when graph markdown reads bypass the path sandbox helper."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOTS = (
+    REPO_ROOT / "src" / "graph",
+    REPO_ROOT / "src" / "agent",
+    REPO_ROOT / "src" / "rag",
+    REPO_ROOT / "src" / "semantic",
+)
+
+# Files allowed to call Path.read_text directly (sandbox primitives or non-markdown I/O).
+ALLOWLIST = frozenset(
+    {
+        "src/graph/path_sandbox.py",
+        "src/graph/markdown_io.py",
+        "src/agent/plumber_modules/property_hygiene.py",  # repo-local YAML rules
+        "src/agent/maintenance_daemon.py",  # daemon pid/lock sidecars only
+        "src/utils/bounded_json.py",
+        "src/utils/config_paths.py",
+        "src/utils/provision_l1.py",
+        "src/utils/runtime_bootstrap.py",
+        "src/cli/ui_server.py",
+        "src/config.py",
+    },
+)
+
+# maintenance_daemon.py: only pid/lock reads are allowlisted inline.
+_DAEMON_ALLOWLINES = frozenset({823, 883})
+
+_READ_TEXT_RE = re.compile(r"\.read_text\s*\(")
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def main() -> int:
+    violations: list[str] = []
+    for root in SCAN_ROOTS:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            rel = _rel(path)
+            if rel in ALLOWLIST:
+                if rel == "src/agent/maintenance_daemon.py":
+                    lines = path.read_text(encoding="utf-8").splitlines()
+                    for lineno, line in enumerate(lines, start=1):
+                        if lineno in _DAEMON_ALLOWLINES:
+                            continue
+                        if _READ_TEXT_RE.search(line):
+                            violations.append(f"{rel}:{lineno}: {line.strip()}")
+                continue
+            text = path.read_text(encoding="utf-8")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if _READ_TEXT_RE.search(line):
+                    violations.append(f"{rel}:{lineno}: {line.strip()}")
+
+    if violations:
+        print("Direct Path.read_text() on graph paths is forbidden outside the sandbox allowlist:")
+        for item in violations:
+            print(f"  - {item}")
+        print("Use read_graph_file_text() / read_graph_page_text() from path_sandbox / markdown_io.")
+        return 1
+
+    print("sandbox-read-check: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent/graph_tool_helpers.py
+++ b/src/agent/graph_tool_helpers.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from ..graph.markdown_blocks import locate_block_by_uuid
-from ..graph.path_sandbox import graph_safe_page_path
+from ..graph.path_sandbox import graph_safe_page_path, read_graph_file_text
 from ..utils.json_repair import loads_repaired_json
 from ..utils.regex_policy import validate_regex_pattern
 from .page_input_normalizer import (
@@ -222,7 +222,7 @@ def read_subtree_markdown(graph_path: str, query: str) -> str:
         raise ValueError(msg)
 
     path = graph_safe_page_path(graph_path, page_ref)
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = read_graph_file_text(path, graph_path, errors="replace")
     lines = text.splitlines(keepends=True)
     stripped = [ln.rstrip("\n") for ln in lines]
     loc = locate_block_by_uuid(stripped, block_uuid)
@@ -288,7 +288,7 @@ def read_block_ast_markdown(graph_path: str, query: str) -> str:
         raise ValueError(msg)
     page_ref, block_uuid = parts[0], parts[1]
     path = graph_safe_page_path(graph_path, page_ref)
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = read_graph_file_text(path, graph_path, errors="replace")
     lines = text.splitlines(keepends=True)
     stripped = [ln.rstrip("\n") for ln in lines]
     loc = locate_block_by_uuid(stripped, block_uuid)
@@ -327,7 +327,7 @@ def _scan_pages_for_regex(
         if not path.is_file() or not is_scannable_graph_markdown(path, root):
             continue
         try:
-            body = path.read_text(encoding="utf-8", errors="replace")
+            body = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         scanned_bytes += len(body.encode("utf-8", errors="replace"))

--- a/src/agent/ingestion.py
+++ b/src/agent/ingestion.py
@@ -28,6 +28,7 @@ from ..graph.markdown_blocks import (
 )
 from ..graph.page_properties import stamp_plumber_authored_page
 from ..graph.page_write_lock import page_rmw_lock
+from ..graph.path_sandbox import read_graph_file_text
 from ..utils.secret_redaction import secret_violations_in_text
 from .graph_tool_helpers import graph_missing_text, graph_path_from_env
 
@@ -201,7 +202,7 @@ def _append_markdown_page(
     section_text = section.rstrip() + "\n"
 
     with page_rmw_lock(path):
-        prev = path.read_text(encoding="utf-8") if path.is_file() else ""
+        prev = read_graph_file_text(path, graph_root, encoding="utf-8") if path.is_file() else ""
         if not prev.strip():
             prev = stamp_plumber_authored_page("")
         new_text = prev.rstrip("\n") + ("\n\n" if prev.strip() else "") + section_text
@@ -249,7 +250,11 @@ def _build_glossary_section(
     if not pairs:
         return ""
     glossary_path = graph_safe_page_path(graph_root, GLOSSARY_PAGE_TITLE)
-    existing = glossary_path.read_text(encoding="utf-8") if glossary_path.is_file() else ""
+    existing = (
+        read_graph_file_text(glossary_path, graph_root, encoding="utf-8")
+        if glossary_path.is_file()
+        else ""
+    )
     existing_fold = existing.casefold()
     lines: list[str] = []
     for term, block_uuid in pairs:

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -85,11 +85,13 @@ from ..graph.page_write_lock import (
 from ..graph.path_sandbox import (
     graph_relative_path_key,
     normalize_daemon_file_key,
+    read_graph_file_text,
 )
 from ..graph.semantic_clustering import (
     format_cluster_neighborhood,
     load_or_compute_semantic_clusters,
 )
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from ..utils.console_sanitize import sanitize_for_console
 from ..utils.logging_config import configure_loguru
 from ..utils.runtime_bootstrap import prepare_matryca_runtime
@@ -742,16 +744,8 @@ def _read_daemon_state_payload(path: Path) -> dict[str, Any] | None:
     """Load JSON payload from disk, retrying once on transient empty or malformed reads."""
     for attempt in range(2):
         try:
-            raw = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return None
-        if not raw.strip():
-            if attempt == 0:
-                continue
-            return None
-        try:
-            payload = json.loads(raw)
-        except (json.JSONDecodeError, ValueError):
+            payload = read_bounded_json(path)
+        except BoundedJsonError:
             if attempt == 0:
                 continue
             return None
@@ -1367,7 +1361,7 @@ def append_structural_lint_warning(
                 page_path,
             )
             return False
-        text = page_path.read_text(encoding="utf-8", errors="replace")
+        text = read_graph_file_text(page_path, graph_root, errors="replace")
         if _structural_lint_section_present(text):
             return False
 
@@ -1425,7 +1419,7 @@ def apply_semantic_page_result(
 
     with page_rmw_lock(page_path):
         if page_path.is_file():
-            prev = page_path.read_text(encoding="utf-8", errors="replace")
+            prev = read_graph_file_text(page_path, graph_root, errors="replace")
             if baseline_mtime is None:
                 baseline_mtime = read_file_mtime(page_path)
         else:
@@ -1538,7 +1532,7 @@ def append_semantic_index(
 ) -> None:
     """Append a semantic index section without modifying existing user content."""
     if page_path.is_file():
-        prev = page_path.read_text(encoding="utf-8", errors="replace")
+        prev = read_graph_file_text(page_path, graph_root, errors="replace")
         if _semantic_index_section_present(prev):
             return
     apply_semantic_page_result(
@@ -1725,9 +1719,9 @@ def _mtime_matches(stored: float, current: float) -> bool:
     return math.isclose(stored, current, rel_tol=0.0, abs_tol=1e-6)
 
 
-def _read_page_content(path: Path) -> str:
+def _read_page_content(path: Path, graph_root: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8", errors="replace")
+        return read_graph_file_text(path, graph_root, errors="replace")
     except OSError:
         return ""
 
@@ -1752,7 +1746,7 @@ def page_needs_phase2_cognitive(
     if title in MATRYCA_GENERATED_PAGE_TITLES:
         return False
 
-    text = content if content is not None else _read_page_content(path)
+    text = content if content is not None else _read_page_content(path, graph_root)
     if _page_is_terminal_skip(text):
         return False
 
@@ -2276,7 +2270,7 @@ class MaintenanceDaemon:
     def _sync_catalog_after_page_write(self, path: Path, title: str) -> None:
         """Upsert catalog row from on-disk semantic index immediately after a page write."""
         try:
-            new_text = path.read_text(encoding="utf-8", errors="replace")
+            new_text = read_graph_file_text(path, self.graph_root, errors="replace")
             mtime = int(path.stat().st_mtime)
         except OSError as exc:
             self.token_logger.log_structural_lint_warning(
@@ -2463,7 +2457,7 @@ class MaintenanceDaemon:
 
         state.last_file = sanitize_for_console(key)
         try:
-            content = path.read_text(encoding="utf-8", errors="replace")
+            content = read_graph_file_text(path, self.graph_root, errors="replace")
         except OSError:
             return False
 
@@ -2532,7 +2526,7 @@ class MaintenanceDaemon:
         try:
             baseline_mtime = occ_snapshot(path) if path.is_file() else None
             if path.is_file():
-                content = path.read_text(encoding="utf-8", errors="replace")
+                content = read_graph_file_text(path, self.graph_root, errors="replace")
                 if link_verify_enabled():
                     with contextlib.suppress(OSError):
                         merge_page_links_into_registry(self.graph_root, path, content)
@@ -2561,7 +2555,7 @@ class MaintenanceDaemon:
                 )
                 self._save_cycle_checkpoint(state, path=path)
                 if path.is_file():
-                    content = path.read_text(encoding="utf-8", errors="replace")
+                    content = read_graph_file_text(path, self.graph_root, errors="replace")
                     refreshed_mtime = occ_snapshot(path)
                     if refreshed_mtime is not None:
                         baseline_mtime = refreshed_mtime

--- a/src/agent/memory_tools.py
+++ b/src/agent/memory_tools.py
@@ -18,6 +18,7 @@ from ..daemon.config_layer import (
 )
 from ..graph.graph_path_validate import validate_logseq_graph_path
 from ..graph.markdown_blocks import atomic_write_bytes
+from ..graph.path_sandbox import read_graph_file_text
 from .graph_dispatch import _headless_append_child
 from .graph_tool_helpers import graph_missing_text, graph_path_from_env
 
@@ -40,7 +41,7 @@ def _ensure_config_page(graph_root: Path) -> Path:
     """Create ``pages/matryca-config.md`` with base headings when missing."""
     path = resolve_identity_config_path(graph_root, for_write=True)
     if path.is_file():
-        content = path.read_text(encoding="utf-8")
+        content = read_graph_file_text(path, graph_root, encoding="utf-8")
         if content.strip():
             return path
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/agent/plumber_modules/__init__.py
+++ b/src/agent/plumber_modules/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from ...graph.path_sandbox import read_graph_file_text
 from ..page_prompt_session import PagePromptSession, build_page_prompt_session
 from ..plumber_config import PlumberLintConfig
 from ._shared import ModuleOutcome, is_journal_page_path
@@ -121,7 +122,7 @@ def run_cognitive_lint_pipeline(
             outcome,
         )
         if page_path.is_file():
-            content = page_path.read_text(encoding="utf-8", errors="replace")
+            content = read_graph_file_text(page_path, graph_root, errors="replace")
 
     if config.heal_dangling:
         _run_cognitive_module_safe(
@@ -166,7 +167,7 @@ def run_cognitive_lint_pipeline(
             outcome,
         )
         if page_path.is_file():
-            content = page_path.read_text(encoding="utf-8", errors="replace")
+            content = read_graph_file_text(page_path, graph_root, errors="replace")
 
     if config.property_hygiene and not journal_page:
         _run_cognitive_module_safe(
@@ -186,7 +187,7 @@ def run_cognitive_lint_pipeline(
         )
 
     if page_path.is_file():
-        content = page_path.read_text(encoding="utf-8", errors="replace")
+        content = read_graph_file_text(page_path, graph_root, errors="replace")
     disk_changed = content != initial_content or page_title in outcome.pages_modified
     if disk_changed and session is not None:
         session = _rebuild_prompt_session(

--- a/src/agent/plumber_modules/auto_split.py
+++ b/src/agent/plumber_modules/auto_split.py
@@ -18,6 +18,7 @@ from ...graph.markdown_blocks import (
 )
 from ...graph.page_properties import inject_page_property, stamp_plumber_authored_page
 from ...graph.page_write_lock import page_rmw_lock
+from ...graph.path_sandbox import read_graph_file_text
 from ._shared import ModuleOutcome, is_blank_page_content, sanitize_page_title
 
 _BULLET = re.compile(r"^(\s*)[-*+]\s+(.*)$")
@@ -69,7 +70,7 @@ def run_auto_split(
     baseline_mtime = occ_snapshot(page_path)
 
     with page_rmw_lock(page_path):
-        text = page_path.read_text(encoding="utf-8", errors="replace")
+        text = read_graph_file_text(page_path, graph_root, errors="replace")
         if is_blank_page_content(text):
             return outcome
         if baseline_mtime is not None and file_mtime_drifted(page_path, baseline_mtime):

--- a/src/agent/plumber_modules/backlink_backpropagator.py
+++ b/src/agent/plumber_modules/backlink_backpropagator.py
@@ -11,6 +11,7 @@ from ...graph.alias_index import AliasIndex, resolve_canonical_page_title
 from ...graph.generational_cache import patch_generational_caches_for_paths
 from ...graph.markdown_blocks import atomic_write_bytes_if_unchanged, read_file_mtime
 from ...graph.page_write_lock import page_rmw_lock
+from ...graph.path_sandbox import read_graph_file_text
 from ._shared import ModuleOutcome, page_file_exists, resolve_page_path
 
 _BACKLINK_HEADING = "### Matryca Backlink Context"
@@ -226,7 +227,7 @@ def run_backlink_backpropagator(
             summary = _summary_from_correction(correction, source_title)
             modified = False
             with page_rmw_lock(target_path):
-                prev = target_path.read_text(encoding="utf-8", errors="replace")
+                prev = read_graph_file_text(target_path, graph_root, errors="replace")
                 if not prev.strip():
                     continue
                 baseline_mtime = read_file_mtime(target_path)

--- a/src/agent/plumber_modules/marpa_framework.py
+++ b/src/agent/plumber_modules/marpa_framework.py
@@ -229,7 +229,7 @@ def run_marpa_framework(
 
     with page_rmw_lock(page_path):
         if page_path.is_file():
-            text = page_path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(page_path, graph_root, errors="replace")
         else:
             text = content
         if baseline_mtime is not None and file_mtime_drifted(page_path, baseline_mtime):

--- a/src/agent/plumber_modules/property_hygiene.py
+++ b/src/agent/plumber_modules/property_hygiene.py
@@ -14,6 +14,7 @@ from ...graph.markdown_blocks import (
 )
 from ...graph.page_properties import inject_page_properties
 from ...graph.page_write_lock import page_rmw_lock
+from ...graph.path_sandbox import read_graph_file_text
 from ._shared import ModuleOutcome, extract_inline_tags, is_blank_page_content, page_property_keys
 
 _DEFAULT_RULES: dict[str, list[str]] = {
@@ -109,7 +110,7 @@ def run_property_hygiene(
         return outcome
 
     with page_rmw_lock(page_path):
-        text = page_path.read_text(encoding="utf-8", errors="replace")
+        text = read_graph_file_text(page_path, graph_root, errors="replace")
         if is_blank_page_content(text):
             return outcome
         if baseline_mtime is not None and file_mtime_drifted(page_path, baseline_mtime):

--- a/src/agent/plumber_modules/semantic_cache_router.py
+++ b/src/agent/plumber_modules/semantic_cache_router.py
@@ -18,6 +18,7 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError
 
 from ...graph.json_flock import cross_process_json_flock
+from ...utils.bounded_json import BoundedJsonError, read_bounded_json
 
 _CACHE_DIRNAME = ".matryca_semantic_cache"
 _DEFAULT_TTL_SECONDS = 86_400
@@ -130,8 +131,8 @@ def cache_get(graph_root: Path, namespace: str, cache_key: str) -> dict[str, Any
         return None
     try:
         with cross_process_json_flock(path):
-            raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+            raw = read_bounded_json(path)
+    except (BoundedJsonError, OSError):
         return None
     if not isinstance(raw, dict):
         return None
@@ -280,8 +281,8 @@ def purge_expired_semantic_cache(graph_root: Path) -> int:
         if path.name in _RESERVED_CACHE_JSON:
             continue
         try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            raw = read_bounded_json(path)
+        except BoundedJsonError:
             path.unlink(missing_ok=True)
             removed += 1
             continue

--- a/src/cli/ui_auth.py
+++ b/src/cli/ui_auth.py
@@ -30,9 +30,13 @@ def warn_if_ephemeral_ui_token() -> None:
     from loguru import logger
 
     logger.warning(
-        "MATRYCA_UI_TOKEN is unset: a random bearer token was generated for this process. "
-        "Any local process on loopback can obtain it via GET /api/auth/session. "
-        "Set MATRYCA_UI_TOKEN to a long random value on shared or multi-user hosts."
+        "SECURITY: MATRYCA_UI_TOKEN is unset — a random bearer token was "
+        "generated for this process. "
+        "Any local process on loopback can obtain it via GET /api/auth/session and call protected "
+        "endpoints (including /api/config with LLM credentials). "
+        "Set MATRYCA_UI_TOKEN to a long random value, or enable "
+        "MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true. "
+        "See SECURITY.md for shared-host guidance."
     )
 
 

--- a/src/graph/backlink_index.py
+++ b/src/graph/backlink_index.py
@@ -8,6 +8,7 @@ import threading
 from pathlib import Path
 from typing import Any, TypedDict
 
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .alias_index import (
     iter_alias_source_paths,
     iter_scannable_pages_markdown,
@@ -15,6 +16,7 @@ from .alias_index import (
 )
 from .json_flock import cross_process_json_flock
 from .markdown_blocks import atomic_write_bytes
+from .path_sandbox import read_graph_file_text
 
 _INDEX_VERSION = 1
 _INDEX_FILENAME = "backlink_counts.json"
@@ -60,7 +62,7 @@ def _compute_incoming_full(graph_root: Path) -> dict[str, int]:
         title = page_title_from_path(root, path)
         incoming.setdefault(title, 0)
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         for match in _wikilink.finditer(text):
@@ -81,8 +83,8 @@ def _load_disk(graph_root: Path) -> dict[str, Any] | None:
         return None
     try:
         with cross_process_json_flock(path):
-            raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+            raw = read_bounded_json(path)
+    except (BoundedJsonError, OSError):
         return None
     return raw if isinstance(raw, dict) else None
 

--- a/src/graph/bootstrap_harvest.py
+++ b/src/graph/bootstrap_harvest.py
@@ -145,7 +145,7 @@ def _append_minimal_semantic_index(
         if baseline_mtime is not None and file_mtime_drifted(page_path, baseline_mtime):
             return
         if page_path.is_file():
-            prev = page_path.read_text(encoding="utf-8", errors="replace")
+            prev = read_graph_page_text(page_path, graph_root, errors="replace")
         else:
             prev = ""
             baseline_mtime = None

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -18,6 +18,7 @@ from .alias_index import (
     remove_page_from_alias_index,
 )
 from .page_path import page_title_from_graph_relpath
+from .path_sandbox import read_graph_file_text
 
 _lock = threading.Lock()
 _alias_cache: dict[str, tuple[frozenset[tuple[str, int]], AliasIndex]] = {}
@@ -187,7 +188,7 @@ def patch_generational_caches_for_paths(
                     _remove_bm25_doc(corpus, rel)
                     continue
                 try:
-                    raw = path.read_text(encoding="utf-8", errors="replace")
+                    raw = read_graph_file_text(path, root, errors="replace")
                 except OSError:
                     _remove_bm25_doc(corpus, rel)
                     continue
@@ -269,7 +270,7 @@ def _build_bm25_corpus(root: Path) -> Bm25Corpus:
     doc_lens: list[int] = []
     for path in paths:
         try:
-            raw = path.read_text(encoding="utf-8", errors="replace")
+            raw = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         toks = tokenize(raw)

--- a/src/graph/graph_analytics.py
+++ b/src/graph/graph_analytics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,6 +9,7 @@ from typing import Literal
 
 from loguru import logger
 
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .alias_index import (
     is_scannable_graph_markdown,
     iter_alias_source_paths,
@@ -19,6 +19,7 @@ from .generational_cache import cached_build_alias_index
 from .link_tag_hop import _WIKILINK
 from .master_catalog import MATRYCA_GENERATED_INDEX_TITLES, load_master_catalog
 from .page_properties import is_plumber_authored_page
+from .path_sandbox import read_graph_file_text
 
 _CACHE_DIRNAME = ".matryca_semantic_cache"
 _DEFAULT_CONTEXT_ACCELERATION = 0.0
@@ -105,7 +106,7 @@ def _count_journal_metrics(graph_root: Path) -> tuple[int, int]:
             continue
         total += 1
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, graph_root, errors="replace")
         except OSError:
             continue
         if is_plumber_authored_page(text):
@@ -131,7 +132,7 @@ def _count_links_scanned(graph_root: Path) -> int:
     total = 0
     for path in iter_alias_source_paths(graph_root):
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, graph_root, errors="replace")
         except OSError:
             continue
         total += len(_WIKILINK.findall(text))
@@ -162,8 +163,8 @@ def _context_acceleration_rate(graph_root: Path, total_pages: int) -> float:
     valid_entries = 0
     for path in cache_dir.glob("*.json"):
         try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            raw = read_bounded_json(path)
+        except BoundedJsonError:
             continue
         if not isinstance(raw, dict):
             continue
@@ -185,7 +186,7 @@ def _count_blocks_scanned(graph_root: Path) -> int:
     total = 0
     for path in iter_alias_source_paths(graph_root):
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, graph_root, errors="replace")
         except OSError:
             continue
         for line in text.splitlines():
@@ -241,7 +242,7 @@ def _count_current_ai_pages(graph_root: Path) -> int:
     total = 0
     for path in iter_scannable_pages_markdown(graph_root):
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, graph_root, errors="replace")
         except OSError:
             continue
         if is_plumber_authored_page(text):

--- a/src/graph/insights_engine.py
+++ b/src/graph/insights_engine.py
@@ -21,7 +21,7 @@ from .link_tag_hop import (
 from .markdown_blocks import atomic_write_bytes
 from .master_catalog import MasterCatalog, load_master_catalog
 from .page_path import filename_to_page_title
-from .path_sandbox import graph_safe_page_path
+from .path_sandbox import graph_safe_page_path, read_graph_file_text
 
 GRAPH_INSIGHTS_TITLE = "Matryca Graph Insights"
 _DENSE_WIKILINK_THRESHOLD = 25
@@ -86,7 +86,7 @@ def _incoming_backlink_counts(graph_root: Path) -> dict[str, int]:
         title = page_title_from_path(root, path)
         incoming.setdefault(title, 0)
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         for match in _WIKILINK.finditer(text):
@@ -105,7 +105,7 @@ def _outgoing_wikilink_counts(graph_root: Path) -> dict[str, int]:
     for path in iter_alias_source_paths(root):
         title = page_title_from_path(root, path)
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             outgoing[title] = 0
             continue
@@ -123,7 +123,7 @@ def _tag_signatures(graph_root: Path) -> dict[str, set[str]]:
     for path in iter_alias_source_paths(graph_root):
         title = page_title_from_path(graph_root, path)
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, graph_root, errors="replace")
         except OSError:
             signatures[title] = set()
             continue
@@ -203,7 +203,7 @@ def compute_topology_metrics(
     for path in iter_alias_source_paths(root):
         title = page_title_from_path(root, path)
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         block_count = _count_bullets(text)

--- a/src/graph/journal_task_scan.py
+++ b/src/graph/journal_task_scan.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .markdown_blocks import atomic_write_bytes
 from .page_write_lock import page_rmw_lock
+from .path_sandbox import read_graph_file_text
 
 _BULLET = re.compile(r"^(\s*)[-*+]\s+")
 _LEGACY_ACTIVITY_HEADING = "## 🤖 Matryca Activity"
@@ -140,7 +141,7 @@ def scan_journal_tasks(
             continue
         report.files_scanned += 1
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError as exc:
             report.notes.append(f"Could not read `{path}`: {exc}")
             continue
@@ -280,7 +281,7 @@ def upsert_matryca_activity_block(
     with page_rmw_lock(path):
         prev = ""
         if path.is_file():
-            prev = path.read_text(encoding="utf-8", errors="replace")
+            prev = read_graph_file_text(path, root, errors="replace")
         cleaned = _strip_legacy_matryca_activity_sections(prev)
         lines = cleaned.splitlines() if cleaned else []
         idx = _find_top_level_activity_line(lines)
@@ -353,7 +354,7 @@ def append_journal_markdown_section(
     with page_rmw_lock(path):
         prev = ""
         if path.is_file():
-            prev = path.read_text(encoding="utf-8", errors="replace")
+            prev = read_graph_file_text(path, root, errors="replace")
         new_text = prev.rstrip("\n") + ("\n\n" if prev.strip() else "") + section
 
         if dry_run:

--- a/src/graph/link_tag_hop.py
+++ b/src/graph/link_tag_hop.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import cast
 from urllib.parse import unquote
 
+from .path_sandbox import read_graph_file_text
+
 _WIKILINK = re.compile(r"\[\[([^\]#|]+)(?:\|[^\]]+)?\]\]")
 # Inline #tag — avoid markdown headings (line-start # followed by space).
 _TAG_INLINE = re.compile(r"(?<![\w/])#([\w/-]+)")
@@ -115,7 +117,7 @@ def build_structural_graph(graph_root: str | Path) -> dict[str, set[tuple[str, s
     for path in paths:
         stem = path.stem
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
 

--- a/src/graph/link_verification.py
+++ b/src/graph/link_verification.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 import httpx
 from loguru import logger
 
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .global_fence_scanner import compute_page_protected_line_indices
 from .json_flock import cross_process_json_flock
 from .markdown_blocks import (
@@ -34,6 +35,12 @@ from .markdown_blocks import (
 )
 from .mldoc_properties import parse_logseq_property_line
 from .page_write_lock import page_rmw_lock
+from .path_sandbox import (
+    PathTraversalSecurityError,
+    is_resolved_path_within_graph,
+    read_graph_file_text,
+    resolve_graph_relative_key,
+)
 
 LINK_REGISTRY_FILENAME = ".matryca_link_registry.json"
 REGISTRY_VERSION = 1
@@ -147,8 +154,8 @@ def _load_registry_unlocked(path: Path) -> dict[str, LinkRegistryEntry]:
     if not path.is_file():
         return {}
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        payload = read_bounded_json(path)
+    except (BoundedJsonError, OSError) as exc:
         logger.warning("Link registry unreadable: {}", exc)
         return {}
     entries_raw = payload.get("entries", {})
@@ -156,8 +163,16 @@ def _load_registry_unlocked(path: Path) -> dict[str, LinkRegistryEntry]:
         return {}
     out: dict[str, LinkRegistryEntry] = {}
     for key, item in entries_raw.items():
-        if isinstance(item, dict):
-            out[str(key)] = LinkRegistryEntry.from_json(item)
+        if not isinstance(item, dict):
+            continue
+        entry = LinkRegistryEntry.from_json(item)
+        if _safe_page_path(path.parent, entry.page_relpath) is None:
+            logger.warning(
+                "Link registry entry dropped (invalid page_relpath): {}",
+                entry.page_relpath,
+            )
+            continue
+        out[str(key)] = entry
     return out
 
 
@@ -200,13 +215,30 @@ def _persist_checked_registry_updates(
         _save_registry_unlocked(path, fresh)
 
 
+_INVALID_ASSET = ".matryca_invalid_asset"
+
+
+def _safe_page_path(graph_root: Path, page_relpath: str) -> Path | None:
+    """Resolve a registry page key under the graph root, or None when invalid."""
+    if not page_relpath.strip():
+        return None
+    try:
+        return resolve_graph_relative_key(graph_root, page_relpath)
+    except PathTraversalSecurityError:
+        return None
+
+
 def _resolve_asset_path(graph_root: Path, page_path: Path, asset_ref: str) -> Path:
     ref = asset_ref.strip()
     if ref.startswith("/"):
-        return graph_root / ".matryca_invalid_absolute_asset"
+        return graph_root / _INVALID_ASSET
     if ref.startswith("assets/"):
-        return graph_root / ref
-    return (page_path.parent / ref).resolve()
+        candidate = (graph_root / ref).resolve()
+    else:
+        candidate = (page_path.parent / ref).resolve()
+    if not is_resolved_path_within_graph(candidate, graph_root):
+        return graph_root / _INVALID_ASSET
+    return candidate
 
 
 def _block_has_property(
@@ -394,7 +426,9 @@ def _append_verify_error(result: LinkVerificationCycleResult, message: str) -> N
 
 
 def _asset_missing(graph_root: Path, page_relpath: str, asset_ref: str) -> bool:
-    page_path = graph_root / page_relpath
+    page_path = _safe_page_path(graph_root, page_relpath)
+    if page_path is None or not page_path.is_file():
+        return True
     resolved = _resolve_asset_path(graph_root, page_path, asset_ref)
     return not resolved.is_file()
 
@@ -511,8 +545,8 @@ def _mutate_block_hygiene_property(
     remove: bool,
 ) -> bool:
     """Add or remove ``dead-link::`` / ``missing-asset::`` under the block (OCC-safe)."""
-    page_path = graph_root / page_relpath
-    if not page_path.is_file():
+    page_path = _safe_page_path(graph_root, page_relpath)
+    if page_path is None or not page_path.is_file():
         return False
 
     prop_key = property_name if property_name.endswith("::") else f"{property_name}::"
@@ -525,7 +559,7 @@ def _mutate_block_hygiene_property(
     with page_rmw_lock(page_path):
         if read_file_mtime(page_path) != baseline_mtime:
             return False
-        raw = page_path.read_text(encoding="utf-8", errors="replace")
+        raw = read_graph_file_text(page_path, graph_root, errors="replace")
         lines = raw.splitlines(keepends=True)
         if not lines:
             lines = [""]
@@ -667,8 +701,8 @@ def register_page_links_from_path(graph_root: Path, page_path: Path) -> int:
             return _purge_registry_entries_for_page(graph_root, page_relpath)
         return 0
     try:
-        content = page_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+        content = read_graph_file_text(page_path, graph_root, errors="replace")
+    except (OSError, PathTraversalSecurityError):
         return 0
     return merge_page_links_into_registry(graph_root, page_path, content)
 

--- a/src/graph/markdown_blocks.py
+++ b/src/graph/markdown_blocks.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from .io_retry import IO_RETRY_ATTEMPTS, IO_RETRY_INITIAL_DELAY_S, IO_RETRY_MAX_DELAY_S
 from .logseq_uuid import assert_valid_block_refs_in_markdown
-from .path_sandbox import PathTraversalSecurityError, assert_path_within_graph
+from .path_sandbox import PathTraversalSecurityError, assert_path_within_graph, read_graph_file_text
 from .path_sandbox import graph_safe_page_path as _graph_safe_page_path
 
 _BULLET = re.compile(r"^(\s*)[-*+]\s+")
@@ -112,7 +112,7 @@ def read_page_lines(
         return None, None, "path_escapes_graph"
     if not path.is_file():
         return None, None, "page_not_found"
-    text = path.read_text(encoding="utf-8")
+    text = read_graph_file_text(path, root, encoding="utf-8")
     return path, text.splitlines(keepends=True), None
 
 

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -14,10 +14,12 @@ from typing import Any
 
 from loguru import logger
 
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .alias_index import build_alias_index, iter_alias_source_paths, page_title_from_path
 from .json_flock import cross_process_json_flock
 from .markdown_blocks import atomic_write_bytes
 from .markdown_io import MmapTextView, read_graph_page_text
+from .path_sandbox import read_graph_file_text
 
 CATALOG_FILENAME = "master_catalog.json"
 CATALOG_VERSION = 1
@@ -233,16 +235,15 @@ def _quarantine_corrupt_catalog(catalog_path: Path) -> Path:
 def _load_catalog_payload_from_disk(path: Path, root: Path) -> MasterCatalog:
     """Parse catalog JSON from disk; restore backup or quarantine on corruption."""
     try:
-        raw = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        raise
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+        payload = read_bounded_json(path)
+    except BoundedJsonError as exc:
+        msg = str(exc)
+        if msg.startswith("Cannot stat") or msg.startswith("Cannot read"):
+            raise OSError(msg) from exc
         backup = _catalog_backup_path(path)
         if backup.is_file():
             try:
-                payload = json.loads(backup.read_text(encoding="utf-8", errors="replace"))
+                payload = read_bounded_json(backup)
                 logger.warning(
                     "[METADATA CORRUPTION DETECTED] Restored master catalog from backup at {}",
                     backup,
@@ -251,7 +252,7 @@ def _load_catalog_payload_from_disk(path: Path, root: Path) -> MasterCatalog:
                     catalog = MasterCatalog.from_json(root, payload)
                     catalog.persist_allowed = True
                     return catalog
-            except (OSError, json.JSONDecodeError, ValueError):
+            except BoundedJsonError:
                 pass
         try:
             quarantined = _quarantine_corrupt_catalog(path)
@@ -491,7 +492,7 @@ def is_bootstrap_catalog_complete(graph_root: Path) -> bool:
         if title in MATRYCA_GENERATED_INDEX_TITLES:
             continue
         try:
-            content = path.read_text(encoding="utf-8", errors="replace")
+            content = read_graph_file_text(path, root, errors="replace")
             mtime_ns = path.stat().st_mtime_ns
         except OSError:
             return False

--- a/src/graph/semantic_clustering.py
+++ b/src/graph/semantic_clustering.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from loguru import logger
 
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .json_flock import cross_process_json_flock
 from .markdown_blocks import atomic_write_bytes
 
@@ -540,8 +541,8 @@ def load_semantic_clusters(graph_root: Path) -> dict[str, list[str]] | None:
     if not path.is_file():
         return None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        payload = read_bounded_json(path)
+    except BoundedJsonError as exc:
         logger.warning("Ignoring corrupt semantic cluster cache at {}: {}", path, exc)
         return None
     if not isinstance(payload, dict):
@@ -578,8 +579,8 @@ def load_or_compute_semantic_clusters(
         path = semantic_clusters_path(graph_root)
         if path.is_file():
             try:
-                payload = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
+                payload = read_bounded_json(path)
+            except BoundedJsonError:
                 payload = None
             if isinstance(payload, dict):
                 cached_at = payload.get("catalog_updated_at")

--- a/src/graph/tag_unify.py
+++ b/src/graph/tag_unify.py
@@ -11,6 +11,7 @@ from .global_fence_scanner import compute_page_protected_line_indices
 from .markdown_blocks import atomic_write_bytes, iter_graph_markdown_files
 from .mldoc_properties import double_quoted_spans_in_value, parse_logseq_property_line
 from .page_write_lock import page_rmw_lock
+from .path_sandbox import read_graph_file_text
 
 _TAG_RE = re.compile(r"#([\w./-]+)", re.UNICODE)
 
@@ -98,7 +99,7 @@ def scan_tag_clusters(graph_root: str | Path) -> list[TagLintRow]:
     clusters: dict[str, TagCluster] = {}
     for path in iter_graph_markdown_files(root):
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         for line in text.splitlines():
@@ -257,7 +258,7 @@ def lint_unify_logseq_tags(
     for path in iter_graph_markdown_files(root):
         with page_rmw_lock(path):
             try:
-                raw = path.read_text(encoding="utf-8", errors="replace")
+                raw = read_graph_file_text(path, root, errors="replace")
             except OSError as exc:
                 file_results.append(
                     TagUnifyFileResult(

--- a/src/graph/templates.py
+++ b/src/graph/templates.py
@@ -8,6 +8,7 @@ from .path_sandbox import (
     SECURITY_VIOLATION_MSG,
     PathTraversalSecurityError,
     assert_path_within_graph,
+    read_graph_file_text,
     resolved_graph_root,
 )
 
@@ -55,7 +56,7 @@ def read_logseq_template(
         msg = f"template not found: {path}"
         raise FileNotFoundError(msg)
 
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = read_graph_file_text(path, graph_root, errors="replace")
     rel = path.relative_to(Path(graph_root).expanduser().resolve(strict=False))
     return (rel.as_posix(), text)
 

--- a/src/graph/unlinked_mentions.py
+++ b/src/graph/unlinked_mentions.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .global_fence_scanner import compute_page_protected_line_indices
 from .markdown_blocks import iter_graph_markdown_files
 from .page_path import filename_to_page_title
+from .path_sandbox import read_graph_file_text
 
 
 def _page_titles_from_graph(graph_root: Path) -> list[str]:
@@ -99,7 +100,7 @@ def resolve_unlinked_mentions(
     for path in iter_graph_markdown_files(root):
         files_scanned += 1
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError:
             continue
         rel = path.relative_to(root).as_posix()

--- a/src/graph/wiki_lint.py
+++ b/src/graph/wiki_lint.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from ..config import MatrycaWikiConfig
+from .alias_index import is_scannable_graph_markdown
+from .path_sandbox import read_graph_file_text
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _TYPE_RE = re.compile(r"(?im)^\s*type::\s*(\S+)\s*$")
@@ -61,9 +63,11 @@ def lint_wiki_prefixed_pages(
     for path in sorted(pages.glob("*.md")):
         if not path.is_file() or not path.name.startswith(prefix):
             continue
+        if not is_scannable_graph_markdown(path, root):
+            continue
         rel = str(path.relative_to(root))
         try:
-            text = path.read_text(encoding="utf-8", errors="replace")
+            text = read_graph_file_text(path, root, errors="replace")
         except OSError as exc:
             findings.append(
                 WikiLintFinding(

--- a/src/rag/local_query.py
+++ b/src/rag/local_query.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from ..graph.path_sandbox import read_graph_file_text
+
 _TOKEN = re.compile(r"[0-9a-z]+", re.IGNORECASE)
 
 
@@ -34,7 +36,7 @@ def rank_pages_by_keyword(
     scored: list[tuple[str, int]] = []
     for path in _iter_page_files(root):
         try:
-            text = path.read_text(encoding="utf-8", errors="replace").lower()
+            text = read_graph_file_text(path, root, errors="replace").lower()
         except OSError:
             continue
         hits = text.count(needle)

--- a/src/semantic/store.py
+++ b/src/semantic/store.py
@@ -13,6 +13,7 @@ from typing import Any
 from loguru import logger
 
 from ..graph.json_flock import cross_process_json_flock
+from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 
 BLOCK_VECTORS_FILENAME = "block_vectors.json"
 BLOCK_VECTORS_VERSION = 1
@@ -214,10 +215,10 @@ def load_block_vector_store(
         if path.is_file():
             try:
                 with cross_process_json_flock(path):
-                    payload = json.loads(path.read_text(encoding="utf-8"))
+                    payload = read_bounded_json(path)
                 if isinstance(payload, dict):
                     store = BlockVectorStore.from_json(Path(key), payload)
-            except (OSError, json.JSONDecodeError) as exc:
+            except (BoundedJsonError, OSError) as exc:
                 logger.warning("Failed to load block_vectors.json: {}", exc)
         _loaded[key] = store
         _disk_mtimes[key] = disk_mtime

--- a/src/utils/agent_debug_log.py
+++ b/src/utils/agent_debug_log.py
@@ -8,7 +8,11 @@ import time
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
+from .config_paths import resolve_optional_path_under_allowed_roots
 from .json_repair import max_consecutive_literal_backslash_n
+from .secret_redaction import redact_for_log
 
 
 def _debug_enabled() -> bool:
@@ -23,7 +27,13 @@ def _debug_enabled() -> bool:
 def _debug_log_path() -> Path:
     custom = os.environ.get("MATRYCA_LLM_DEBUG_LOG_PATH", "").strip()
     if custom:
-        return Path(custom)
+        allowed = resolve_optional_path_under_allowed_roots(custom)
+        if allowed is not None:
+            return allowed
+        logger.warning(
+            "MATRYCA_LLM_DEBUG_LOG_PATH is outside allowed roots; "
+            "using default .cursor/debug-llm.jsonl",
+        )
     return Path(__file__).resolve().parents[2] / ".cursor" / "debug-llm.jsonl"
 
 
@@ -59,8 +69,9 @@ def agent_debug_log(
         }
         path = _debug_log_path()
         path.parent.mkdir(parents=True, exist_ok=True)
+        line = redact_for_log(json.dumps(payload, ensure_ascii=False)) + "\n"
         with path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            handle.write(line)
     except OSError:
         pass
     # #endregion

--- a/src/utils/bounded_json.py
+++ b/src/utils/bounded_json.py
@@ -1,0 +1,59 @@
+"""Bounded JSON reads for graph-local checkpoint files (memory DoS guard)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_MAX_BYTES = 64_000_000
+_MAX_BYTES_ENV = "MATRYCA_JSON_MAX_BYTES"
+
+
+class BoundedJsonError(ValueError):
+    """Raised when a JSON checkpoint exceeds the configured size cap."""
+
+
+def json_max_bytes() -> int:
+    raw = os.environ.get(_MAX_BYTES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_BYTES
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+
+
+def read_bounded_json(
+    path: Path | str,
+    *,
+    max_bytes: int | None = None,
+    encoding: str = "utf-8",
+) -> Any:
+    """Read and parse JSON from ``path`` after enforcing a byte-size cap."""
+    cap = max_bytes if max_bytes is not None else json_max_bytes()
+    file_path = Path(path)
+    try:
+        size = file_path.stat().st_size
+    except OSError as exc:
+        raise BoundedJsonError(f"Cannot stat JSON checkpoint: {file_path}") from exc
+    if size > cap:
+        raise BoundedJsonError(
+            f"JSON checkpoint exceeds {cap} bytes: {file_path} ({size} bytes)",
+        )
+    try:
+        text = file_path.read_text(encoding=encoding)
+    except OSError as exc:
+        raise BoundedJsonError(f"Cannot read JSON checkpoint: {file_path}") from exc
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise BoundedJsonError(f"Invalid JSON in checkpoint: {file_path}") from exc
+
+
+__all__ = [
+    "BoundedJsonError",
+    "json_max_bytes",
+    "read_bounded_json",
+]

--- a/tests/test_agent_debug_log.py
+++ b/tests/test_agent_debug_log.py
@@ -1,0 +1,39 @@
+"""Tests for LLM debug log path allowlist and secret redaction."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from src.utils import agent_debug_log
+
+
+def test_debug_log_path_rejects_outside_allowed_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_LLM_DEBUG_LOG_PATH", "/etc/passwd")
+    path = agent_debug_log._debug_log_path()
+    assert path.name == "debug-llm.jsonl"
+    assert ".cursor" in path.as_posix()
+
+
+def test_agent_debug_log_redacts_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_path = tmp_path / "debug.jsonl"
+    monkeypatch.setenv("MATRYCA_LLM_DEBUG_JSON", "true")
+    monkeypatch.setenv("MATRYCA_LLM_DEBUG_LOG_PATH", str(log_path))
+    secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+    agent_debug_log.agent_debug_log(
+        location="test",
+        message="probe",
+        data={"prompt": secret},
+        hypothesis_id="H1",
+    )
+    line = log_path.read_text(encoding="utf-8").strip()
+    payload = json.loads(line)
+    assert secret not in line
+    assert "sk-" not in str(payload.get("data", {}))

--- a/tests/test_bounded_json.py
+++ b/tests/test_bounded_json.py
@@ -1,0 +1,26 @@
+"""Tests for bounded JSON checkpoint reads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from src.utils.bounded_json import BoundedJsonError, read_bounded_json
+
+
+def test_read_bounded_json_parses_valid_file(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps({"ok": True}), encoding="utf-8")
+    assert read_bounded_json(path) == {"ok": True}
+
+
+def test_read_bounded_json_rejects_oversized_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "big.json"
+    path.write_text("[" + "1," * 500 + "1]", encoding="utf-8")
+    monkeypatch.setenv("MATRYCA_JSON_MAX_BYTES", "32")
+    with pytest.raises(BoundedJsonError, match="exceeds"):
+        read_bounded_json(path)

--- a/tests/test_link_verification.py
+++ b/tests/test_link_verification.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -224,3 +225,51 @@ def test_merge_prunes_links_removed_from_page(graph_with_page: tuple[Path, Path]
     page.write_text(stripped, encoding="utf-8")
     merge_page_links_into_registry(root, page, stripped)
     assert load_link_registry(root) == {}
+
+
+def test_asset_traversal_outside_graph_treated_as_missing(tmp_path: Path) -> None:
+    from src.graph.link_verification import _asset_missing
+
+    root = tmp_path / "graph"
+    pages = root / "pages"
+    pages.mkdir(parents=True)
+    outside = tmp_path / "secret.png"
+    outside.write_bytes(b"png")
+    page = pages / "note.md"
+    page.write_text("- img\n  id:: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\n", encoding="utf-8")
+    assert _asset_missing(root, "pages/note.md", "../../secret.png") is True
+
+
+def test_load_registry_drops_tampered_page_relpath(tmp_path: Path) -> None:
+    root = tmp_path / "graph"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret\n", encoding="utf-8")
+    reg_path = link_registry_path(root)
+    reg_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": {
+                    "bad": {
+                        "kind": "url",
+                        "target": "https://example.com",
+                        "page_relpath": f"../{outside.name}",
+                        "block_uuid": BLOCK,
+                    },
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    assert load_link_registry(root) == {}
+
+
+def test_flag_block_rejects_tampered_page_relpath(graph_with_page: tuple[Path, Path]) -> None:
+    root, _page = graph_with_page
+    assert not flag_block_hygiene_property(
+        root,
+        "../etc/passwd",
+        BLOCK,
+        "dead-link",
+    )

--- a/tests/test_sandbox_read_check.py
+++ b/tests/test_sandbox_read_check.py
@@ -1,0 +1,19 @@
+"""Smoke test for sandbox read_text CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_sandbox_read_check_passes_on_clean_tree() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(repo / "scripts" / "check_graph_read_sandbox.py")],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_ui_explicit_token.py
+++ b/tests/test_ui_explicit_token.py
@@ -1,0 +1,23 @@
+"""Tests for require_explicit_ui_token_if_configured."""
+
+from __future__ import annotations
+
+import pytest
+from src.cli.ui_auth import require_explicit_ui_token_if_configured
+
+
+def test_require_explicit_token_raises_when_enabled_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN", "true")
+    monkeypatch.delenv("MATRYCA_UI_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="MATRYCA_UI_TOKEN"):
+        require_explicit_ui_token_if_configured()
+
+
+def test_require_explicit_token_allows_when_token_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN", "true")
+    monkeypatch.setenv("MATRYCA_UI_TOKEN", "fixed-token")
+    require_explicit_ui_token_if_configured()

--- a/tests/test_wiki_lint.py
+++ b/tests/test_wiki_lint.py
@@ -24,3 +24,15 @@ def test_lint_skips_non_prefixed_pages(tmp_path: Path) -> None:
     (pages / "Journal.md").write_text("- x\n", encoding="utf-8")
     cfg = MatrycaWikiConfig(wiki_file_prefix="Matryca___")
     assert lint_wiki_prefixed_pages(tmp_path, cfg) == []
+
+
+def test_lint_skips_symlink_escape(tmp_path: Path) -> None:
+    graph = tmp_path / "graph"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("type:: secret\n", encoding="utf-8")
+    link = pages / "Matryca___Evil.md"
+    link.symlink_to(outside)
+    cfg = MatrycaWikiConfig(wiki_file_prefix="Matryca___")
+    assert lint_wiki_prefixed_pages(graph, cfg) == []


### PR DESCRIPTION
## Summary

- Harden link verification reads: sandbox `_resolve_asset_path`, validate registry `page_relpath`, and route page I/O through `read_graph_file_text()`.
- Introduce `read_bounded_json()` with `MATRYCA_JSON_MAX_BYTES` (64 MiB default) for all graph-local JSON checkpoints.
- Filter `wiki_lint` with `is_scannable_graph_markdown()` to block symlink escape reads.
- Restrict `MATRYCA_LLM_DEBUG_LOG_PATH` to allowed roots and redact secrets in NDJSON debug output.
- Template `MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true` in `.env.example` and strengthen ephemeral-token startup warnings.
- Migrate graph/agent/rag reads to `read_graph_file_text()`; add CI `sandbox-read-check` gate.

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run mypy src tests`
- [x] `uv run pytest -q --no-cov` (683 passed)
- [x] `make sandbox-read-check`

Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33

Made with [Cursor](https://cursor.com)