### PR TITLE
Store bootstrap catalog mtimes at nanosecond precision

### DIFF
--- a/src/graph/bootstrap_harvest.py
+++ b/src/graph/bootstrap_harvest.py
@@ -204,7 +204,7 @@ def harvest_page_into_catalog(
         return "missing", True, False
 
     try:
-        mtime = int(page_path.stat().st_mtime)
+        mtime = int(page_path.stat().st_mtime_ns)
     except OSError as exc:
         return f"error:{exc}", False, False
 
@@ -271,7 +271,7 @@ def harvest_page_into_catalog(
         summary=summary_result.summary,
         tags=summary_result.suggested_tags,
         domain=domain,
-        mtime=int(page_path.stat().st_mtime),
+        mtime=int(page_path.stat().st_mtime_ns),
         orphan=orphan,
     )
     catalog.upsert(title, entry)

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -24,6 +24,7 @@ from .path_sandbox import read_graph_file_text
 
 CATALOG_FILENAME = "master_catalog.json"
 CATALOG_VERSION = 1
+LEGACY_SECONDS_MTIME_CUTOFF = 10_000_000_000
 SEMANTIC_INDEX_HEADING = "### Matryca Semantic Index"
 SEMANTIC_INDEX_HEADER = f"- {SEMANTIC_INDEX_HEADING}"
 MASTER_INDEX_PAGE_TITLE = "Matryca Master Index"
@@ -43,6 +44,19 @@ _catalog_mtime_ns: dict[str, int] = {}
 
 class CatalogLoadError(OSError):
     """Raised when ``master_catalog.json`` cannot be read and no safe cache exists."""
+
+
+def normalize_stored_mtime_ns(stored_mtime: int) -> int:
+    """Return ``last_mtime`` as nanoseconds, accepting legacy second values."""
+    if abs(stored_mtime) < LEGACY_SECONDS_MTIME_CUTOFF:
+        return stored_mtime * 1_000_000_000
+    return stored_mtime
+
+
+def _stored_mtime_matches(stored_mtime: int, mtime_ns: int) -> bool:
+    if abs(stored_mtime) < LEGACY_SECONDS_MTIME_CUTOFF:
+        return int(mtime_ns // 1_000_000_000) == stored_mtime
+    return int(mtime_ns) == stored_mtime
 
 
 @dataclass(slots=True)
@@ -221,7 +235,7 @@ class MasterCatalog:
             entry = self.pages.get(page_title)
             if entry is None:
                 return True
-            return int(mtime_ns // 1_000_000_000) != entry.last_mtime
+            return not _stored_mtime_matches(entry.last_mtime, int(mtime_ns))
 
     def prune_missing_pages(self) -> int:
         """Drop catalog rows and alias mappings for deleted markdown files."""
@@ -268,7 +282,11 @@ def _merge_catalog_page_deltas(
     merged = dict(disk_pages)
     for title, entry in pending.items():
         existing = merged.get(title)
-        if existing is None or entry.last_mtime >= existing.last_mtime:
+        entry_mtime_ns = normalize_stored_mtime_ns(entry.last_mtime)
+        existing_mtime_ns = (
+            normalize_stored_mtime_ns(existing.last_mtime) if existing is not None else None
+        )
+        if existing_mtime_ns is None or entry_mtime_ns >= existing_mtime_ns:
             merged[title] = entry
     return merged
 
@@ -453,14 +471,13 @@ def entry_from_page_path(graph_root: Path, page_path: Path) -> CatalogEntry | No
     try:
         content = read_graph_page_text(page_path, graph_root, errors="replace")
         mtime_ns = page_path.stat().st_mtime_ns
-        mtime = int(mtime_ns // 1_000_000_000)
     except OSError:
         return None
 
     extracted = extract_catalog_fields_from_content(content)
     if extracted is None:
         return None
-    extracted.last_mtime = mtime
+    extracted.last_mtime = int(mtime_ns)
     return extracted
 
 
@@ -593,5 +610,6 @@ __all__ = [
     "load_master_catalog",
     "unload_master_catalog",
     "master_index_page_path",
+    "normalize_stored_mtime_ns",
     "write_master_index_page",
 ]

--- a/tests/test_bootstrap_yield.py
+++ b/tests/test_bootstrap_yield.py
@@ -103,6 +103,33 @@ def test_harvest_upserts_catalog_when_semantic_index_append_succeeds(graph_root:
     entry = catalog.get(title)
     assert entry is not None
     assert entry.summary.startswith("Harvested summary for Needs Index")
+    assert entry.last_mtime == page.stat().st_mtime_ns
     assert status == "llm"
     assert changed is True
     assert llm_called is True
+
+
+def test_harvest_regex_path_stores_nanosecond_mtime(graph_root: Path) -> None:
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Indexed.md"
+    page.write_text(
+        f"- type:: risorsa\n{SEMANTIC_INDEX_HEADER}\n- summary:: Indexed summary\n",
+        encoding="utf-8",
+    )
+    title = page_title_from_path(graph_root, page)
+    catalog = load_master_catalog(graph_root)
+
+    status, changed, llm_called = harvest_page_into_catalog(
+        graph_root,
+        catalog,
+        page,
+        llm=None,
+    )
+
+    entry = catalog.get(title)
+    assert entry is not None
+    assert entry.last_mtime == page.stat().st_mtime_ns
+    assert status == "regex"
+    assert changed is True
+    assert llm_called is False

--- a/tests/test_master_catalog.py
+++ b/tests/test_master_catalog.py
@@ -382,6 +382,45 @@ def test_needs_refresh_detects_mtime_drift(graph_root: Path) -> None:
     assert catalog.needs_refresh("Fresh", path.stat().st_mtime_ns) is True
 
 
+def test_needs_refresh_accepts_legacy_second_mtime(graph_root: Path) -> None:
+    path = _write_page(graph_root, "Fresh", _indexed_body())
+    mtime_ns = path.stat().st_mtime_ns
+    catalog = load_master_catalog(graph_root)
+    catalog.upsert(
+        "Fresh",
+        CatalogEntry(
+            summary="Old",
+            domain="",
+            tags=[],
+            last_mtime=int(mtime_ns // 1_000_000_000),
+            orphan=False,
+        ),
+    )
+    assert catalog.needs_refresh("Fresh", mtime_ns) is False
+
+
+def test_needs_refresh_detects_same_second_nanosecond_drift(
+    graph_root: Path,
+) -> None:
+    path = _write_page(graph_root, "Fresh", _indexed_body())
+    mtime_ns = path.stat().st_mtime_ns
+    same_second_drift = mtime_ns - 1 if mtime_ns % 1_000_000_000 else mtime_ns + 1
+    catalog = load_master_catalog(graph_root)
+    catalog.upsert(
+        "Fresh",
+        CatalogEntry(
+            summary="Fresh",
+            domain="",
+            tags=[],
+            last_mtime=mtime_ns,
+            orphan=False,
+        ),
+    )
+    assert same_second_drift // 1_000_000_000 == mtime_ns // 1_000_000_000
+    assert catalog.needs_refresh("Fresh", mtime_ns) is False
+    assert catalog.needs_refresh("Fresh", same_second_drift) is True
+
+
 def test_build_master_index_groups_by_domain_with_collapsed(graph_root: Path) -> None:
     catalog = MasterCatalog(graph_root=graph_root)
     catalog.upsert(
@@ -511,7 +550,7 @@ def test_incremental_refresh_only_touches_stale_pages(graph_root: Path) -> None:
     catalog = load_master_catalog(graph_root, force_reload=True)
     assert catalog.pages["Changed"].summary == "Changed summary."
     assert catalog.pages["Stable"].summary == "Stable summary."
-    assert catalog.pages["Stable"].last_mtime == int(indexed.stat().st_mtime)
+    assert catalog.pages["Stable"].last_mtime == indexed.stat().st_mtime_ns
 
 
 def test_compute_topology_metrics_orphans_and_clusters(graph_root: Path) -> None:


### PR DESCRIPTION
Fixes #89.

`run_bootstrap_harvest()` and `harvest_page_into_catalog()` were still writing `CatalogEntry.last_mtime` from `st_mtime`, so rows produced by bootstrap only had second-level precision. That can disagree with the newer nanosecond mtime checks and miss a page edit that lands inside the same second.

This switches both bootstrap catalog write paths to `st_mtime_ns`. I also updated the catalog refresh comparison to understand both formats: existing catalogs with old second-based values still compare at second precision, while newly-written nanosecond values compare exactly. Merge-on-save now normalizes both formats before deciding which row is newer, so a mixed old/new catalog does not regress ordering.

Checked:
- `python -m py_compile src\graph\bootstrap_harvest.py src\graph\master_catalog.py tests\test_bootstrap_yield.py tests\test_master_catalog.py`
- `python -m ruff check src\graph\bootstrap_harvest.py src\graph\master_catalog.py tests\test_bootstrap_yield.py tests\test_master_catalog.py`
- `python -m ruff format --check src\graph\bootstrap_harvest.py src\graph\master_catalog.py tests\test_bootstrap_yield.py tests\test_master_catalog.py`
- `python -m mypy src\graph\bootstrap_harvest.py src\graph\master_catalog.py`
- `python -m pytest tests\test_bootstrap_yield.py::test_harvest_regex_path_stores_nanosecond_mtime tests\test_bootstrap_yield.py::test_harvest_upserts_catalog_when_semantic_index_append_succeeds tests\test_master_catalog.py::test_needs_refresh_accepts_legacy_second_mtime tests\test_master_catalog.py::test_needs_refresh_detects_same_second_nanosecond_drift tests\test_master_catalog.py::test_incremental_refresh_only_touches_stale_pages -q -o addopts="" --basetemp C:\tmp\matryca-plumber-pytest\run`
- `python -m pytest tests\test_bootstrap_yield.py tests\test_master_catalog.py -q -o addopts="" --basetemp C:\tmp\matryca-plumber-pytest\run -k "not serializes_reads_under_concurrent_save"` -> 28 passed, 1 deselected

One Windows-local note: the full two-file run still fails on `test_load_master_catalog_serializes_reads_under_concurrent_save` because a reader thread can hold `master_catalog.json` while `os.replace()` runs, producing `WinError 5`. I left that alone because it is an existing Windows file-locking behavior outside this mtime fix. A broader `tests` collection on this Windows runner is also blocked by `resource`, which is Unix-only.
