### PR TITLE
fix: log journal link registry failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Journal settle (#128):** Link registry merge failures during journal structural settle now log exception details while preserving the existing non-blocking settle flow.
+
 ### Changed
 
 - **Repository hygiene (TRIZ separation-in-space)** — Vendor-specific graph indexer tooling moved under gitignored `.local/`; public wrappers `scripts/provision-local-workspace.sh` and `scripts/reindex-code-graph.sh` delegate via `LOCAL_GRAPH_ANALYZER_NPM_PACKAGE` / `CODE_GRAPH_CLI` with no vendor names in the OSS tree.

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -2557,8 +2557,10 @@ class MaintenanceDaemon:
             if path.is_file():
                 content = read_graph_file_text(path, self.graph_root, errors="replace")
                 if link_verify_enabled():
-                    with contextlib.suppress(OSError):
+                    try:
                         merge_page_links_into_registry(self.graph_root, path, content)
+                    except OSError:
+                        logger.exception("Journal structural settle link registry merge failed")
             get_graph_ast_cache(self.graph_root).apply_file_event(path, "modified")
             state.files[key] = FileState(
                 mtime=path.stat().st_mtime,

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -2133,6 +2133,40 @@ def test_run_cycle_journal_phase1_only_skips_semantic_indexing(
     assert "SemanticTopic" in dual_embed_titles
 
 
+def test_journal_structural_settle_logs_link_registry_merge_failure(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal_dir = graph_root / "journals"
+    journal_dir.mkdir(parents=True)
+    journal_path = journal_dir / "2026_06_10.md"
+    journal_path.write_text(f"- daily note\n  id:: {BLOCK_UUID}\n", encoding="utf-8")
+    journal_key = graph_relative_path_key(journal_path, graph_root)
+    logged_messages: list[str] = []
+
+    def fail_link_registry_merge(*_args: object, **_kwargs: object) -> None:
+        raise OSError("registry sidecar unavailable")
+
+    def capture_exception(message: str, *_args: object, **_kwargs: object) -> None:
+        logged_messages.append(message)
+
+    monkeypatch.setattr("src.agent.maintenance_daemon.link_verify_enabled", lambda: True)
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.merge_page_links_into_registry",
+        fail_link_registry_merge,
+    )
+    monkeypatch.setattr("src.agent.maintenance_daemon.logger.exception", capture_exception)
+
+    state = DaemonState(bootstrap_complete=True)
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+
+    result = daemon._settle_journal_structural_cycle_file(journal_path, state)
+
+    assert result is False
+    assert state.files[journal_key].status == "processed"
+    assert logged_messages == ["Journal structural settle link registry merge failed"]
+
+
 def test_page_needs_phase2_cognitive_journal_settles_without_semantic_requeue(
     graph_root: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Replace the silent `contextlib.suppress(OSError)` around journal structural-settle link registry merging with explicit `try` / `except OSError` logging.
- Preserve the existing non-blocking journal settle flow: registry merge failures no longer abort the journal path, and the journal file is still marked processed.
- Add a regression test covering the logged fallback behavior.
- Document the fix in `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [x] `uv run pytest tests/test_maintenance_daemon.py -q --no-cov` passes locally
- [x] `uv run ruff check src/agent/maintenance_daemon.py tests/test_maintenance_daemon.py` passes locally
- [x] `uv run mypy src/agent/maintenance_daemon.py tests/test_maintenance_daemon.py` passes locally
- [x] `git diff --check` passes locally
- [x] `make check` passes locally
- [x] OCC / CRLF: graph writes preserve `id::` lines and page frontmatter at line 0
  - This PR does not modify graph write semantics; it only adds observability around the existing journal settle fallback path.
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] If CLI/MCP/env changed: [`llms.txt`](../llms.txt) and [`.well-known/llms.txt`](../.well-known/llms.txt) stay in sync
  - Not applicable: no CLI, MCP, or env surface changed.

## Issue linking

Closes #128
