### PR TITLE
test: assert shutdown cleanup after save failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Contributor onboarding:** Five new good-first issues ([#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101)–[#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105)) plus promoted [#38](https://github.com/MarcoPorcellato/matryca-plumber/issues/38); shipped #44 closed via #100 — see [`good_first_issues_blueprints.md`](good_first_issues_blueprints.md).
+- **Test coverage (#105):** Graceful shutdown tests now assert cleanup still runs after final catalog/state save failures.
 
 ## [1.10.6] - 2026-06-19
 

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -639,6 +639,49 @@ def test_graceful_shutdown_logs_final_save_errors(
     ]
 
 
+def test_graceful_shutdown_cleanup_runs_after_final_save_errors(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingCatalog:
+        def save(self) -> None:
+            raise OSError("catalog unavailable")
+
+    stopped_watchers: list[bool] = []
+
+    def fail_save_daemon_state(_graph_root: Path, _state: DaemonState) -> None:
+        raise OSError("state unavailable")
+
+    def capture_exception(_message: str, *args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    def stop_file_watcher() -> None:
+        stopped_watchers.append(True)
+
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.load_master_catalog",
+        lambda _graph_root: FailingCatalog(),
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.save_daemon_state",
+        fail_save_daemon_state,
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.logger.exception",
+        capture_exception,
+    )
+
+    write_pid_file(graph_root)
+    assert read_pid_file(graph_root) is not None
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+    monkeypatch.setattr(daemon, "_stop_file_watcher", stop_file_watcher)
+
+    daemon._finalize_graceful_shutdown(DaemonState())
+
+    assert stopped_watchers == [True]
+    assert read_pid_file(graph_root) is None
+
+
 def test_collect_snapshot_reports_metrics(graph_root: Path) -> None:
     _write_page(graph_root, "Snap", "- snap\n")
     snap = collect_snapshot(


### PR DESCRIPTION
## Summary

- Add regression coverage proving graceful shutdown cleanup still runs after final catalog and daemon state save failures.
- Assert both watcher cleanup and PID file removal happen after the failing-save path.
- Document the test coverage addition in `CHANGELOG.md`.

## Test plan

- [x] `make check` passes locally (772 passed, 2 skipped; coverage 80.60%)
- [x] `uv run pytest tests/test_maintenance_daemon.py -q --no-cov` passes locally (78 passed)
- [x] `git diff --check`
- [x] OCC / CRLF: no production or graph write path changed
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] CLI/MCP/env sync: not applicable

Note: `uv run pytest tests/test_maintenance_daemon.py -q` ran all 78 tests successfully but exited on the repo-wide coverage fail-under because partial runs inherit `--cov=src --cov-fail-under=70`; the full `make check` gate passes with 80.60% total coverage.

## Issue linking

Closes #105
