### PR TITLE
fix: store catalog sync mtimes in nanoseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
+- **Catalog sync (#103):** Phase-2 post-write catalog updates now persist page mtimes with nanosecond precision.
 
 ### Changed
 

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -2306,7 +2306,7 @@ class MaintenanceDaemon:
         """Upsert catalog row from on-disk semantic index immediately after a page write."""
         try:
             new_text = read_graph_file_text(path, self.graph_root, errors="replace")
-            mtime = int(path.stat().st_mtime)
+            mtime = path.stat().st_mtime_ns
         except OSError as exc:
             self.token_logger.log_structural_lint_warning(
                 target_file=path,

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -1352,6 +1352,22 @@ def test_run_cycle_prunes_deleted_pages_from_catalog(graph_root: Path) -> None:
     _ = live
 
 
+def test_sync_catalog_after_page_write_stores_nanosecond_mtime(graph_root: Path) -> None:
+    path = _write_page(
+        graph_root,
+        "PrecisePage",
+        f"- type:: risorsa\n- body\n\n{SEMANTIC_INDEX_HEADER}\n- summary:: precise\n",
+    )
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+
+    daemon._sync_catalog_after_page_write(path, "PrecisePage")
+
+    reloaded = load_master_catalog(graph_root, force_reload=True)
+    stored_mtime = reloaded.pages["PrecisePage"].last_mtime
+    assert stored_mtime == path.stat().st_mtime_ns
+    assert stored_mtime != int(path.stat().st_mtime)
+
+
 def test_bootstrap_pipeline_sets_complete_only_after_master_index(
     graph_root: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Store `_sync_catalog_after_page_write` catalog mtimes using `st_mtime_ns`.
- Add regression coverage that verifies post-write catalog sync persists nanosecond mtimes.
- Document the catalog precision fix in `CHANGELOG.md`.

## Test plan

- [x] `make check` passes locally (772 passed, 2 skipped; coverage 80.61%)
- [x] `uv run pytest tests/test_maintenance_daemon.py tests/test_master_catalog.py -q --no-cov` passes locally (103 passed)
- [x] `git diff --check`
- [x] OCC / CRLF: no page write content path changed
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] CLI/MCP/env sync: not applicable

Note: `uv run pytest tests/test_maintenance_daemon.py tests/test_master_catalog.py -q` ran all 103 tests successfully but exited on the repo-wide coverage fail-under because partial runs inherit `--cov=src --cov-fail-under=70`; the full `make check` gate passes with 80.61% total coverage.

## Issue linking

Closes #103
