### PR TITLE
fix: log TUI daemon state load failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Daemon shutdown (#44):** Final catalog and daemon state save failures now log exception details instead of being silently suppressed during graceful shutdown (thanks to @gaoflow in #100).
 - **Daemon shutdown (#101):** SIGTERM/SIGINT token-log shutdown breadcrumb failures now emit exception details instead of being silently suppressed.
 - **TUI dashboard (#102):** Token activity tail and daemon state refresh I/O failures now log exception details while preserving the existing fallback UI.
+- **TUI dashboard (#127):** Daemon state load failures now catch only expected state I/O/JSON/value errors and log a breadcrumb before falling back to the cached or empty state.
 - **Catalog sync (#103):** Phase-2 post-write catalog updates now persist page mtimes with nanosecond precision.
 - **Semantic clusters (#104):** Cluster cache loads now read `semantic_clusters.json` under the shared JSON flock.
 

--- a/src/cli/tui_dashboard.py
+++ b/src/cli/tui_dashboard.py
@@ -21,6 +21,7 @@ from ..agent.maintenance_daemon import (
     resolve_graph_root,
 )
 from ..agent.plumber_config import resolve_lm_model
+from ..utils.bounded_json import BoundedJsonError
 from ..utils.token_logger import TokenLogger, resolve_plumber_log_path
 
 MONITOR_TITLE = "[MATRYCA PLUMBER MONITOR]"
@@ -91,7 +92,8 @@ def _try_load_daemon_state(
     """Load daemon state without blocking the TUI on transient read or parse failures."""
     try:
         return load_daemon_state(graph_root)
-    except Exception:
+    except (OSError, BoundedJsonError, ValueError):
+        loguru_logger.exception("TUI dashboard failed to load daemon state; using fallback state")
         if last_good is not None:
             return last_good
         return DaemonState()
@@ -236,7 +238,7 @@ def collect_snapshot_safe(
     if root is not None:
         try:
             last_good_state = load_daemon_state(root)
-        except OSError:
+        except (OSError, BoundedJsonError, ValueError):
             loguru_logger.exception("TUI dashboard failed to refresh last good daemon state")
     return snapshot, last_good_state
 

--- a/tests/test_tui_dashboard.py
+++ b/tests/test_tui_dashboard.py
@@ -8,7 +8,8 @@ from unittest.mock import patch
 
 import pytest
 from src.agent.maintenance_daemon import DaemonState, FileState, save_daemon_state
-from src.cli.tui_dashboard import collect_snapshot, collect_snapshot_safe
+from src.cli.tui_dashboard import _try_load_daemon_state, collect_snapshot, collect_snapshot_safe
+from src.utils.bounded_json import BoundedJsonError
 from src.utils.token_logger import TokenLogger
 
 
@@ -194,4 +195,48 @@ def test_collect_snapshot_safe_falls_back_to_last_good_state_on_read_failure(
 
     assert second.session_prompt_tokens == 42
     assert still_cached is cached_state
-    logged.assert_called_once_with("TUI dashboard failed to refresh last good daemon state")
+    logged.assert_any_call("TUI dashboard failed to load daemon state; using fallback state")
+    logged.assert_any_call("TUI dashboard failed to refresh last good daemon state")
+    assert logged.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        OSError("state file busy"),
+        BoundedJsonError("state json corrupt"),
+        ValueError("invalid daemon state payload"),
+    ],
+)
+def test_try_load_daemon_state_logs_and_returns_last_good_on_expected_load_failures(
+    graph_root: Path,
+    failure: Exception,
+) -> None:
+    last_good = DaemonState(status="running", session_prompt_tokens=99)
+
+    with (
+        patch("src.cli.tui_dashboard.load_daemon_state", side_effect=failure),
+        patch("src.cli.tui_dashboard.loguru_logger.exception") as logged,
+    ):
+        state = _try_load_daemon_state(graph_root, last_good=last_good)
+
+    assert state is last_good
+    logged.assert_called_once_with(
+        "TUI dashboard failed to load daemon state; using fallback state"
+    )
+
+
+def test_try_load_daemon_state_logs_and_returns_empty_state_without_cache(
+    graph_root: Path,
+) -> None:
+    with (
+        patch("src.cli.tui_dashboard.load_daemon_state", side_effect=ValueError("bad state")),
+        patch("src.cli.tui_dashboard.loguru_logger.exception") as logged,
+    ):
+        state = _try_load_daemon_state(graph_root, last_good=None)
+
+    assert state.files == {}
+    assert state.status == "idle"
+    logged.assert_called_once_with(
+        "TUI dashboard failed to load daemon state; using fallback state"
+    )


### PR DESCRIPTION
## Summary

- Narrow `_try_load_daemon_state` to the expected daemon state load failure modes (`OSError`, `BoundedJsonError`, `ValueError`) instead of swallowing every exception.
- Add a log breadcrumb before falling back to the cached state or a fresh `DaemonState()` so corrupt/unreadable state files are visible during TUI refreshes.
- Extend the same expected failure handling to the `collect_snapshot_safe` last-good refresh path.
- Add regression coverage for cached and empty-state fallback behavior, plus update `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [x] `uv run pytest tests/test_tui_dashboard.py -q --no-cov` passes locally
- [x] `uv run ruff check src/cli/tui_dashboard.py tests/test_tui_dashboard.py` passes locally
- [x] `uv run mypy src/cli/tui_dashboard.py tests/test_tui_dashboard.py` passes locally
- [x] `uv run ruff format --check src/cli/tui_dashboard.py tests/test_tui_dashboard.py` passes locally
- [x] `git diff --check` passes locally
- [x] `make check` passes locally
- [x] OCC / CRLF: graph writes preserve `id::` lines and page frontmatter at line 0
  - Not applicable: this PR only changes TUI daemon-state loading and tests.
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] If CLI/MCP/env changed: [`llms.txt`](../llms.txt) and [`.well-known/llms.txt`](../.well-known/llms.txt) stay in sync
  - Not applicable: no CLI, MCP, or env surface changed.

## Issue linking

Closes #127
