### PR TITLE
fix(concurrency): OCC-protected hub page writes (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hub page OCC (#34)** — `write_master_index_page` and `write_graph_insights_page` use `page_rmw_lock`, pre-compile `occ_snapshot`, and `atomic_write_bytes_if_unchanged`; concurrent edits during compile log a graceful skip (derived pages regenerate on the next daemon cycle).
+
 ### Changed
 
 - **GitHub backlog hygiene** — Closed shipped audit issues #35, #36, #37, #41, #67, #68, #70; tagged six good-first issues (#45, #53, #56, #69, #71, #85) with `good first issue` + `help wanted` and welcome comments; opened [#85](https://github.com/MarcoPorcellato/matryca-plumber/issues/85) for `BootstrapHarvestStatus` Literal dedup (slice of #62). Docs: [`good_first_issues_blueprints.md`](good_first_issues_blueprints.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`ROADMAP.md`](ROADMAP.md).

--- a/src/graph/generated_hub_write.py
+++ b/src/graph/generated_hub_write.py
@@ -1,0 +1,86 @@
+"""OCC-safe writes for Matryca-generated hub pages (Master Index, Graph Insights)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+from .markdown_blocks import (
+    atomic_write_bytes,
+    atomic_write_bytes_if_unchanged,
+    file_mtime_drifted,
+    occ_snapshot,
+)
+from .page_write_lock import page_rmw_lock
+from .path_sandbox import graph_safe_page_path
+
+
+@dataclass(frozen=True)
+class GeneratedHubWriteResult:
+    """Outcome of a daemon hub-page compile write."""
+
+    path: Path
+    written: bool
+
+
+def write_generated_hub_page(
+    graph_root: Path,
+    page_title: str,
+    markdown: str,
+    *,
+    baseline_mtime: float | None = None,
+    robot_commit_summary: str,
+) -> GeneratedHubWriteResult:
+    """Write a compiled hub page under ``page_rmw_lock`` with OCC guards.
+
+    ``baseline_mtime`` should be captured **before** expensive markdown generation
+    so edits during compile are detected. On drift, logs a graceful skip and returns
+    ``written=False`` (caller may retry on the next daemon cycle).
+    """
+    path = graph_safe_page_path(graph_root, page_title)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pre_mtime = baseline_mtime if baseline_mtime is not None else occ_snapshot(path)
+
+    with page_rmw_lock(path):
+        if path.is_file():
+            if pre_mtime is not None and file_mtime_drifted(path, pre_mtime):
+                logger.info(
+                    "Graceful skip: hub page {} edited during compile (mtime drift)",
+                    page_title,
+                )
+                return GeneratedHubWriteResult(path, False)
+            current_mtime = occ_snapshot(path)
+            if current_mtime is None:
+                logger.info(
+                    "Graceful skip: hub page {} missing on disk under lock",
+                    page_title,
+                )
+                return GeneratedHubWriteResult(path, False)
+            if not atomic_write_bytes_if_unchanged(
+                path,
+                markdown.encode("utf-8"),
+                graph_root=graph_root,
+                baseline_mtime=current_mtime,
+                validate_block_refs=False,
+                robot_commit_summary=robot_commit_summary,
+            ):
+                logger.info(
+                    "Graceful skip: hub page {} OCC abort at commit",
+                    page_title,
+                )
+                return GeneratedHubWriteResult(path, False)
+            return GeneratedHubWriteResult(path, True)
+
+        atomic_write_bytes(
+            path,
+            markdown.encode("utf-8"),
+            graph_root=graph_root,
+            validate_block_refs=False,
+            robot_commit_summary=robot_commit_summary,
+        )
+        return GeneratedHubWriteResult(path, True)
+
+
+__all__ = ["GeneratedHubWriteResult", "write_generated_hub_page"]

--- a/src/graph/insights_engine.py
+++ b/src/graph/insights_engine.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ..agent.plumber_llm import GraphInsightsLLMResult, InsightsLLM
 from ..agent.prompt_constraints import finalize_system_prompt
 from .alias_index import iter_alias_source_paths, page_title_from_path
+from .generated_hub_write import write_generated_hub_page
 from .generational_cache import patch_generational_caches_for_paths
 from .link_tag_hop import (
     _WIKILINK,
@@ -18,7 +19,7 @@ from .link_tag_hop import (
     _resolve_target_to_stem,
     _tags_prop_values,
 )
-from .markdown_blocks import atomic_write_bytes
+from .markdown_blocks import occ_snapshot
 from .master_catalog import MasterCatalog, load_master_catalog
 from .page_path import filename_to_page_title
 from .path_sandbox import graph_safe_page_path, read_graph_file_text
@@ -353,11 +354,22 @@ def format_graph_insights_markdown(
 def write_graph_insights_page(
     graph_root: Path,
     markdown: str,
+    *,
+    baseline_mtime: float | None = None,
 ) -> Path:
+    """Write Graph Insights hub page with OCC; pass ``baseline_mtime`` before compile."""
     path = graph_safe_page_path(graph_root, GRAPH_INSIGHTS_TITLE)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_bytes(path, markdown.encode("utf-8"), graph_root=graph_root)
-    return path
+    pre_mtime = baseline_mtime
+    if pre_mtime is None and path.is_file():
+        pre_mtime = occ_snapshot(path)
+    result = write_generated_hub_page(
+        graph_root,
+        GRAPH_INSIGHTS_TITLE,
+        markdown,
+        baseline_mtime=pre_mtime,
+        robot_commit_summary="recompiled Matryca Graph Insights hub page",
+    )
+    return result.path
 
 
 def run_graph_insights_engine(
@@ -369,6 +381,8 @@ def run_graph_insights_engine(
     """Compute topology metrics and write ``pages/Matryca Graph Insights.md``."""
     started = time.perf_counter()
     root = graph_root.expanduser().resolve(strict=False)
+    insights_path = graph_safe_page_path(root, GRAPH_INSIGHTS_TITLE)
+    baseline_mtime = occ_snapshot(insights_path) if insights_path.is_file() else None
     catalog = catalog or load_master_catalog(root, force_reload=True)
     metrics = compute_topology_metrics(root, catalog)
 
@@ -384,7 +398,11 @@ def run_graph_insights_engine(
         llm_result = _fallback_insights(metrics)
 
     markdown = format_graph_insights_markdown(metrics, llm_result)
-    output_path = write_graph_insights_page(root, markdown)
+    output_path = write_graph_insights_page(
+        root,
+        markdown,
+        baseline_mtime=baseline_mtime,
+    )
     patch_generational_caches_for_paths(root, [output_path])
 
     return InsightsRunResult(

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -16,8 +16,9 @@ from loguru import logger
 
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .alias_index import build_alias_index, iter_alias_source_paths, page_title_from_path
+from .generated_hub_write import write_generated_hub_page
 from .json_flock import cross_process_json_flock
-from .markdown_blocks import atomic_write_bytes
+from .markdown_blocks import atomic_write_bytes, occ_snapshot
 from .markdown_io import MmapTextView, read_graph_page_text
 from .path_sandbox import read_graph_file_text
 
@@ -561,11 +562,17 @@ def write_master_index_page(graph_root: Path, catalog: MasterCatalog) -> Path:
     """Write the compiled master index page under ``pages/``."""
     from .path_sandbox import graph_safe_page_path
 
+    path = graph_safe_page_path(graph_root, MASTER_INDEX_PAGE_TITLE)
+    baseline_mtime = occ_snapshot(path) if path.is_file() else None
     md = build_master_index_markdown(catalog)
-    path = graph_safe_page_path(graph_root, "Matryca Master Index")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_bytes(path, md.encode("utf-8"), graph_root=graph_root)
-    return path
+    result = write_generated_hub_page(
+        graph_root,
+        MASTER_INDEX_PAGE_TITLE,
+        md,
+        baseline_mtime=baseline_mtime,
+        robot_commit_summary="recompiled Matryca Master Index hub page",
+    )
+    return result.path
 
 
 __all__ = [

--- a/tests/test_hubs.py
+++ b/tests/test_hubs.py
@@ -1,11 +1,29 @@
-"""Tests for namespace hub index."""
+"""Tests for namespace hub index and OCC-protected generated hub writes."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from src.config import MatrycaWikiConfig
+from src.graph.generated_hub_write import write_generated_hub_page
 from src.graph.hubs import build_namespace_index_markdown
+from src.graph.insights_engine import GRAPH_INSIGHTS_TITLE, write_graph_insights_page
+from src.graph.markdown_blocks import occ_snapshot
+from src.graph.master_catalog import (
+    MASTER_INDEX_PAGE_TITLE,
+    CatalogEntry,
+    MasterCatalog,
+    master_index_page_path,
+    write_master_index_page,
+)
+from src.graph.path_sandbox import graph_safe_page_path
+
+
+@pytest.fixture
+def graph_root(tmp_path: Path) -> Path:
+    (tmp_path / "pages").mkdir(parents=True)
+    return tmp_path
 
 
 def test_namespace_index_groups_triple_underscore(tmp_path: Path) -> None:
@@ -17,3 +35,108 @@ def test_namespace_index_groups_triple_underscore(tmp_path: Path) -> None:
     md = build_namespace_index_markdown(tmp_path, cfg)
     assert "Wiki" in md
     assert "Wiki/Tech/Docker" in md or "[[Wiki/Tech/Docker]]" in md
+
+
+def test_write_generated_hub_page_skips_on_baseline_drift(graph_root: Path) -> None:
+    path = graph_safe_page_path(graph_root, MASTER_INDEX_PAGE_TITLE)
+    path.write_text("- user baseline\n", encoding="utf-8")
+    baseline_mtime = occ_snapshot(path)
+    assert baseline_mtime is not None
+
+    path.write_text("- user edited during compile\n", encoding="utf-8")
+
+    result = write_generated_hub_page(
+        graph_root,
+        MASTER_INDEX_PAGE_TITLE,
+        "- daemon compiled\n",
+        baseline_mtime=baseline_mtime,
+        robot_commit_summary="test hub write",
+    )
+
+    assert result.written is False
+    assert path.read_text(encoding="utf-8") == "- user edited during compile\n"
+
+
+def test_write_generated_hub_page_occ_abort_at_commit(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = graph_safe_page_path(graph_root, GRAPH_INSIGHTS_TITLE)
+    path.write_text("- stable insights\n", encoding="utf-8")
+    baseline_mtime = occ_snapshot(path)
+    assert baseline_mtime is not None
+
+    monkeypatch.setattr(
+        "src.graph.generated_hub_write.atomic_write_bytes_if_unchanged",
+        lambda *_args, **_kwargs: False,
+    )
+
+    result = write_generated_hub_page(
+        graph_root,
+        GRAPH_INSIGHTS_TITLE,
+        "- refreshed insights\n",
+        baseline_mtime=baseline_mtime,
+        robot_commit_summary="test hub write",
+    )
+
+    assert result.written is False
+    assert path.read_text(encoding="utf-8") == "- stable insights\n"
+
+
+def test_write_master_index_page_skips_on_concurrent_edit(graph_root: Path) -> None:
+    path = master_index_page_path(graph_root)
+    path.write_text("- user hub\n", encoding="utf-8")
+
+    catalog = MasterCatalog(graph_root=graph_root)
+    catalog.upsert(
+        "Alpha",
+        CatalogEntry(summary="Alpha summary", domain="risorsa", last_mtime=1),
+    )
+
+    import src.graph.master_catalog as master_catalog_mod
+
+    original_build = master_catalog_mod.build_master_index_markdown
+
+    def _build_and_touch(catalog: MasterCatalog) -> str:
+        path.write_text("- symbiotic user edit\n", encoding="utf-8")
+        return original_build(catalog)
+
+    master_catalog_mod.build_master_index_markdown = _build_and_touch
+    try:
+        write_master_index_page(graph_root, catalog)
+    finally:
+        master_catalog_mod.build_master_index_markdown = original_build
+
+    assert path.read_text(encoding="utf-8") == "- symbiotic user edit\n"
+
+
+def test_write_graph_insights_page_skips_on_concurrent_edit(graph_root: Path) -> None:
+    path = graph_safe_page_path(graph_root, GRAPH_INSIGHTS_TITLE)
+    path.write_text("- user insights\n", encoding="utf-8")
+    baseline_mtime = occ_snapshot(path)
+    assert baseline_mtime is not None
+
+    path.write_text("- symbiotic edit during compile\n", encoding="utf-8")
+
+    write_graph_insights_page(
+        graph_root,
+        "- daemon insights\n",
+        baseline_mtime=baseline_mtime,
+    )
+
+    assert path.read_text(encoding="utf-8") == "- symbiotic edit during compile\n"
+
+
+def test_write_master_index_page_updates_when_quiet(graph_root: Path) -> None:
+    catalog = MasterCatalog(graph_root=graph_root)
+    catalog.upsert(
+        "Alpha",
+        CatalogEntry(summary="Alpha summary", domain="risorsa", last_mtime=1),
+    )
+
+    write_master_index_page(graph_root, catalog)
+
+    path = master_index_page_path(graph_root)
+    text = path.read_text(encoding="utf-8")
+    assert "Alpha" in text
+    assert "Matryca Master Index" in text


### PR DESCRIPTION
## Summary

- Add `write_generated_hub_page` helper: `page_rmw_lock`, pre-compile `occ_snapshot`, and `atomic_write_bytes_if_unchanged` for Matryca-generated hub pages.
- Wire `write_master_index_page` and `write_graph_insights_page` through the helper; `run_graph_insights_engine` captures baseline before metrics compile.
- On OCC drift or commit abort, writers log a **graceful skip** locally and return without raising (derived pages regenerate on the next bootstrap / Phase 2 cycle).
- Extend `tests/test_hubs.py` with concurrent-edit abort coverage for both hub writers.

Closes #34

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run mypy src/ tests/`
- [x] `uv run pytest tests/test_hubs.py -q`
- [x] `733 passed` full suite (`pytest -q --no-cov`)
