### PR TITLE
docs(quality): dev audit bug registry (#113–#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Docs** — GitNexus bug hunt registry: [`docs/quality/BUG_HUNT_2026-06-23.md`](docs/quality/BUG_HUNT_2026-06-23.md) + GitHub backlog [`docs/quality/GITHUB_BUG_BACKLOG.md`](docs/quality/GITHUB_BUG_BACKLOG.md); filed **#113–#119** on GitHub.
 - **Contributor onboarding:** Five new good-first issues ([#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101)–[#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105)) plus promoted [#38](https://github.com/MarcoPorcellato/matryca-plumber/issues/38); shipped #44 closed via #100 — see [`good_first_issues_blueprints.md`](good_first_issues_blueprints.md).
 
 ## [1.10.6] - 2026-06-19

--- a/docs/PROJECT_DIARY.md
+++ b/docs/PROJECT_DIARY.md
@@ -10,6 +10,21 @@ Entries are chronological (**newest first** within each major release block). Wh
 
 ---
 
+## [2026-06-23] Unreleased — GitNexus bug hunt & quality audit
+
+### Context
+
+Systematic bug hunt using GitNexus graph analysis (`check`, `query`, `clusters`, `detect_changes`) cross-checked with runtime gates (pytest, ruff, mypy strict).
+
+### Findings & actions
+
+1. **Flaky test fixed** — `test_compute_semantic_clusters_scales_to_three_thousand_pages` failed intermittently under full-suite load (9.09s vs 8s ceiling); moved to `tests/slow/` with `@pytest.mark.slow` and 15s ceiling. Full report: [`docs/quality/BUG_HUNT_2026-06-23.md`](quality/BUG_HUNT_2026-06-23.md).
+2. **Import cycle resolved (P2)** — `alias_index` ↔ `generational_cache` broken via DI: `is_journal_page_title_in_index(AliasIndex)` in domain; cached facade in `generational_cache`. Runtime verified: `alias_index` loads without pulling `generational_cache`.
+3. **Import cycles remaining** — GitNexus still reports 3 other cycles (control_room TYPE_CHECKING, html false positive, plumber_config lazy); `maintenance_daemon` (3283 LOC) deferred.
+4. **GitHub backlog** — 49 open issues triaged; **#113–#119 filed** from GitNexus hunt — see [`docs/quality/GITHUB_BUG_BACKLOG.md`](quality/GITHUB_BUG_BACKLOG.md).
+
+---
+
 ## [2026-06-19] v1.10.6 — Concurrency integrity (unified flock + hub page OCC)
 
 ### Context

--- a/docs/quality/BUG_HUNT_2026-06-23.md
+++ b/docs/quality/BUG_HUNT_2026-06-23.md
@@ -1,0 +1,198 @@
+# Bug Hunt — Matryca Plumber (2026-06-23)
+
+**Metodologia:** evidenza runtime (pytest, benchmark, ruff, mypy) + analisi strutturale GitNexus  
+**Framework qualità:** [Clean Code](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) / Clean Architecture (Robert C. Martin) — SRP, DIP, confini espliciti, test deterministici  
+**Indice GitNexus:** `matryca-plumber` — 371 file, 5356 simboli, 300 processi (aggiornato 2026-06-23)
+
+---
+
+## Executive summary
+
+| Area | Esito | Severità |
+|------|-------|----------|
+| Test suite (874 test) | 1 fallimento intermittente → **corretto** | P1 |
+| Ruff + Mypy strict | Pulito | — |
+| Coverage `src/` | 81.12% (gate 70%) | — |
+| Cicli di import (GitNexus `check`) | 4 rilevati; 2 mitigati, 1 accettabile, 1 falso positivo | P2 |
+| Taint PDG (`explain`) | Layer non indicizzato (`analyze --pdg`) | Info |
+| God module `maintenance_daemon.py` | 3283 LOC — debito architetturale | P3 |
+| `except Exception` ampi | 5 siti — 2 rischiosi, 3 intenzionali (resilienza UI) | P2 |
+
+---
+
+## 1. Bug confermato: test flaky di performance
+
+### Sintomo (evidenza runtime)
+
+```
+FAILED tests/test_semantic_clustering.py::test_compute_semantic_clusters_scales_to_three_thousand_pages
+AssertionError: clustering took 9.09s, expected under 8 seconds in CI
+```
+
+Suite completa: **873 passed, 1 failed** (prima esecuzione).  
+Stesso test isolato: **20/20 pass** in ~1.7–3.5s ciascuno.
+
+### Ipotesi e verifica
+
+| ID | Ipotesi | Esito | Evidenza |
+|----|---------|-------|----------|
+| H1 | Regressione algoritmica Louvain/TF-IDF | **REJECTED** | Benchmark diretto: 1.3–3.4s su 10 run (`python3 -c …`) |
+| H2 | Soglia 8s troppo stretta sotto carico CI | **CONFIRMED** | Fallimento a 9.09s con suite completa; isolato sempre <4s |
+| H3 | Corruzione dati cluster | **REJECTED** | Asserzioni strutturali (3000 titoli unici, size bounds) passano quando non scade il timer |
+| H4 | Race pytest-xdist | **INCONCLUSIVE** | Primo fail con `pytest -q` senza `-n`; possibile contributo CPU/GC |
+
+### Violazione Clean Code / Clean Architecture
+
+- **Single Responsibility (test):** un unico test misura correttezza *e* performance con soglia assoluta non deterministica.
+- **Boundaries:** test di regressione performance appartengono al layer `tests/slow/` (già usato da `make perf`), non al gate strutturale default.
+
+### Remediation applicata
+
+- Spostato in [`tests/slow/test_semantic_clustering_scale.py`](../../tests/slow/test_semantic_clustering_scale.py)
+- Marcato `@pytest.mark.slow`
+- Soglia alzata a **15s** (cattura regressioni >5× mantenendo margine sotto carico macchina)
+- `make test-fast` già esclude `tests/slow/`; `make perf` esegue esplicitamente i test lenti
+
+---
+
+## 2. Analisi GitNexus — cicli di import
+
+Comando: `gitnexus check --cycles` → **4 cicli**.
+
+### 2.1 ~~`alias_index.py` ↔ `generational_cache.py`~~ (risolto 2026-06-23)
+
+**Prima:** ciclo runtime — `generational_cache` importava `alias_index` a module load; `is_journal_page_title()` in `alias_index` importava lazy `cached_build_alias_index`.
+
+**Dopo (Clean Architecture / DI):**
+
+| Layer | Modulo | Responsabilità |
+|-------|--------|----------------|
+| Domain | `alias_index.py` | `is_journal_page_title_in_index(idx: AliasIndex, title)` — pura, zero cache |
+| Infrastructure | `generational_cache.py` | `is_journal_page_title(graph_root, title)` — facade con cache mtime |
+| Use case | `entity_consolidation.py` | `cached_build_alias_index()` una volta per run → `should_skip_entity_overlap_pair(..., alias_index=idx)` |
+
+Verifica runtime: `import src.graph.alias_index` non carica `generational_cache`.
+
+### 2.2 `plumber_config.py` ↔ `llm_url_policy.py` (reale, mitigato)
+
+- Lazy import in `assert_safe_lm_proxy_url()` L139.
+- **Accettabile:** policy layer (`utils`) non deve importare agent a module load; il lazy import preserva acyclicity al bootstrap.
+
+### 2.3 `control_room_progress.py` ↔ `maintenance_daemon.py` (falso positivo strutturale)
+
+- `TYPE_CHECKING` per `DaemonState`; `refresh_phase2_cognitive_totals` importa `compute_phase2_progress_metrics` solo a runtime.
+- **Pattern Uncle Bob:** inversione dipendenza parziale — il modulo progress è un adapter sottile; refactor futuro: port/interface `Phase2MetricsProvider`.
+
+### 2.4 `html.py` self-cycle (falso positivo GitNexus)
+
+- Nessun import circolare runtime; probabile artefatto indexer su modulo foglia Tana.
+
+---
+
+## 3. GitNexus — cluster e coesione moduli
+
+| Modulo | Simboli | Coesione | Nota Clean Architecture |
+|--------|---------|----------|---------------------------|
+| Daemon | 136 | **87%** | Confine runtime ben definito |
+| Semantic | 55 | 79% | Use case Phase 2 isolato |
+| Agent | 410 | 64% | `maintenance_daemon` diluisce coesione |
+| Graph | 431 | 61% | Core domain — accettabile per vault I/O |
+| Tests | 1012 | 61% | — |
+
+**Processi critici (query GitNexus):**
+
+- Concurrency: `page_rmw_lock` → `run_auto_split` → `PageLockUnavailableError`
+- Security: `validate_logseq_graph_path` → `PathTraversalSecurityError` (test adversarial presenti)
+- Error surface MCP: `format_tool_error` / `guard_mcp_tool`
+
+---
+
+## 4. Gestione errori — audit `except Exception`
+
+| File | Contesto | Valutazione |
+|------|----------|-------------|
+| `graph_analytics.py:123` | `_count_catalog_summaries` → ritorna 0 | **P2:** maschera errori catalogo corrotti; preferire `BoundedJsonError`, `OSError` espliciti + log |
+| `tui_dashboard.py:93,119,129` | Fallback TUI su parse/metrics | **OK:** boundary presentation — non crashare la dashboard |
+| `importers/tana/html.py:39` | Fallback strip tag HTML malformato | **OK:** degradazione graceful con fallback regex |
+
+**Principio:** *fail fast* nel dominio (`graph/`), *resilienza* ai confini (`cli/`, `tui`).
+
+---
+
+## 5. Debito architetturale (SRP / dimensione moduli)
+
+| Modulo | LOC | Responsabilità mescolate (SRP) |
+|--------|-----|--------------------------------|
+| `maintenance_daemon.py` | **3283** | bootstrap, Phase 1/2, harvest, checkpoint, journey log, thermal, flock |
+| `graph_dispatch.py` | 1268 | read/write MCP/CLI headless |
+| `llm_client.py` | 1110 | transport, adaptive schema, retry |
+
+**Raccomandazione (Uncle Bob — scream architecture):**
+
+1. Estrarre `MaintenanceDaemon` in use case package: `daemon/bootstrap/`, `daemon/phase1/`, `daemon/phase2/`, `daemon/persistence/`.
+2. `graph_dispatch` resta **Interface Adapter** — già allineato al pattern ports/adapters.
+3. Non refactor massivo in un unico PR; usare GitNexus `impact()` prima di ogni estrazione.
+
+---
+
+## 6. Sicurezza
+
+- **GitNexus `explain`:** 0 finding — layer PDG non presente. Per audit taint: `./scripts/gitnexus-analyze-embeddings.sh` + `gitnexus analyze --pdg`.
+- **Test adversarial:** `tests/test_adversarial_security.py`, `tests/test_security_remediation.py` — path traversal, symlink, SSRF LLM URL.
+- **Sandbox:** `path_sandbox.py`, `graph_path_validate.py` — confine esplicito (Clean Architecture: policy al bordo).
+
+---
+
+## 7. Static analysis gate
+
+```bash
+uv run ruff check src tests   # All checks passed
+uv run mypy src tests         # Success: 254 source files
+uv run pytest -q              # 874 passed (post-fix), 81.12% coverage
+```
+
+---
+
+## 8. Backlog prioritizzato
+
+| Priorità | Item | Tipo | Effort |
+|----------|------|------|--------|
+| P1 | ~~Test flaky semantic clustering~~ | Bug | **Done** |
+| P2 | ~~Ciclo `alias_index` ↔ `generational_cache`~~ | Architettura | **Done** — [#71](https://github.com/MarcoPorcellato/matryca-plumber/issues/71) comment |
+| P2 | `_count_catalog_summaries` silent swallow | Bug | S → [#113](https://github.com/MarcoPorcellato/matryca-plumber/issues/113) |
+| P2–P3 | GitNexus hunt follow-ups | Varie | → [#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114)–[#119](https://github.com/MarcoPorcellato/matryca-plumber/issues/119) |
+| P3 | Estrarre sotto-moduli da `maintenance_daemon.py` | Architettura | L → [#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58) |
+
+---
+
+## 9. Comandi GitNexus usati in questa sessione
+
+```text
+gitnexus://repo/matryca-plumber/context
+list_repos
+check (cycles)
+query — concurrency, security, error handling
+detect_changes — working tree docs-only, risk low
+explain — taint layer absent
+clusters — cohesion scores
+```
+
+Re-index con embeddings (repo locale):
+
+```bash
+./scripts/gitnexus-analyze-embeddings.sh
+```
+
+---
+
+## 10. Riferimenti
+
+- [`docs/quality/GITHUB_BUG_BACKLOG.md`](GITHUB_BUG_BACKLOG.md) — registro GitHub-ready (#106–#112 proposti + mappa #38–#105)
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) — confini daemon / MCP / UI
+- [`docs/openspec/security-sandbox.md`](../openspec/security-sandbox.md)
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — `make test-fast` vs `make test-full` vs `make perf`
+- GitNexus skills: `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md`
+
+---
+
+*Prossima revisione consigliata: dopo ogni release minor o refactor di `maintenance_daemon`.*

--- a/docs/quality/GITHUB_BUG_BACKLOG.md
+++ b/docs/quality/GITHUB_BUG_BACKLOG.md
@@ -1,0 +1,136 @@
+# GitHub Bug Backlog — Matryca Plumber
+
+**Hunt date:** 2026-06-23  
+**Tools:** GitNexus (`check`, `query`, `clusters`, `detect_changes`, `explain`, `cypher`) + `pytest` (874 passed), `ruff`, `mypy --strict`  
+**Companion:** [`BUG_HUNT_2026-06-23.md`](BUG_HUNT_2026-06-23.md)
+
+This document is the **maintainer-ready registry** for filing or triaging GitHub issues. It deduplicates against the **42 open issues** on `MarcoPorcellato/matryca-plumber` as of this hunt.
+
+---
+
+## Hunt verdict
+
+| Gate | Result |
+|------|--------|
+| `pytest -q` | **874 passed**, 2 skipped |
+| Coverage `src/` | **81.13%** (gate 70%) |
+| Ruff | Clean |
+| Mypy strict | Clean |
+| Runtime regressions found | **0** (no failing tests) |
+| Confirmed code defects / debt | **Yes** — mostly observability, concurrency precision, performance, architecture |
+
+**Conclusion:** The codebase is **test-green** but not **bug-free**. Most actionable work already lives in GitHub **#38–#105** (v1.9.x audit). GitNexus hunt filed **#113–#119** on GitHub (2026-06-23); records **2 fixes already merged locally**.
+
+---
+
+## Fixed locally (do not re-file)
+
+| Item | Resolution | Evidence |
+|------|------------|----------|
+| Flaky semantic clustering perf test | Moved to `tests/slow/`, `@pytest.mark.slow`, 15s ceiling | Intermittent 9.09s fail under full suite |
+| `alias_index` ↔ `generational_cache` import cycle | DI: `is_journal_page_title_in_index` in domain; cached facade in `generational_cache` | `import src.graph.alias_index` does not load `generational_cache` |
+
+**Follow-up for #71:** Partially addressed — journal detection now has a pure domain API + injected `AliasIndex`. Consider commenting on [#71](https://github.com/MarcoPorcellato/matryca-plumber/issues/71) when closing the import-cycle slice.
+
+**Follow-up for GitNexus:** Re-run `./scripts/gitnexus-analyze-embeddings.sh` so `check --cycles` drops the stale `alias_index` edge.
+
+---
+
+## Existing open issues — priority map
+
+### P0 — Concurrency / data integrity (file first)
+
+| Issue | Title | Location (verified) |
+|-------|-------|---------------------|
+| [#38](https://github.com/MarcoPorcellato/matryca-plumber/issues/38) | `needs_refresh` truncated seconds vs OCC nanoseconds | `master_catalog.py` |
+| [#39](https://github.com/MarcoPorcellato/matryca-plumber/issues/39) | `auto_split` child pages without child path lock | `auto_split.py` |
+| [#42](https://github.com/MarcoPorcellato/matryca-plumber/issues/42) | Semantic cache purge / cluster load without flock | `semantic_clustering.py` |
+| [#43](https://github.com/MarcoPorcellato/matryca-plumber/issues/43) | Race seeding `matryca-config.md` in `store_fact` | `memory_tools.py` / dispatch |
+| [#103](https://github.com/MarcoPorcellato/matryca-plumber/issues/103) | `_sync_catalog_after_page_write` second-precision mtime | `maintenance_daemon.py:2309` — `int(path.stat().st_mtime)` |
+| [#104](https://github.com/MarcoPorcellato/matryca-plumber/issues/104) | `load_semantic_clusters` without `cross_process_json_flock` | `semantic_clustering.py:561-570` |
+
+### P1 — Observability / silent failure
+
+| Issue | Title | Location (verified) |
+|-------|-------|---------------------|
+| [#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101) | SIG handler suppresses `token_logger` shutdown | `maintenance_daemon.py:2042` — `contextlib.suppress(Exception)` |
+| [#102](https://github.com/MarcoPorcellato/matryca-plumber/issues/102) | TUI suppresses activity / state load failures | `tui_dashboard.py:93,119,129,225` |
+| [#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105) | Test: shutdown cleanup after save failures | test gap |
+
+### P2 — Performance (v1.9.x audit #20–#30)
+
+| Issue | Title |
+|-------|-------|
+| [#46](https://github.com/MarcoPorcellato/matryca-plumber/issues/46)–[#56](https://github.com/MarcoPorcellato/matryca-plumber/issues/56) | AST cache, catalog reload, daemon state saves, vault scans, mmap copy, Phase-2 double-read, backlink cache, etc. |
+| [#69](https://github.com/MarcoPorcellato/matryca-plumber/issues/69) | Skip cluster-focus for single-page clusters |
+
+### P3 — Tech debt / v2.0
+
+| Issue | Title |
+|-------|-------|
+| [#57](https://github.com/MarcoPorcellato/matryca-plumber/issues/57)–[#64](https://github.com/MarcoPorcellato/matryca-plumber/issues/64) | env parser DRY, mega-modules, parser coupling |
+| [#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58) | `maintenance_daemon.py` ~3283 LOC |
+| [#59](https://github.com/MarcoPorcellato/matryca-plumber/issues/59) | `graph_dispatch.py` handler registry |
+| [#71](https://github.com/MarcoPorcellato/matryca-plumber/issues/71) | Centralize journal page detection |
+| [#73](https://github.com/MarcoPorcellato/matryca-plumber/issues/73) | Soak tests for daemon memory |
+| [#99](https://github.com/MarcoPorcellato/matryca-plumber/issues/99) | Biological memory epic |
+
+---
+
+## NEW — Filed on GitHub (#113–#119, 2026-06-23)
+
+| Issue | Title | Milestone |
+|-------|-------|-----------|
+| [#113](https://github.com/MarcoPorcellato/matryca-plumber/issues/113) | `_count_catalog_summaries` swallows exceptions | v1.9.12 |
+| [#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114) | Graph Insights LLM silent fallback | v1.9.12 |
+| [#115](https://github.com/MarcoPorcellato/matryca-plumber/issues/115) | `memory/config` layer inversion (blocks #99) | v2.0.0 |
+| [#116](https://github.com/MarcoPorcellato/matryca-plumber/issues/116) | `plumber_config` ↔ `llm_url_policy` cycle | v1.9.12 |
+| [#117](https://github.com/MarcoPorcellato/matryca-plumber/issues/117) | `control_room_progress` ↔ `maintenance_daemon` | v1.9.12 |
+| [#118](https://github.com/MarcoPorcellato/matryca-plumber/issues/118) | httpx2 / Starlette deprecation in CI | v1.9.12 |
+| [#119](https://github.com/MarcoPorcellato/matryca-plumber/issues/119) | GitNexus PDG + `check --cycles` in CI | v1.9.12 |
+
+Issue bodies (maintainer template): `docs/quality/issue-bodies/10{6..2}-*.md`
+
+---
+
+## Archive — draft bodies
+
+_Superseded by #113–#119. Maintainer templates: `docs/quality/issue-bodies/106-*.md` … `112-*.md`._
+
+---
+
+## GitNexus structural findings (reference)
+
+| Finding | Status | GitHub |
+|---------|--------|--------|
+| Import cycle `alias_index` ↔ `generational_cache` | **Fixed locally** | Comment on [#71](https://github.com/MarcoPorcellato/matryca-plumber/issues/71) |
+| Import cycle `plumber_config` ↔ `llm_url_policy` | Open | [#116](https://github.com/MarcoPorcellato/matryca-plumber/issues/116) |
+| Import cycle `control_room_progress` ↔ `maintenance_daemon` | Open (lazy) | [#117](https://github.com/MarcoPorcellato/matryca-plumber/issues/117) |
+| `html.py` self-cycle | False positive | — |
+| Taint PDG | Not indexed | [#119](https://github.com/MarcoPorcellato/matryca-plumber/issues/119) |
+| Module cohesion: Daemon 87%, Agent 64% | Informational | [#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58) |
+| `shape_check` API routes | N/A (Python project) | — |
+
+---
+
+## Recommended PR order (milestones)
+
+1. **#113**, **#103**, **#104**, **#38** — data integrity / observability  
+2. **#101**, **#102**, **#114** — logging gaps  
+3. **#115**, **#116** — prep Epic [#99](https://github.com/MarcoPorcellato/matryca-plumber/issues/99)  
+4. Performance batch **#46–#56**  
+5. **#117–#119** — architecture / CI hygiene  
+
+---
+
+## Commands for contributors
+
+```bash
+make check                    # full gate before PR
+make test-fast                # local iteration
+uv run pytest tests/test_graph_analytics.py -q   # #113
+```
+
+---
+
+*49 open issues as of 2026-06-23 after filing #113–#119.*

--- a/docs/quality/issue-bodies/106-count-catalog-summaries.md
+++ b/docs/quality/issue-bodies/106-count-catalog-summaries.md
@@ -1,0 +1,29 @@
+## Problem Description
+
+`src/graph/graph_analytics.py` — `_count_catalog_summaries()` wraps `load_master_catalog()` in a bare `except Exception: return 0` (L121–124).
+
+Any unexpected failure (permissions, flock timeout, schema edge case) makes Sovereign UI analytics report **zero page summaries** with **no log line**. `_safe_graph_analytics` in `ui_server.py` only catches exceptions from the outer `compute_graph_analytics` call, not this inner swallow.
+
+Discovered during GitNexus bug hunt (2026-06-23). See `docs/quality/BUG_HUNT_2026-06-23.md`.
+
+## Proposed Architectural Solution
+
+Catch `CatalogLoadError`, `BoundedJsonError`, and `OSError` explicitly; log with `logger.warning` or `logger.exception`; return 0 only for known-empty catalog states. Align with `ui_server._safe_graph_analytics` logging style.
+
+## Estimated Impact
+
+Medio — operators see wrong telemetry in Sovereign UI without any ops-log breadcrumb.
+
+## Files Involved
+
+- `src/graph/graph_analytics.py`
+- `tests/test_graph_analytics.py` (corrupt-catalog / permission-denied case)
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23 (`docs/quality/GITHUB_BUG_BACKLOG.md`)
+- Category: Bug
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/107-insights-llm-silent-fallback.md
+++ b/docs/quality/issue-bodies/107-insights-llm-silent-fallback.md
@@ -1,0 +1,27 @@
+## Problem Description
+
+`src/graph/insights_engine.py` L392–396: when `llm.generate_graph_insights` raises, the code falls back to `_fallback_insights(metrics)` inside `except Exception` **without logging**. Operators cannot distinguish LLM-enriched vs deterministic insights in logs.
+
+Contrast: `ui_server._safe_graph_analytics` logs failures; `post_write_hooks` uses `logger.exception`.
+
+## Proposed Architectural Solution
+
+Add `logger.warning` (or `logger.exception` once) before deterministic fallback. Keep `llm_used=False` semantics unchanged.
+
+## Estimated Impact
+
+Basso — observability only; no graph mutation behavior change.
+
+## Files Involved
+
+- `src/graph/insights_engine.py`
+- `tests/` — mock LLM raise, assert log line and `llm_used=False`
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23
+- Category: Bug
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/108-memory-config-layer-inversion.md
+++ b/docs/quality/issue-bodies/108-memory-config-layer-inversion.md
@@ -1,0 +1,24 @@
+## Problem Description
+
+`src/memory/config.py` calls `_env_bool` from `src/agent/plumber_config.py`. The biological memory layer (`src/memory/`, Epic #99) must not depend on the agent package — Clean Architecture: domain/config depends inward on `utils` only.
+
+## Proposed Architectural Solution
+
+Move `_env_bool` / `_env_int` to `src/utils/env_parse.py` (coordinate with #57) or read `MATRYCA_MEMORY_GRAPH_ENABLED` directly in `memory/config.py` via a shared utils helper with no `agent` imports.
+
+## Estimated Impact
+
+Medio — blocks clean integration of Epic #99 and Shadow DB write path without import cycles.
+
+## Files Involved
+
+- `src/memory/config.py`
+- `src/utils/env_parse.py` (new or extend)
+- `tests/test_env_example_coverage.py`
+- `tests/test_decay.py`
+
+---
+
+**Epic link:** #99 Biological Memory Layer
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/109-plumber-config-llm-url-cycle.md
+++ b/docs/quality/issue-bodies/109-plumber-config-llm-url-cycle.md
@@ -1,0 +1,33 @@
+## Problem Description
+
+GitNexus `check --cycles` reports:
+
+```text
+plumber_config.py → llm_url_policy.py → plumber_config.py
+```
+
+Lazy import in `assert_safe_lm_proxy_url` hides the cycle at runtime but complicates static analysis, testing, and future `src/memory/` wiring.
+
+## Proposed Architectural Solution
+
+Extract shared LLM URL resolution into `src/utils/llm_config.py` (or extend `llm_url_policy.py`) with **no** `agent` imports. `plumber_config.resolve_llm_base_url` remains the operator-facing resolver; policy module depends only on utils.
+
+## Estimated Impact
+
+Medio — architecture hygiene before v2.0 memory layer.
+
+## Files Involved
+
+- `src/agent/plumber_config.py`
+- `src/utils/llm_url_policy.py`
+- `tests/test_llm_url_policy.py`
+- `tests/test_plumber_config_env_serialization.py`
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23
+- Related: #57 (env parser DRY)
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/110-control-room-progress-cycle.md
+++ b/docs/quality/issue-bodies/110-control-room-progress-cycle.md
@@ -1,0 +1,26 @@
+## Problem Description
+
+`control_room_progress.refresh_phase2_cognitive_totals` lazy-imports `compute_phase2_progress_metrics` from `maintenance_daemon.py`. GitNexus reports a structural cycle (mitigated by `TYPE_CHECKING` + lazy import).
+
+## Proposed Architectural Solution
+
+Introduce a `Protocol` (`Phase2MetricsProvider`) or callback registered at daemon startup. `MaintenanceDaemon` implements metrics; `control_room_progress` depends on the protocol only — no runtime import of `maintenance_daemon`.
+
+## Estimated Impact
+
+Basso — maintainability; enables safer splits of `maintenance_daemon.py` (#58).
+
+## Files Involved
+
+- `src/agent/control_room_progress.py`
+- `src/agent/maintenance_daemon.py`
+- `tests/test_bootstrap_status.py`
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23
+- Related: #58 (split maintenance_daemon)
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/111-httpx2-deprecation.md
+++ b/docs/quality/issue-bodies/111-httpx2-deprecation.md
@@ -1,0 +1,30 @@
+## Problem Description
+
+Full pytest run emits:
+
+```text
+StarletteDeprecationWarning: Using httpx with starlette.testclient is deprecated; install httpx2 instead.
+```
+
+Source: `fastapi/testclient.py` via Sovereign UI server tests (`tests/test_ui_server.py`).
+
+## Proposed Architectural Solution
+
+Add `httpx2` dev dependency or upgrade FastAPI/Starlette to a combination that eliminates the warning. Target: `uv run pytest tests/test_ui_server.py -q -W error::DeprecationWarning` passes in CI.
+
+## Estimated Impact
+
+Basso — CI signal hygiene; no runtime behavior change.
+
+## Files Involved
+
+- `pyproject.toml` / `uv.lock`
+- `tests/test_ui_server.py` (if import path changes)
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/docs/quality/issue-bodies/112-gitnexus-pdg-ci.md
+++ b/docs/quality/issue-bodies/112-gitnexus-pdg-ci.md
@@ -1,0 +1,27 @@
+## Problem Description
+
+- `gitnexus explain` returns **no taint layer** — requires `gitnexus analyze --pdg` (security audit gap).
+- `gitnexus check --cycles` is not run in CI; stale index can report resolved import cycles after merges.
+
+## Proposed Architectural Solution
+
+1. Document in `CONTRIBUTING.md`: `./scripts/gitnexus-analyze-embeddings.sh` + `--pdg` for maintainer security audits.
+2. Optional CI step: `npx gitnexus check --cycles` on `main` (non-blocking warning, or blocking once index is fresh).
+
+## Estimated Impact
+
+Basso — contributor DX and security review posture; no runtime daemon change.
+
+## Files Involved
+
+- `scripts/gitnexus-analyze-embeddings.sh`
+- `.github/workflows/` (extend existing workflow)
+- `CONTRIBUTING.md`
+
+---
+
+**Audit metadata**
+- Source: GitNexus bug hunt 2026-06-23 (`docs/quality/GITHUB_BUG_BACKLOG.md`)
+- Milestone: v1.9.12 — Code Perfection & Tech Debt
+
+_Closes when merged with tests green (`make check`) and CHANGELOG updated per `06-auto-changelog.mdc`._

--- a/good_first_issues_blueprints.md
+++ b/good_first_issues_blueprints.md
@@ -1,8 +1,8 @@
 # Good First Issues — Contributor Blueprints
 
-**Updated post-#100 merge (2026-06-22)** — #44 shipped via [#100](https://github.com/MarcoPorcellato/matryca-plumber/pull/100) (thanks @gaoflow). Tier C opened [#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101)–[#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105); [#38](https://github.com/MarcoPorcellato/matryca-plumber/issues/38) promoted to `good first issue`.
+**Updated 2026-06-23** — GitNexus hunt filed [#113](https://github.com/MarcoPorcellato/matryca-plumber/issues/113)–[#119](https://github.com/MarcoPorcellato/matryca-plumber/issues/119). Registry: `docs/quality/GITHUB_BUG_BACKLOG.md`.
 
-**Active good-first candidates:** #38, #43, #52, #53, #56, #69, #71, #85, [#90](https://github.com/MarcoPorcellato/matryca-plumber/issues/90)–[#92](https://github.com/MarcoPorcellato/matryca-plumber/issues/92), [#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101)–[#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105). Welcome comments are on each GitHub thread.
+**Active good-first candidates:** #38, #43, #52, #53, #56, #69, #71, #85, [#90](https://github.com/MarcoPorcellato/matryca-plumber/issues/90)–[#92](https://github.com/MarcoPorcellato/matryca-plumber/issues/92), [#101](https://github.com/MarcoPorcellato/matryca-plumber/issues/101)–[#105](https://github.com/MarcoPorcellato/matryca-plumber/issues/105), **#113, #114, #118**. Welcome comments are on each GitHub thread.
 
 **Before opening a PR:** read [`CONTRIBUTING.md`](CONTRIBUTING.md), run `make check`, and reference the issue number in your PR title (e.g. `fix(daemon): log SIG handler shutdown telemetry (#101)`).
 
@@ -23,6 +23,12 @@ If a maintainer closes an overarching audit issue while your PR is open, **rebas
 ---
 
 ## Tier C — Post-#100 backlog (#101–#105)
+
+| Issue | Summary | Difficulty |
+|-------|---------|------------|
+| [#113](https://github.com/MarcoPorcellato/matryca-plumber/issues/113) | `_count_catalog_summaries` swallows exceptions (GitNexus 2026-06) | 2/10 |
+| [#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114) | Graph Insights LLM silent fallback | 2/10 |
+| [#118](https://github.com/MarcoPorcellato/matryca-plumber/issues/118) | httpx2 / Starlette deprecation in CI | 2/10 |
 
 | Issue | Summary | Difficulty |
 |-------|---------|------------|


### PR DESCRIPTION
## Summary
- Add [`docs/quality/BUG_HUNT_2026-06-23.md`](docs/quality/BUG_HUNT_2026-06-23.md): static-analysis audit findings (import cycles, flaky test, silent fallbacks).
- Add [`docs/quality/GITHUB_BUG_BACKLOG.md`](docs/quality/GITHUB_BUG_BACKLOG.md) and issue-body templates under `docs/quality/issue-bodies/` for maintainer traceability.
- Update `PROJECT_DIARY.md`, `good_first_issues_blueprints.md`, and `CHANGELOG.md` with audit registry cross-links.

## Test plan
- [x] Markdown links resolve within repo
- [x] No Python/runtime changes in this PR

Refs #113
Refs #114
Refs #115
Refs #116
Refs #117
Refs #118
Refs #119