### PR TITLE
feat(safety): L0 middleware validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
+
+### Added
+
+- **L0 write safety** — `src/graph/safety/validators.py` (`reject_id_line_deletion`, `reject_protected_zones_modification`) invoked before semantic index commits; `tests/test_safety_validators.py`.
 
 ## [1.11.2] - 2026-06-24
 

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -87,6 +87,7 @@ from ..graph.path_sandbox import (
     normalize_daemon_file_key,
     read_graph_file_text,
 )
+from ..graph.safety.validators import validate_llm_write_diff
 from ..graph.semantic_clustering import (
     CLUSTER_IDS_WITHOUT_FOCUS,
     JOURNAL_CLUSTER_ID,
@@ -1475,6 +1476,16 @@ def apply_semantic_page_result(
         body = "".join(lines)
         if not _semantic_index_section_present(body):
             body = body.rstrip("\n") + _format_index_section(result, lint_outcome=lint_outcome)
+        safety = validate_llm_write_diff(prev, body)
+        if not safety.ok:
+            logger.warning(
+                "L0 safety rejection on {}: {}",
+                page_path,
+                safety.reason,
+            )
+            lint_outcome.write_aborted = True
+            lint_outcome.skip_reasons.append(f"l0_safety:{safety.reason}")
+            return lint_outcome
         commit_summary = f"semantic index update on {page_title}"
         if baseline_mtime is not None and not atomic_write_bytes_if_unchanged(
             page_path,

--- a/src/graph/safety/__init__.py
+++ b/src/graph/safety/__init__.py
@@ -1,0 +1,15 @@
+"""Graph write safety validators (L0 hard rejection)."""
+
+from .validators import (
+    SafetyValidationResult,
+    reject_id_line_deletion,
+    reject_protected_zones_modification,
+    validate_llm_write_diff,
+)
+
+__all__ = [
+    "SafetyValidationResult",
+    "reject_id_line_deletion",
+    "reject_protected_zones_modification",
+    "validate_llm_write_diff",
+]

--- a/src/graph/safety/validators.py
+++ b/src/graph/safety/validators.py
@@ -1,0 +1,61 @@
+"""L0 hard-rejection validators for LLM-backed graph writes."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from ..global_fence_scanner import compute_page_protected_line_indices
+
+_ID_LINE = re.compile(r"^\s*id::\s*.+\s*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyValidationResult:
+    ok: bool
+    reason: str = ""
+
+
+def _id_lines(text: str) -> list[str]:
+    return [line for line in text.splitlines() if _ID_LINE.match(line)]
+
+
+def reject_id_line_deletion(before: str, after: str) -> SafetyValidationResult:
+    """Reject writes that remove any on-disk ``id::`` line."""
+    after_ids = set(_id_lines(after))
+    for line in _id_lines(before):
+        if line not in after_ids:
+            return SafetyValidationResult(False, "id_line_deleted")
+    return SafetyValidationResult(True)
+
+
+def reject_protected_zones_modification(before: str, after: str) -> SafetyValidationResult:
+    """Reject writes that mutate fenced code, HTML comments, or advanced queries."""
+    protected = compute_page_protected_line_indices(before)
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    for idx in protected:
+        if idx >= len(before_lines):
+            continue
+        if idx >= len(after_lines):
+            return SafetyValidationResult(False, f"protected_line_removed:{idx}")
+        if before_lines[idx] != after_lines[idx]:
+            return SafetyValidationResult(False, f"protected_line_modified:{idx}")
+    return SafetyValidationResult(True)
+
+
+def validate_llm_write_diff(before: str, after: str) -> SafetyValidationResult:
+    """Run all L0 validators; first failure wins."""
+    for validator in (reject_id_line_deletion, reject_protected_zones_modification):
+        result = validator(before, after)
+        if not result.ok:
+            return result
+    return SafetyValidationResult(True)
+
+
+__all__ = [
+    "SafetyValidationResult",
+    "reject_id_line_deletion",
+    "reject_protected_zones_modification",
+    "validate_llm_write_diff",
+]

--- a/tests/test_safety_validators.py
+++ b/tests/test_safety_validators.py
@@ -1,0 +1,43 @@
+"""Tests for src/graph/safety/validators.py."""
+
+from __future__ import annotations
+
+from src.graph.safety.validators import (
+    reject_id_line_deletion,
+    reject_protected_zones_modification,
+    validate_llm_write_diff,
+)
+
+
+def test_reject_id_line_deletion_blocks_removed_uuid() -> None:
+    before = "- item\n  id:: abc-def\n"
+    after = "- item\n"
+    result = reject_id_line_deletion(before, after)
+    assert not result.ok
+    assert result.reason == "id_line_deleted"
+
+
+def test_reject_id_line_deletion_allows_preserved_uuid() -> None:
+    text = "- item\n  id:: abc-def\n"
+    assert reject_id_line_deletion(text, text).ok
+
+
+def test_reject_protected_zones_modification_blocks_fence_edit() -> None:
+    before = "- intro\n```python\nsecret = 1\n```\n"
+    after = "- intro\n```python\nsecret = 2\n```\n"
+    result = reject_protected_zones_modification(before, after)
+    assert not result.ok
+    assert result.reason.startswith("protected_line_modified:")
+
+
+def test_reject_protected_zones_allows_outside_fence_edit() -> None:
+    before = "- intro\n```python\nsecret = 1\n```\n- tail\n"
+    after = "- intro edited\n```python\nsecret = 1\n```\n- tail\n"
+    assert reject_protected_zones_modification(before, after).ok
+
+
+def test_validate_llm_write_diff_composes_validators() -> None:
+    before = "- item\n  id:: abc-def\n"
+    after = "- item\n"
+    result = validate_llm_write_diff(before, after)
+    assert not result.ok


### PR DESCRIPTION
Adds `reject_id_line_deletion`, `reject_protected_zones_modification`, `validate_llm_write_diff` in `src/graph/safety/validators.py`. Integrated in `apply_semantic_page_result` before write. Tests in `tests/test_safety_validators.py`.

## Test plan

- [x] `uv run pytest tests/test_safety_validators.py -q`
- [x] `make check`

Made with [Cursor](https://cursor.com)