### PR TITLE
chore: embeddings re-index scripts and config (#119)

### DIFF
--- a/.gitnexusrc
+++ b/.gitnexusrc
@@ -1,0 +1,5 @@
+{
+  "skipAgentsMd": true,
+  "defaultBranch": "main",
+  "embeddings": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GitNexus embeddings tooling** — [`scripts/gitnexus-analyze-embeddings.sh`](scripts/gitnexus-analyze-embeddings.sh) + [`scripts/gitnexus-hf-cache.mjs`](scripts/gitnexus-hf-cache.mjs): re-index with semantic vectors when global `gitnexus` is root-owned under `/usr/local` (redirects HuggingFace cache to `~/.cache/huggingface`). [`.gitnexusrc`](.gitnexusrc) enables `embeddings` by default.
 - **v2.0 roadmaps** — Maintainer checklists for Shadow DB ([#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24)) and Nacre-inspired biological memory layer: [`docs/roadmaps/ROADMAP_V2_SHADOW_DB.md`](docs/roadmaps/ROADMAP_V2_SHADOW_DB.md), [`docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md); cross-links in [`ROADMAP.md`](ROADMAP.md) and [`docs/openspec/README.md`](docs/openspec/README.md).
 - **v2.0 shadow schema** — [`src/shadow/schema.py`](src/shadow/schema.py) DDL for Logseq read cache (`pages`, `blocks`, `block_refs`, `blocks_fts`) plus biological memory tables (`memory_nodes` through `memory_snapshots`); `apply_shadow_schema()` helper and [`tests/test_shadow_schema.py`](tests/test_shadow_schema.py).
 - **v2.0 biological memory decay (Epic #99, Phase A)** — [`src/memory/decay.py`](src/memory/decay.py) Ebbinghaus pure math (`calculate_decayed_weight`, `calculate_stability`, `MemoryEdgeState`) ported from Nacre with numerical parity tests in [`tests/test_decay.py`](tests/test_decay.py).

--- a/scripts/gitnexus-analyze-embeddings.sh
+++ b/scripts/gitnexus-analyze-embeddings.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Re-index matryca-plumber with GitNexus semantic embeddings (BM25 + vector).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+mkdir -p "$HF_HOME"
+
+export NODE_OPTIONS="--import ./scripts/gitnexus-hf-cache.mjs${NODE_OPTIONS:+ $NODE_OPTIONS}"
+
+if command -v gitnexus >/dev/null 2>&1; then
+  GITNEXUS=gitnexus
+elif [[ -x "$ROOT/tools/gitnexus-cli/node_modules/.bin/gitnexus" ]]; then
+  GITNEXUS="$ROOT/tools/gitnexus-cli/node_modules/.bin/gitnexus"
+else
+  echo "gitnexus CLI not found (install globally or run: npm install --prefix tools/gitnexus-cli gitnexus@1.6.1)" >&2
+  exit 1
+fi
+
+exec "$GITNEXUS" analyze --embeddings --skip-agents-md "$@"

--- a/scripts/gitnexus-hf-cache.mjs
+++ b/scripts/gitnexus-hf-cache.mjs
@@ -1,0 +1,28 @@
+/**
+ * Preload for `gitnexus analyze --embeddings` when gitnexus is installed globally
+ * under /usr/local (root-owned). transformers.js defaults to a package-local
+ * `.cache/` that is not writable; this redirects to HF_HOME or ~/.cache/huggingface.
+ *
+ * Usage:
+ *   NODE_OPTIONS="--import ./scripts/gitnexus-hf-cache.mjs" gitnexus analyze --embeddings
+ */
+import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const gitnexusRoot =
+  process.env.GITNEXUS_MODULE_ROOT ?? '/usr/local/lib/node_modules/gitnexus';
+
+try {
+  const require = createRequire(join(gitnexusRoot, 'package.json'));
+  const transformersEntry = require.resolve('@huggingface/transformers');
+  const transformersMjs = transformersEntry.replace(/\.cjs$/, '.mjs');
+  const { env } = await import(transformersMjs);
+  const cacheDir = process.env.HF_HOME ?? join(homedir(), '.cache', 'huggingface');
+  env.cacheDir = cacheDir;
+  env.useFSCache = true;
+  env.useBrowserCache = false;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`gitnexus-hf-cache: could not set transformers cacheDir: ${message}`);
+}


### PR DESCRIPTION
## Summary
- Add local maintainer scripts for hybrid BM25+vector re-indexing when the global CLI install is root-owned.
- Add local config with `embeddings: true` by default.

## Test plan
- [x] Scripts are executable and documented in CHANGELOG
- [ ] Maintainer smoke against a local clone

Refs #119