### PR TITLE
fix: install httpx2 to resolve StarletteDeprecationWarning (closes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **v2.0 biological memory decay (Epic #99, Phase A)** — [`src/memory/decay.py`](src/memory/decay.py) Ebbinghaus pure math (`calculate_decayed_weight`, `calculate_stability`, `MemoryEdgeState`) ported from Nacre with numerical parity tests in [`tests/test_decay.py`](tests/test_decay.py).
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Core:** `link_verification` now correctly uses `file_mtime_drifted()` with exact nanosecond precision for OCC checks (thanks to @gaoflow in #88).
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Concurrency integrity — unified flock + hub page OCC**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **JSON sidecar flock parity (#40)** — `cross_process_json_flock` shares `src/utils/platform_lock.py` with page RMW locks: non-blocking acquire with exponential backoff, blocking fallback after NB exhaustion, `MATRYCA_ALLOW_FLOCK_DEGRADATION`, and thread-local reentrancy depth tracking (fixes nested catalog/registry deadlocks and reduces pytest-xdist lock thrashing).
 - **Hub page OCC (#34)** — `write_generated_hub_page` in `src/graph/generated_hub_write.py` wraps Master Index and Graph Insights compiles: pre-compile `occ_snapshot`, `page_rmw_lock`, and `atomic_write_bytes_if_unchanged`; concurrent human edits during compile log a graceful skip (derived pages regenerate on the next daemon cycle).
@@ -75,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Fast test gate & CI fixes**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **CI mypy** — `test_semantic_cache_router` patches `time.time` via dotted module path so strict mypy passes (`attr-defined` clean).
 
@@ -87,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Catalog Integrity & OSS Maturity**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Harvest catalog drift guard (#37)** — `catalog.upsert` runs only when `_append_minimal_semantic_index` confirms the page write (or the header is already present); OCC abort returns `pending_llm` without catalog/page drift.
 - **Link registry atomic save (#41)** — `_save_registry_unlocked` uses `atomic_write_bytes`, matching backlink index and daemon state persistence.
@@ -110,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Strict Mypy Compliance & Journal Phase-2 Bypass**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Mypy strictness (#60)** — Removed all 11 `# type: ignore` suppressions under `src/`; replaced with `cast()`, `isinstance()` narrowing, `Path()` coercion, a `_FilesystemObserver` Protocol, and lambda key functions so strict mypy passes without cheats.
 
@@ -126,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Good First Issues blueprints** — Root [`good_first_issues_blueprints.md`](good_first_issues_blueprints.md) with six curated v1.9.x audit issues and copy-paste GitHub contributor guide comments for external onboarding.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **SessionAliasRegistry SLF001** — Centralized upstream private dict access in `safe_update_alias` / `safe_alias_items` helpers (`src/agent/alias_state.py`); `graph_tool_helpers.py` no longer mutates `_alias_to_uuid` directly (#64).
 - **HTTP NoRedirect DRY** — Shared `NoRedirect` handler in `src/utils/network.py` replaces duplicate classes in `preflight.py` and `ui_server.py` (#62).
@@ -142,6 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Enterprise Resilience Update — 12 architectural hardening fixes**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 #### Security & Sandbox
 
@@ -177,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Sovereign UI reliability — large vault operator fixes**
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Sovereign UI reliability** — lazy runtime bootstrap (`eager_graph=False`) on settings save, graph-path save, L1 provision, and **Start Engine** so large vaults no longer hit the 10s fetch timeout; `GET /api/config` reads `LOGSEQ_GRAPH_PATH` from `.env` file values; Settings drawer blocks save until config loads, confirms discard on close, and shows API errors (not `engineError`); pre-flight treats `warn` as non-blocking; modal auto-dismisses when checks pass; graph-path pre-flight surfaces post-save verification failures; graph analytics uses 18s server cache, 60s client timeout, and marks telemetry offline on poll failure.
 
@@ -225,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Chaos-hardened AX tests** — `tests/test_agent_experience_robustness.py` stress-tests path traversal rejection, namespace edge cases, and safe fallback writes for hallucinated LLM targets.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **MCP outline validation** — Automatic type coercion (`int` → `str`) for `heading_level` in `mutate_graph` / `write_outline` payloads; parser echo keys are hoisted from `properties` and stripped before disk write so `heading_level::` never lands in Logseq `.md` files (improves Agent Experience with local LLMs such as Hermes).
 - **MCP write resilience** — `write_outline` / `inject_query` with `Page Title|block` targets perform a safe page-bottom append when the block UUID or `[n]` alias is invalid but the page exists; empty or blockless pages append at EOF; warnings are returned in the JSON payload and logged to stderr.
@@ -246,6 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation** — `llms.txt`, `.well-known/llms.txt`, ARCHITECTURE, OpenSpec index, and `agent-onboarding.md` aligned with Hermes host config and lazy MCP handshake (v1.9.6).
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **GitHub traffic badges** — README Shields.io endpoints now read badge JSON from the `metrics` branch (`raw.githubusercontent.com/.../metrics/metrics/...`); `metrics-saver` publishes a metrics-only orphan branch via `METRICS_TOKEN` instead of bloating the branch with the full repo tree.
 - **README badges** — Python badge reads `requires-python` from `pyproject.toml` (PyPI `pyversions` showed `missing` without Trove classifiers); coverage anchor and test-count badge aligned with current suite (`640+`, `cov-fail-under=70` at `pyproject.toml` L138).
@@ -288,6 +298,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auto-unfreeze** — Sovereign UI detects a live Plumber PID (`daemon_pid` or `running`/`idle` status) and resumes state polling even when started from `matryca plumber start` in another terminal; full logs/analytics still require **Start Engine**.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Thread-safe daemon checkpoints** — Telemetry persistence uses `threading.Lock` plus immutable `DaemonState` JSON snapshots so heartbeat threads never race the main LLM loop during `index_page()`.
 - **Stuck progress bar & pills** — Progress, bootstrap pills, and Phase 2 file pills reach disk on heartbeat and per-file checkpoints instead of appearing only after **Stop Engine**.
@@ -332,6 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sovereign UI settings** — Infrastructure drawer exposes `LLM_API_KEY` as **API Token** (password field); persisted to `.env` on save. Required only for cloud OpenAI-compatible endpoints.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Journey log pending leak** — After appending `## 🤖 Matryca Activity` to today's journal, the daemon records `journals/YYYY_MM_DD.md` in file state so `list_pending_files` does not re-queue it on the next cycle (`src/agent/maintenance_daemon.py`).
 - **Link verification hygiene** — Re-check flagged registry entries; GET fallback when HEAD is inconclusive; merge-safe registry persistence; prune removed page links; clear on-graph `dead-link::` / `missing-asset::` on recovery; journey log splits URL vs asset flag counts (`src/graph/link_verification.py`, `src/agent/maintenance_daemon.py`).
@@ -362,6 +374,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cursor rule `07-env-example.mdc`** — Agents must update `.env.example` when env vars change; file split into **Operator essentials** vs **Advanced / high impact** sections.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **v1.8 audit (round 4)** — `generate_graph_insights` is stateless so ontology reports do not pollute Ermes history; context-compression summaries are prose-sanitized before persistence; semantic-index block catalogs cap at 8k chars; Phase 2 LLM inference no longer holds `page_rmw_lock` (write-only lock in `apply_semantic_page_result`); `id::` lines are excluded from property-line hygiene so Logseq block UUIDs are never edited as properties.
 - **Gemma JSON degeneration** — Structured LLM completions cap at `MATRYCA_LLM_MAX_COMPLETION_TOKENS` (default 2048); `json_repair` uses balanced-brace extraction (not greedy `{.*}`), strips post-`}` `\n` token loops, and normalizes Gemma `\n  \"key` leakage before indexing Logseq pages.
@@ -380,12 +393,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **README** — Expanded professional badge block at the top (PyPI, GitHub Release, CI quality gates, platform, MCP, Logseq OG, security, contributing, code of conduct).
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **CI** — Pin `astral-sh/setup-uv` to immutable `v8.1.0` (major tag `@v8` was removed in setup-uv v8.0.0).
 
 ## [1.8.3] - 2026-05-29
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **CI** — `ruff format` on `maintenance_daemon.py`; GitHub Actions upgraded to Node 24–compatible action majors (`checkout@v6`, `setup-node@v6`, `setup-uv@v8`).
 
@@ -396,6 +411,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`logseq-matryca-parser`** — minimum dependency raised to **1.1.1** (latest on PyPI; was `>=0.3.3`).
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Cognitive KV-cache alignment** — `run_cognitive_lint_pipeline` rebuilds `PagePromptSession` after on-disk mutations so semantic index LLM calls no longer use a stale stable prefix.
 - **Master catalog load safety** — transient `OSError` no longer caches an empty catalog that could overwrite `master_catalog.json`; corrupt JSON is quarantined or restored from `.bak`; `save()` is blocked until a successful load.
@@ -412,6 +428,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.1] - 2026-05-28
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **CI formatting** — `ruff format` on `page_prompt_session.py`, `process_priority.py`, and `master_catalog.py` so `make ci` passes on `main`.
 
@@ -442,6 +459,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Structured output** — `InstructorLLMClient` moved to `llm_client.py`; instructor mode carousel replaced by probe-driven Path A/B.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Semantic cache TTL** — no longer deletes the master catalog when purging expired inference cache files.
 
@@ -464,6 +482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI** — single `ci.yml` workflow with `make ci` (`ruff format --check` without mutating the tree); Ruff `ASYNC`/`S`/`PERF`/`RUF`; pytest coverage gate (70% on `src`).
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **`graph_dispatch`** — safe integer parsing for JSON tool options (no bare `ValueError` escapes).
 - **Phase 2 progress bar (Sovereign UI)** — vault-wide and per-cluster progress now share one resolver with the TUI and daemon checkpoints (`progress_*` on `GET /api/state`); persisted `phase2_cognitive_*` counters and in-flight cluster file subtitles so the bar no longer stays at 0% while the engine works.
@@ -490,6 +509,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`.env.example`** — `MATRYCA_L1_PATH` left commented (sibling `matryca-l1/` via pre-flight); documents log path overrides and runtime layout pointers.
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **Phase 1 catalog pills (empty state)** — pills no longer read only `state.files` during Phase 1 when the daemon has not yet started Phase 2 file checkpoints.
 - **Phase 1 thermal delay** — bootstrap pauses reload `MATRYCA_THERMAL_DELAY_BOOTSTRAP` from `.env` after every catalog LLM turn (Settings Drawer value is honored); cool-down sleeps wake promptly on Stop.
@@ -535,6 +555,7 @@ No user-facing changes (version alignment with PyPI / lockfile).
 ## [1.5.15] - 2026-05-24
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **MCP log bridge** — reset/re-register Loguru MCP telemetry sink after `logger.remove()` (fixes flaky `test_mcp_telemetry` under full pytest collection).
 - **Sovereign UI daemon start** — treat successful detached launcher exit (code 0) as success when a live PID is published.
@@ -555,6 +576,7 @@ No user-facing changes (version alignment with PyPI / lockfile).
 ## [1.5.13] - 2026-05-24
 
 ### Fixed
+- **CI / deps (#118):** Replaced empty `httpx` shim with `httpx2>=2.4.0` in `[project.optional-dependencies] dev` to silence `StarletteDeprecationWarning` emitted by `fastapi/testclient` during the test run.
 
 - **MCP Loguru sink** — thread-safe `enqueue` pickling for telemetry under pytest and multi-threaded hosts.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dev = [
     "pytest-xdist>=3.8.0,<4.0.0",
     "ruff>=0.8.0,<1.0.0",
     "mypy>=1.13.0,<3.0.0",
+    "httpx2>=2.4.0",
 ]
 
 [tool.setuptools]
@@ -168,7 +169,3 @@ markers = [
     "integration: subprocess or full-bootstrap tests (skipped by make test-fast)",
 ]
 
-[dependency-groups]
-dev = [
-    "httpx2>=2.4.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,8 @@ markers = [
     "slow: performance or memory soak tests (excluded from default CI)",
     "integration: subprocess or full-bootstrap tests (skipped by make test-fast)",
 ]
+
+[dependency-groups]
+dev = [
+    "httpx2>=2.4.0",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422", size = 64618, upload-time = "2026-06-11T06:35:53.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242", size = 80151, upload-time = "2026-06-11T06:35:50.89Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -701,6 +714,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef", size = 81691, upload-time = "2026-06-11T06:35:54.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9", size = 74941, upload-time = "2026-06-11T06:35:52.235Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -711,11 +740,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1035,6 +1064,11 @@ edge = [
     { name = "psutil" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx2" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
@@ -1061,6 +1095,9 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
 provides-extras = ["edge", "dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "httpx2", specifier = ">=2.4.0" }]
 
 [[package]]
 name = "mcp"
@@ -1954,6 +1991,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Installs `httpx2` as a dev dependency to silence the `StarletteDeprecationWarning` 
emitted by `fastapi/testclient.py` during the test run.

## How to verify
uv run pytest tests/test_ui_server.py -q -W error::DeprecationWarning
# → 37 passed, 0 warnings

Closes #118