### PR TITLE
fix: flock semantic cluster cache loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
+- **Semantic clusters (#104):** Cluster cache loads now read `semantic_clusters.json` under the shared JSON flock.
 
 ### Changed
 

--- a/src/graph/semantic_clustering.py
+++ b/src/graph/semantic_clustering.py
@@ -564,9 +564,10 @@ def load_semantic_clusters(graph_root: Path) -> dict[str, list[str]] | None:
     if not path.is_file():
         return None
     try:
-        payload = read_bounded_json(path)
-    except BoundedJsonError as exc:
-        logger.warning("Ignoring corrupt semantic cluster cache at {}: {}", path, exc)
+        with cross_process_json_flock(path):
+            payload = read_bounded_json(path)
+    except (BoundedJsonError, OSError) as exc:
+        logger.warning("Ignoring unreadable semantic cluster cache at {}: {}", path, exc)
         return None
     if not isinstance(payload, dict):
         return None

--- a/tests/test_semantic_clustering.py
+++ b/tests/test_semantic_clustering.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from types import TracebackType
 
+import pytest
 from src.graph.master_catalog import clear_master_catalog_cache
 from src.graph.semantic_clustering import (
     DEFAULT_MAX_CLUSTER_SIZE,
@@ -96,6 +98,41 @@ def test_save_and_load_semantic_clusters(tmp_path: Path) -> None:
     assert payload["clusters"]["cluster_001"] == ["Alpha", "Beta"]
     loaded = load_semantic_clusters(tmp_path)
     assert loaded == clusters
+
+
+def test_load_semantic_clusters_uses_json_flock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_master_catalog_cache(tmp_path)
+    clusters = {"cluster_001": ["Alpha", "Beta"]}
+    save_semantic_clusters(tmp_path, clusters)
+    locked_paths: list[Path] = []
+
+    class RecordingFlock:
+        def __init__(self, path: Path) -> None:
+            locked_paths.append(path)
+
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
+            _ = (exc_type, exc, traceback)
+
+    monkeypatch.setattr(
+        "src.graph.semantic_clustering.cross_process_json_flock",
+        RecordingFlock,
+    )
+
+    loaded = load_semantic_clusters(tmp_path)
+
+    assert loaded == clusters
+    assert locked_paths == [semantic_clusters_path(tmp_path)]
 
 
 def test_load_or_compute_semantic_clusters_uses_cache(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Read `semantic_clusters.json` under `cross_process_json_flock`, matching the existing write path.
- Treat bounded JSON and lock/read I/O failures as an unreadable cache so callers can recompute instead of racing on partial reads.
- Add regression coverage proving `load_semantic_clusters` enters the JSON flock.
- Document the concurrency fix in `CHANGELOG.md`.

## Test plan

- [x] `make check` passes locally (772 passed, 2 skipped; coverage 80.58%)
- [x] `uv run pytest tests/test_semantic_clustering.py -q --no-cov` passes locally (13 passed)
- [x] `git diff --check`
- [x] OCC / CRLF: no page write path changed
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] CLI/MCP/env sync: not applicable

Note: `uv run pytest tests/test_semantic_clustering.py -q` ran all 13 tests successfully but exited on the repo-wide coverage fail-under because partial runs inherit `--cov=src --cov-fail-under=70`; the full `make check` gate passes with 80.58% total coverage.

## Issue linking

Closes #104
