### PR TITLE
fix: log token shutdown write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
+- **Daemon shutdown (#101):** SIGTERM/SIGINT token-log shutdown breadcrumb failures now emit exception details instead of being silently suppressed.
 
 ### Changed
 

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -2039,8 +2039,10 @@ class MaintenanceDaemon:
         self._stop_requested = True
         self._shutdown_event.set()
 
-        with contextlib.suppress(Exception):
+        try:
             self.token_logger.log_daemon_shutdown(signum)
+        except OSError:
+            logger.exception("Daemon shutdown token log failed during graceful shutdown")
 
     def _begin_phase2_write(self) -> None:
         with self._inflight_writes:

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -639,6 +639,34 @@ def test_graceful_shutdown_logs_final_save_errors(
     ]
 
 
+def test_daemon_signal_handler_logs_token_shutdown_errors(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: list[str] = []
+
+    def fail_log_daemon_shutdown(_signum: int) -> None:
+        raise OSError("ops log unavailable")
+
+    def capture_exception(message: str, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+        logged.append(message)
+
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+    monkeypatch.setattr(daemon.token_logger, "log_daemon_shutdown", fail_log_daemon_shutdown)
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.logger.exception",
+        capture_exception,
+    )
+
+    daemon._handle_daemon_graceful_shutdown(15, None)
+
+    assert daemon._shutdown_in_progress is True
+    assert daemon._stop_requested is True
+    assert daemon._shutdown_event.is_set() is True
+    assert logged == ["Daemon shutdown token log failed during graceful shutdown"]
+
+
 def test_collect_snapshot_reports_metrics(graph_root: Path) -> None:
     _write_page(graph_root, "Snap", "- snap\n")
     snap = collect_snapshot(


### PR DESCRIPTION
## Summary

- Replace the daemon SIGTERM/SIGINT token shutdown breadcrumb `suppress(Exception)` with explicit `OSError` logging.
- Add regression coverage for token logger write failures during the daemon signal handler path.
- Document the shutdown observability fix in `CHANGELOG.md`.

## Test plan

- [x] `make check` passes locally (772 passed, 2 skipped; coverage 80.60%)
- [x] `uv run pytest tests/test_maintenance_daemon.py -q --no-cov` passes locally (78 passed)
- [x] `git diff --check`
- [x] OCC / CRLF: no graph write path changed
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] CLI/MCP/env sync: not applicable

Note: `uv run pytest tests/test_maintenance_daemon.py -q` ran all 78 tests successfully but exited on the repo-wide coverage fail-under because partial runs inherit `--cov=src --cov-fail-under=70`; the full `make check` gate passes with 80.60% total coverage.

## Issue linking

Closes #101
