### PR TITLE
fix(concurrency): json_flock parity with page_write_lock (#40)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,7 +184,7 @@ MATRYCA_WATCH_DEBOUNCE_MS=750
 # Template: false
 MATRYCA_DEBUG=false
 
-# Allow daemon without POSIX flock. src/graph/page_write_lock.py
+# Allow daemon without POSIX flock (page RMW + JSON sidecar locks). src/graph/page_write_lock.py, src/graph/json_flock.py via src/utils/platform_lock.py
 # Default (code): false
 # Template: false
 MATRYCA_ALLOW_FLOCK_DEGRADATION=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **JSON sidecar flock parity (#40)** — `cross_process_json_flock` shares `src/utils/platform_lock.py` with page RMW locks: non-blocking acquire with exponential backoff, blocking fallback after NB exhaustion, `MATRYCA_ALLOW_FLOCK_DEGRADATION`, and thread-local reentrancy depth tracking (fixes nested catalog/registry deadlocks and reduces pytest-xdist lock thrashing).
+
 ### Changed
 
 - **GitHub backlog hygiene** — Closed shipped audit issues #35, #36, #37, #41, #67, #68, #70; tagged six good-first issues (#45, #53, #56, #69, #71, #85) with `good first issue` + `help wanted` and welcome comments; opened [#85](https://github.com/MarcoPorcellato/matryca-plumber/issues/85) for `BootstrapHarvestStatus` Literal dedup (slice of #62). Docs: [`good_first_issues_blueprints.md`](good_first_issues_blueprints.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`ROADMAP.md`](ROADMAP.md).

--- a/src/graph/json_flock.py
+++ b/src/graph/json_flock.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
 
-_fcntl: Any
-try:
-    import fcntl as _fcntl
-except ImportError:  # pragma: no cover - Windows
-    _fcntl = None
+from ..utils.platform_lock import cross_process_sidecar_lock
 
 
 def flock_sidecar_path(target: Path) -> Path:
@@ -23,22 +17,14 @@ def flock_sidecar_path(target: Path) -> Path:
 @contextmanager
 def cross_process_json_flock(target: Path) -> Iterator[None]:
     """Hold an exclusive flock for one JSON read/write critical section."""
-    if _fcntl is None:
-        yield
-        return
-
     lock_path = flock_sidecar_path(target)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
-    try:
-        _fcntl.flock(fd, _fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            with suppress(OSError):
-                _fcntl.flock(fd, _fcntl.LOCK_UN)
-    finally:
-        os.close(fd)
+    depth_key = str(lock_path.expanduser().resolve(strict=False))
+    with cross_process_sidecar_lock(
+        lock_path,
+        depth_key=depth_key,
+        unavailable_label="JSON sidecar lock",
+    ):
+        yield
 
 
 __all__ = ["cross_process_json_flock", "flock_sidecar_path"]

--- a/src/graph/page_write_lock.py
+++ b/src/graph/page_write_lock.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
-import os
 import sys
 import threading
 import time
 from collections import OrderedDict
 from collections.abc import Iterator
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 
+from ..utils.platform_lock import (
+    _fcntl,
+    cross_process_sidecar_lock,
+    probe_exclusive_flock,
+)
 from .io_retry import (
     IO_RETRY_ATTEMPTS,
     IO_RETRY_INITIAL_DELAY_S,
@@ -21,21 +24,9 @@ from .io_retry import (
     PageLockUnavailableError,
 )
 
-_fcntl: Any
-try:
-    import fcntl as _fcntl
-except ImportError:  # pragma: no cover - Windows and other non-Unix platforms
-    _fcntl = None
-
 _registry_guard = threading.Lock()
 _page_locks: OrderedDict[str, threading.RLock] = OrderedDict()
 _MAX_PAGE_LOCK_REGISTRY = 4096
-_flock_depth_local = threading.local()
-
-
-def _flock_degradation_allowed() -> bool:
-    raw = os.environ.get("MATRYCA_ALLOW_FLOCK_DEGRADATION", "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
 
 
 def normalize_page_lock_key(page_path: str | Path) -> str:
@@ -47,14 +38,6 @@ def _sidecar_lock_path(page_path: str | Path) -> Path:
     """Return a hidden lock file adjacent to the target (same directory, one volume)."""
     path = Path(page_path).expanduser().resolve(strict=False)
     return path.parent / f".{path.name}.matryca.lock"
-
-
-def _flock_depths() -> dict[str, int]:
-    depths = getattr(_flock_depth_local, "depths", None)
-    if depths is None:
-        depths = {}
-        _flock_depth_local.depths = depths
-    return depths
 
 
 def _lock_for_key(key: str) -> threading.RLock:
@@ -81,86 +64,17 @@ def _lock_for_key(key: str) -> threading.RLock:
         return lock
 
 
-def _acquire_cross_process_flock(fd: int, lock_path: Path) -> bool:
-    """Acquire exclusive flock with backoff; return False when flock is unsupported."""
-    delay = IO_RETRY_INITIAL_DELAY_S
-    for attempt in range(IO_RETRY_ATTEMPTS):
-        try:
-            _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
-            return True
-        except BlockingIOError:
-            if attempt >= IO_RETRY_ATTEMPTS - 1:
-                logger.warning(
-                    "Page lock sidecar still held after {} retries: {}",
-                    IO_RETRY_ATTEMPTS - 1,
-                    lock_path,
-                )
-                raise PageLockUnavailableError(
-                    f"Could not acquire page lock for {lock_path} after retries",
-                ) from None
-            time.sleep(min(IO_RETRY_MAX_DELAY_S, delay))
-            delay = min(IO_RETRY_MAX_DELAY_S, delay * 2)
-        except OSError as exc:
-            if not _flock_degradation_allowed():
-                raise PageLockUnavailableError(
-                    f"Cross-process page lock unavailable for {lock_path}: {exc}",
-                ) from exc
-            logger.info(
-                "[LOCK FILE SYSTEM DEGRADATION] Shared process lock not supported by "
-                "filesystem ({}), falling back to pure in-process thread locking.",
-                exc,
-            )
-            return False
-    return False
-
-
 @contextmanager
 def _cross_process_file_lock(page_path: str | Path) -> Iterator[None]:
     """Exclusive ``fcntl.flock`` on a sidecar lock file (no-op when ``fcntl`` is unavailable)."""
     key = normalize_page_lock_key(page_path)
-    depths = _flock_depths()
-    nested = depths.get(key, 0)
-    if nested > 0:
-        depths[key] = nested + 1
-        try:
-            yield
-        finally:
-            depths[key] -= 1
-        return
-
-    if _fcntl is None:
-        depths[key] = 1
-        try:
-            yield
-        finally:
-            depths.pop(key, None)
-        return
-
     lock_path = _sidecar_lock_path(page_path)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
-    try:
-        acquired = _acquire_cross_process_flock(fd, lock_path)
-        if not acquired and _fcntl is not None and not _flock_degradation_allowed():
-            raise PageLockUnavailableError(
-                f"Could not acquire cross-process page lock for {lock_path}",
-            )
-        if not acquired:
-            depths[key] = 1
-            try:
-                yield
-            finally:
-                depths.pop(key, None)
-            return
-        depths[key] = 1
-        try:
-            yield
-        finally:
-            depths.pop(key, None)
-            with suppress(OSError):
-                _fcntl.flock(fd, _fcntl.LOCK_UN)
-    finally:
-        os.close(fd)
+    with cross_process_sidecar_lock(
+        lock_path,
+        depth_key=key,
+        unavailable_label="page lock",
+    ):
+        yield
 
 
 def probe_page_rmw_lock(page_path: str | Path) -> None:
@@ -176,28 +90,10 @@ def probe_page_rmw_lock(page_path: str | Path) -> None:
             f"Could not probe in-process page lock for {page_path}",
         )
     try:
-        if _fcntl is None:
-            return
-        lock_path = _sidecar_lock_path(page_path)
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
-        try:
-            try:
-                _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
-            except BlockingIOError as exc:
-                raise PageLockUnavailableError(
-                    f"Could not probe cross-process page lock for {lock_path}",
-                ) from exc
-            except OSError as exc:
-                if not _flock_degradation_allowed():
-                    raise PageLockUnavailableError(
-                        f"Cross-process page lock unavailable for {lock_path}: {exc}",
-                    ) from exc
-                return
-            with suppress(OSError):
-                _fcntl.flock(fd, _fcntl.LOCK_UN)
-        finally:
-            os.close(fd)
+        probe_exclusive_flock(
+            _sidecar_lock_path(page_path),
+            unavailable_label="page lock",
+        )
     finally:
         thread_lock.release()
 

--- a/src/utils/platform_lock.py
+++ b/src/utils/platform_lock.py
@@ -1,0 +1,205 @@
+"""Shared cross-process ``fcntl.flock`` sidecar locking (NB + backoff + degradation)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from ..graph.io_retry import (
+    IO_RETRY_ATTEMPTS,
+    IO_RETRY_INITIAL_DELAY_S,
+    IO_RETRY_MAX_DELAY_S,
+    PageLockUnavailableError,
+)
+
+_fcntl: Any
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows and other non-Unix platforms
+    _fcntl = None
+
+_flock_depth_local = threading.local()
+
+
+def flock_degradation_allowed() -> bool:
+    """Return whether flock failures may fall back to in-process-only coordination."""
+    raw = os.environ.get("MATRYCA_ALLOW_FLOCK_DEGRADATION", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def flock_depths() -> dict[str, int]:
+    """Per-thread reentrancy depth keyed by caller-supplied lock identity."""
+    depths = getattr(_flock_depth_local, "depths", None)
+    if depths is None:
+        depths = {}
+        _flock_depth_local.depths = depths
+    return depths
+
+
+def clear_flock_depths() -> None:
+    """Reset thread-local flock depth tracking (tests)."""
+    if hasattr(_flock_depth_local, "depths"):
+        del _flock_depth_local.depths
+
+
+def acquire_exclusive_flock(
+    fd: int,
+    lock_path: Path,
+    *,
+    unavailable_label: str = "sidecar lock",
+) -> bool:
+    """Acquire exclusive flock with exponential backoff.
+
+    Returns:
+        True when the OS flock is held on ``fd``.
+        False when flock is unsupported and degradation is allowed.
+    """
+    if _fcntl is None:
+        return False
+
+    delay = IO_RETRY_INITIAL_DELAY_S
+    for attempt in range(IO_RETRY_ATTEMPTS):
+        try:
+            _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+            return True
+        except BlockingIOError:
+            if attempt >= IO_RETRY_ATTEMPTS - 1:
+                logger.warning(
+                    "{} sidecar contended after {} NB retries; blocking until free: {}",
+                    unavailable_label,
+                    IO_RETRY_ATTEMPTS - 1,
+                    lock_path,
+                )
+                try:
+                    _fcntl.flock(fd, _fcntl.LOCK_EX)
+                    return True
+                except OSError as exc:
+                    if not flock_degradation_allowed():
+                        raise PageLockUnavailableError(
+                            f"Could not acquire {unavailable_label} for {lock_path}: {exc}",
+                        ) from exc
+                    logger.info(
+                        "[LOCK FILE SYSTEM DEGRADATION] Shared process lock not supported by "
+                        "filesystem ({}), falling back to in-process coordination for {}.",
+                        exc,
+                        lock_path,
+                    )
+                    return False
+            time.sleep(min(IO_RETRY_MAX_DELAY_S, delay))
+            delay = min(IO_RETRY_MAX_DELAY_S, delay * 2)
+        except OSError as exc:
+            if not flock_degradation_allowed():
+                raise PageLockUnavailableError(
+                    f"Cross-process {unavailable_label} unavailable for {lock_path}: {exc}",
+                ) from exc
+            logger.info(
+                "[LOCK FILE SYSTEM DEGRADATION] Shared process lock not supported by "
+                "filesystem ({}), falling back to in-process coordination for {}.",
+                exc,
+                lock_path,
+            )
+            return False
+    return False
+
+
+def probe_exclusive_flock(
+    lock_path: Path,
+    *,
+    unavailable_label: str = "sidecar lock",
+) -> None:
+    """Verify a sidecar flock can be acquired (single NB attempt, no hold)."""
+    if _fcntl is None:
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise PageLockUnavailableError(
+                f"Could not probe cross-process {unavailable_label} for {lock_path}",
+            ) from exc
+        except OSError as exc:
+            if not flock_degradation_allowed():
+                raise PageLockUnavailableError(
+                    f"Cross-process {unavailable_label} unavailable for {lock_path}: {exc}",
+                ) from exc
+            return
+        with suppress(OSError):
+            _fcntl.flock(fd, _fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def cross_process_sidecar_lock(
+    lock_path: Path,
+    *,
+    depth_key: str,
+    unavailable_label: str = "sidecar lock",
+) -> Iterator[None]:
+    """Hold an exclusive cross-process flock on ``lock_path`` with reentrancy depth tracking."""
+    depths = flock_depths()
+    nested = depths.get(depth_key, 0)
+    if nested > 0:
+        depths[depth_key] = nested + 1
+        try:
+            yield
+        finally:
+            depths[depth_key] -= 1
+        return
+
+    if _fcntl is None:
+        depths[depth_key] = 1
+        try:
+            yield
+        finally:
+            depths.pop(depth_key, None)
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        acquired = acquire_exclusive_flock(
+            fd,
+            lock_path,
+            unavailable_label=unavailable_label,
+        )
+        if not acquired and not flock_degradation_allowed():
+            raise PageLockUnavailableError(
+                f"Could not acquire cross-process {unavailable_label} for {lock_path}",
+            )
+        if not acquired:
+            depths[depth_key] = 1
+            try:
+                yield
+            finally:
+                depths.pop(depth_key, None)
+            return
+        depths[depth_key] = 1
+        try:
+            yield
+        finally:
+            depths.pop(depth_key, None)
+            with suppress(OSError):
+                _fcntl.flock(fd, _fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+__all__ = [
+    "acquire_exclusive_flock",
+    "clear_flock_depths",
+    "cross_process_sidecar_lock",
+    "flock_degradation_allowed",
+    "flock_depths",
+    "probe_exclusive_flock",
+]

--- a/tests/test_hardening_final.py
+++ b/tests/test_hardening_final.py
@@ -17,13 +17,13 @@ from src.agent.quality_gate import (
     markdown_append_bounds_violations,
     outline_bounds_violations,
 )
-from src.graph import page_write_lock as page_write_lock_mod
 from src.graph.markdown_blocks import atomic_write_bytes
 from src.graph.page_write_lock import (
     clear_page_write_locks,
     cross_process_lock_available,
     page_rmw_lock,
 )
+from src.utils import platform_lock as platform_lock_mod
 
 
 def test_outline_bounds_rejects_too_many_nodes() -> None:
@@ -93,7 +93,7 @@ def test_flock_oserror_falls_back_to_thread_lock(
         raise OSError(95, msg)
 
     monkeypatch.setenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", "true")
-    monkeypatch.setattr(page_write_lock_mod._fcntl, "flock", _reject_flock)
+    monkeypatch.setattr(platform_lock_mod._fcntl, "flock", _reject_flock)
     with page_rmw_lock(target):
         target.write_text("updated\n", encoding="utf-8")
     assert target.read_text(encoding="utf-8") == "updated\n"

--- a/tests/test_json_flock.py
+++ b/tests/test_json_flock.py
@@ -6,9 +6,12 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from src.graph.io_retry import PageLockUnavailableError
 from src.graph.json_flock import cross_process_json_flock
+from src.utils.platform_lock import clear_flock_depths
 
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
@@ -49,3 +52,61 @@ def test_in_process_json_flock_context_manager(tmp_path: Path) -> None:
     with cross_process_json_flock(target):
         target.write_text('{"ok": true}', encoding="utf-8")
     assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+
+
+def test_nested_json_flock_same_thread_reentrant(tmp_path: Path) -> None:
+    clear_flock_depths()
+    target = tmp_path / "nested.json"
+    target.write_text("{}", encoding="utf-8")
+    with cross_process_json_flock(target), cross_process_json_flock(target):  # noqa: SIM117
+        target.write_text('{"nested": true}', encoding="utf-8")
+    assert json.loads(target.read_text(encoding="utf-8")) == {"nested": True}
+
+
+def test_json_flock_raises_when_blocking_acquire_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_flock_depths()
+    target = tmp_path / "contended.json"
+    target.write_text("{}", encoding="utf-8")
+
+    import fcntl
+
+    def _contended_flock(fd: int, op: int) -> None:
+        _ = fd
+        if op & fcntl.LOCK_NB:
+            raise BlockingIOError()
+        raise OSError(95, "flock blocked")
+
+    monkeypatch.delenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", raising=False)
+    monkeypatch.setattr("src.utils.platform_lock.IO_RETRY_ATTEMPTS", 2)
+    monkeypatch.setattr("src.utils.platform_lock.IO_RETRY_INITIAL_DELAY_S", 0.01)
+    monkeypatch.setattr("src.utils.platform_lock.IO_RETRY_MAX_DELAY_S", 0.02)
+    with (
+        patch("src.utils.platform_lock._fcntl.flock", side_effect=_contended_flock),
+        pytest.raises(PageLockUnavailableError),
+        cross_process_json_flock(target),
+    ):
+        pass
+
+
+def test_json_flock_degradation_on_unsupported_fs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_flock_depths()
+    target = tmp_path / "cloud.json"
+    target.write_text("{}", encoding="utf-8")
+
+    def _reject_flock(fd: int, op: int) -> None:
+        _ = (fd, op)
+        raise OSError(95, "flock not supported on this filesystem")
+
+    monkeypatch.setenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", "true")
+    with (
+        patch("src.utils.platform_lock._fcntl.flock", side_effect=_reject_flock),
+        cross_process_json_flock(target),
+    ):
+        target.write_text('{"degraded": true}', encoding="utf-8")
+    assert json.loads(target.read_text(encoding="utf-8")) == {"degraded": True}


### PR DESCRIPTION
## Summary

- Extract shared cross-process flock logic into `src/utils/platform_lock.py` (NB acquire + exponential backoff, blocking fallback after NB exhaustion, `MATRYCA_ALLOW_FLOCK_DEGRADATION`, thread-local reentrancy depth).
- Upgrade `cross_process_json_flock` to delegate to the shared primitive instead of blocking `LOCK_EX`.
- Refactor `page_write_lock.py` to reuse the same engine, removing duplicated fcntl/backoff code.
- Extend `tests/test_json_flock.py` for reentrancy, degradation, and hard failure paths; document JSON sidecar coverage in `.env.example`.

Closes #40

## Test plan

- [x] `uv run ruff check src tests`
- [x] `uv run mypy src tests`
- [x] `uv run pytest -q` (728 passed)
- [x] `tests/test_master_catalog.py::test_load_master_catalog_serializes_reads_under_concurrent_save`
