### PR TITLE
fix: log tui dashboard refresh failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
+- **TUI dashboard (#102):** Token activity tail and daemon state refresh I/O failures now log exception details while preserving the existing fallback UI.
 
 ### Changed
 

--- a/src/cli/tui_dashboard.py
+++ b/src/cli/tui_dashboard.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
+from loguru import logger as loguru_logger
 
 from ..agent.control_room_progress import resolve_control_room_progress
 from ..agent.maintenance_daemon import (
@@ -177,8 +178,10 @@ def collect_snapshot(
         last_file = Path(state.last_file).name
 
     activity_lines: list[str] = []
-    with contextlib.suppress(Exception):
+    try:
         activity_lines = logger.tail_activity_summaries(5)
+    except OSError:
+        loguru_logger.exception("TUI dashboard failed to load token activity summaries")
 
     control_room = resolve_control_room_progress(state)
 
@@ -231,8 +234,10 @@ def collect_snapshot_safe(
         ), last_good_state
 
     if root is not None:
-        with contextlib.suppress(Exception):
+        try:
             last_good_state = load_daemon_state(root)
+        except OSError:
+            loguru_logger.exception("TUI dashboard failed to refresh last good daemon state")
     return snapshot, last_good_state
 
 

--- a/tests/test_tui_dashboard.py
+++ b/tests/test_tui_dashboard.py
@@ -68,6 +68,24 @@ def test_collect_snapshot_activity_feed_updates_when_log_appends(graph_root: Pat
     assert second.activity_lines != first.activity_lines
 
 
+def test_collect_snapshot_logs_activity_tail_failures(graph_root: Path) -> None:
+    _write_page(graph_root, "Snap", "- snap\n")
+    logger = TokenLogger(log_path=graph_root / "ops.log")
+
+    with (
+        patch.object(
+            logger,
+            "tail_activity_summaries",
+            side_effect=OSError("ops log unavailable"),
+        ),
+        patch("src.cli.tui_dashboard.loguru_logger.exception") as logged,
+    ):
+        snap = collect_snapshot(graph_root=graph_root, token_logger=logger)
+
+    assert snap.activity_lines == []
+    logged.assert_called_once_with("TUI dashboard failed to load token activity summaries")
+
+
 def test_collect_snapshot_uses_checkpoint_processed_count_despite_mtime_drift(
     graph_root: Path,
 ) -> None:
@@ -161,9 +179,12 @@ def test_collect_snapshot_safe_falls_back_to_last_good_state_on_read_failure(
     assert first.session_prompt_tokens == 42
     assert cached_state is not None
 
-    with patch(
-        "src.cli.tui_dashboard.load_daemon_state",
-        side_effect=OSError("state file busy"),
+    with (
+        patch(
+            "src.cli.tui_dashboard.load_daemon_state",
+            side_effect=OSError("state file busy"),
+        ),
+        patch("src.cli.tui_dashboard.loguru_logger.exception") as logged,
     ):
         second, still_cached = collect_snapshot_safe(
             graph_root=graph_root,
@@ -173,3 +194,4 @@ def test_collect_snapshot_safe_falls_back_to_last_good_state_on_read_failure(
 
     assert second.session_prompt_tokens == 42
     assert still_cached is cached_state
+    logged.assert_called_once_with("TUI dashboard failed to refresh last good daemon state")


### PR DESCRIPTION
## Summary

- Replace the TUI dashboard's two broad `suppress(Exception)` blocks with explicit `OSError` logging.
- Preserve existing fallback behavior for empty activity lines and cached daemon state.
- Add focused regression tests for token activity tail failures and last-good daemon state refresh failures.
- Document the observability fix in `CHANGELOG.md`.

## Test plan

- [x] `make check` passes locally (772 passed, 2 skipped; coverage 80.59%)
- [x] `uv run pytest tests/test_tui_dashboard.py -q --no-cov` passes locally (8 passed)
- [x] `git diff --check`
- [x] OCC / CRLF: no graph write path changed
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] CLI/MCP/env sync: not applicable

Note: `uv run pytest tests/test_tui_dashboard.py -q` ran all 8 tests successfully but exited on the repo-wide coverage fail-under because partial runs inherit `--cov=src --cov-fail-under=70`; the full `make check` gate passes with 80.59% total coverage.

## Issue linking

Closes #102
