### PR TITLE
Log graceful shutdown save failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
+- **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown.
 
 ## [1.10.6] - 2026-06-19
 

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -2073,14 +2073,18 @@ class MaintenanceDaemon:
         """Flush ledger telemetry and release daemon resources after the loop exits."""
         self._wait_for_inflight_writes()
 
-        with contextlib.suppress(Exception):
+        try:
             load_master_catalog(self.graph_root).save()
+        except OSError:
+            logger.exception("Final master catalog save failed during graceful shutdown")
 
         checkpoint = state or load_daemon_state(self.graph_root)
         checkpoint.status = "stopped"
         self._sync_live_telemetry(checkpoint)
-        with contextlib.suppress(Exception):
+        try:
             save_daemon_state(self.graph_root, checkpoint)
+        except OSError:
+            logger.exception("Final daemon state save failed during graceful shutdown")
 
         self._stop_file_watcher()
         remove_pid_file(self.graph_root)

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -600,6 +600,45 @@ def test_stop_daemon_removes_stale_pid(graph_root: Path) -> None:
     assert stop_out["code"] == "stale_pid_removed"
 
 
+def test_graceful_shutdown_logs_final_save_errors(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingCatalog:
+        def save(self) -> None:
+            raise OSError("catalog unavailable")
+
+    logged: list[str] = []
+
+    def fail_save_daemon_state(_graph_root: Path, _state: DaemonState) -> None:
+        raise OSError("state unavailable")
+
+    def capture_exception(message: str, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        logged.append(message)
+
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.load_master_catalog",
+        lambda _graph_root: FailingCatalog(),
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.save_daemon_state",
+        fail_save_daemon_state,
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.logger.exception",
+        capture_exception,
+    )
+
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+    daemon._finalize_graceful_shutdown(DaemonState())
+
+    assert logged == [
+        "Final master catalog save failed during graceful shutdown",
+        "Final daemon state save failed during graceful shutdown",
+    ]
+
+
 def test_collect_snapshot_reports_metrics(graph_root: Path) -> None:
     _write_page(graph_root, "Snap", "- snap\n")
     snap = collect_snapshot(


### PR DESCRIPTION
## Summary
- Replace the final catalog/state `contextlib.suppress(Exception)` blocks in graceful shutdown with explicit `except OSError` handling.
- Log the failure paths with `logger.exception(...)`, which is loguru's error-level helper for including the active exception stack.
- Add regression coverage and an Unreleased changelog entry for #44.

## Verification
- `uv run pytest tests/test_maintenance_daemon.py::test_graceful_shutdown_logs_final_save_errors -q --no-cov`
- `uv run pytest tests/test_maintenance_daemon.py -q --no-cov`
- `uv run ruff check src/agent/maintenance_daemon.py tests/test_maintenance_daemon.py`
- `uv run ruff format --check src/agent/maintenance_daemon.py tests/test_maintenance_daemon.py`
- `uv run python -m compileall -q src tests/test_maintenance_daemon.py`
- `make check`

Closes #44
