### PR TITLE
feat(docs): AGENTS.md 3-audience router + paradigm SSOT

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,8 +1,17 @@
-# Matryca Plumber — Cursor rules (repository policy)
+# Matryca Plumber — Cursor rules index
 
-## Tooling & Static Analysis Policy
+Load task-specific rules from [`.cursor/rules/`](.cursor/rules/). Contributor router: [`AGENTS.md`](AGENTS.md).
 
-- Do not track, commit, or mention specific third-party local development tools, AST indexers, or custom MCP servers in public documentation, CI/CD, or commit messages.
-- Do not add tool-specific local ignore patterns to the public `.gitignore`; use local-only Git exclude files for personal dev tooling artifacts.
-- Keep the public repository vendor-agnostic and strictly focused on core project requirements.
-- When referring to local code audits in docs or issues, use generic terms like "Local Static Analysis", "AST tooling", or "Graph-based code analysis".
+| Rule | Purpose |
+|------|---------|
+| `00-karpathy-agent-behavior.mdc` | Always — investigate, minimal diff, run checks |
+| `01-core-paradigm.mdc` | Logseq OG blocks/properties → [`docs/openspec/logseq-paradigm.md`](docs/openspec/logseq-paradigm.md) |
+| `02-python-standards.mdc` | `*.py` — uv, mypy strict, Pydantic |
+| `03-logseq-api.mdc` | Headless file I/O default |
+| `04-spatial-parser.mdc` | `src/graph/`, `logseq_matryca_parser` |
+| `05-release-preparation.mdc` | Semver release (on request) |
+| `06-auto-changelog.mdc` | `CHANGELOG.md` after user-visible changes |
+| `07-env-example.mdc` | `.env.example` sync |
+| `08-github-workflow-standards.mdc` | GitHub issues/PRs (on request) |
+| `09-github-identity-marco-porcellato.mdc` | Maintainer voice on GitHub |
+| `10-tooling-static-analysis-policy.mdc` | Vendor-agnostic public repo policy |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — Matryca Plumber instruction router
+
+This file routes coding assistants to the correct instruction layer. **Do not load every doc at once.**
+
+## Audience map
+
+| You are… | Read first | Do not load |
+|----------|------------|-------------|
+| **Cursor agent patching this repo** | [`.cursor/rules/00-karpathy-agent-behavior.mdc`](.cursor/rules/00-karpathy-agent-behavior.mdc), this file, [`CONTRIBUTING.md`](CONTRIBUTING.md) | Full [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) (runtime vault law) |
+| **External agent on a user Logseq vault** | [`llms.txt`](llms.txt) → [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) | [`.cursor/rules/`](.cursor/rules/) |
+| **Maintainer changing MCP/CLI/prompt contracts** | [`docs/openspec/agent-onboarding.md`](docs/openspec/agent-onboarding.md), [`docs/openspec/agent/`](docs/openspec/agent/), [`docs/openspec/llm-performance.md`](docs/openspec/llm-performance.md), rule `11-prompt-maintainer` | — |
+
+## Cursor rule routing
+
+| Rule | When it applies |
+|------|-----------------|
+| [`00-karpathy-agent-behavior.mdc`](.cursor/rules/00-karpathy-agent-behavior.mdc) | Always — investigate, minimal diff, run checks |
+| [`01-core-paradigm.mdc`](.cursor/rules/01-core-paradigm.mdc) | Logseq OG blocks, properties, namespaces → SSOT [`docs/openspec/agent/paradigm.md`](docs/openspec/agent/paradigm.md) |
+| [`02-python-standards.mdc`](.cursor/rules/02-python-standards.mdc) | Any `*.py` edit |
+| [`03-logseq-api.mdc`](.cursor/rules/03-logseq-api.mdc) | `src/**/*.py` — headless file I/O default |
+| [`04-spatial-parser.mdc`](.cursor/rules/04-spatial-parser.mdc) | `src/**/*.py` graph parsing |
+| [`05-release-preparation.mdc`](.cursor/rules/05-release-preparation.mdc) | Semver release (on request) |
+| [`06-auto-changelog.mdc`](.cursor/rules/06-auto-changelog.mdc) | User-visible changes — update `CHANGELOG.md` |
+| [`07-env-example.mdc`](.cursor/rules/07-env-example.mdc) | New/changed `MATRYCA_*` env vars |
+| [`08-github-workflow-standards.mdc`](.cursor/rules/08-github-workflow-standards.mdc) | GitHub issues/PRs (on request) |
+| [`09-github-identity-marco-porcellato.mdc`](.cursor/rules/09-github-identity-marco-porcellato.mdc) | GitHub actions as maintainer |
+| [`10-tooling-static-analysis-policy.mdc`](.cursor/rules/10-tooling-static-analysis-policy.mdc) | Public docs / CI — vendor-agnostic tooling |
+
+## Runtime agent surfaces
+
+- **Distribution quickstart:** [`llms.txt`](llms.txt) and [`.well-known/llms.txt`](.well-known/llms.txt) (byte-identical)
+- **Cognitive law (Tier-2 vault agents):** [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) — LLM OS, MCP tools, Safe-Sync
+- **OpenSpec maintainer specs:** [`docs/openspec/agent-onboarding.md`](docs/openspec/agent-onboarding.md)
+
+## Verification before merge
+
+```bash
+make agents-check          # AGENTS.md paths, llms byte-identity, rule index
+make build-system-prompt   # after editing docs/openspec/agent/ fragments
+make check-system-prompt   # fragment build-hash vs SYSTEM_PROMPT.md
+make check                 # full local gate
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **L0 write safety** — `src/graph/safety/validators.py` (`reject_id_line_deletion`, `reject_protected_zones_modification`) invoked before semantic index commits; `tests/test_safety_validators.py`.
+- **Agent instruction router** — root [`AGENTS.md`](AGENTS.md) maps Cursor vs runtime vault audiences; `make agents-check` / `scripts/check_agents_coherence.py` guard path drift, `llms.txt` byte-identity, and `SYSTEM_PROMPT.md` citation.
 - **Paradigm SSOT** — [`docs/openspec/logseq-paradigm.md`](docs/openspec/logseq-paradigm.md) → [`docs/openspec/agent/paradigm.md`](docs/openspec/agent/paradigm.md).
 - **`SYSTEM_PROMPT.md` assembly** — [`docs/openspec/agent/`](docs/openspec/agent/) fragments, `make build-system-prompt`, `make check-system-prompt` (fragment `build-hash` in generated banner); Soft Gate decision tree in `soft-gate.md`.
 - **Assembly guard** — `build_system_prompt.py` fails when `docs/openspec/agent/*.md` exists but is missing from `_assembly_order.txt`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NUM_WORKERS ?= 4
 
-.PHONY: help install format lint typecheck test test-full test-fast test-fast-parallel test-integration test-resilience check clean version-check build-system-prompt check-system-prompt provision-local reindex-graph
+.PHONY: help install format lint typecheck test test-full test-fast test-fast-parallel test-integration test-resilience check clean version-check agents-check build-system-prompt check-system-prompt provision-local reindex-graph
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -23,6 +23,9 @@ sandbox-read-check: ## Ensure graph reads use read_graph_file_text (v1.9.9 secur
 
 version-check: ## Fail if llms.txt version headers drift from pyproject.toml
 	uv run python scripts/check_version_consistency.py
+
+agents-check: ## Fail if AGENTS.md coherence, llms byte-identity, or doc paths drift
+	uv run python scripts/check_agents_coherence.py
 
 build-system-prompt: ## Assemble SYSTEM_PROMPT.md from docs/openspec/agent/ fragments
 	uv run python scripts/build_system_prompt.py
@@ -54,9 +57,9 @@ perf: ## Run slow performance/memory tests (no coverage gate)
 format-check: ## Verify formatting without modifying files
 	uv run ruff format --check .
 
-check: lint typecheck sandbox-read-check version-check check-system-prompt test ## Run linting, typechecking, sandbox read gate, version sync, system prompt hash, and tests
+check: lint typecheck sandbox-read-check version-check agents-check check-system-prompt test ## Run linting, typechecking, sandbox read gate, version sync, agents router, system prompt hash, and tests
 
-ci: format-check lint typecheck sandbox-read-check version-check check-system-prompt test ## CI gate: format + lint + types + sandbox + version + system prompt + tests
+ci: format-check lint typecheck sandbox-read-check version-check agents-check check-system-prompt test ## CI gate: format + lint + types + sandbox + version + agents + system prompt + tests
 
 provision-local: ## Scaffold .local/ graph indexer (requires LOCAL_GRAPH_ANALYZER_NPM_PACKAGE)
 	@bash scripts/provision-local-workspace.sh

--- a/docs/openspec/agent-onboarding.md
+++ b/docs/openspec/agent-onboarding.md
@@ -1,6 +1,6 @@
-# Agent onboarding (`llms.txt`) — v1.9.11
+# Agent onboarding (`llms.txt`) — v1.11.2
 
-**Milestone:** v1.9.2 — Agent-zero-friction distribution · v1.9.5 — LLM OS / `bootstrap_status` · v1.9.6 — Hermes lazy AST · v1.9.7 — AX robustness · v1.9.8 — doc harmonization · v1.9.9 — Security & Sandbox · v1.9.10 — Sovereign UI fast startup + `status` vs `start` docs · v1.9.11 — Sovereign UI reliability (lazy bootstrap on save/start/L1)  
+**Milestone:** v1.9.2 — Agent-zero-friction distribution · v1.9.5 — LLM OS / `bootstrap_status` · v1.9.6 — Hermes lazy AST · v1.9.7 — AX robustness · v1.9.8 — doc harmonization · v1.9.9 — Security & Sandbox · v1.9.10 — Sovereign UI fast startup + `status` vs `start` docs · v1.9.11 — Sovereign UI reliability (lazy bootstrap on save/start/L1) · v1.11.x — Tana import, graph layer boundary refactor  
 **Artifacts:** [`llms.txt`](../../llms.txt) (repo root), [`.well-known/llms.txt`](../../.well-known/llms.txt) (canonical URL path)  
 **Companion specs:** [`agent-dx.md`](agent-dx.md) (CLI `--json`, `context load`, Journey Log) · [`agent-ax-robustness.md`](agent-ax-robustness.md) (lenient page titles, safe writes) · [`security-sandbox.md`](security-sandbox.md) (path sandbox, bounded JSON, CI read gate)
 

--- a/scripts/check_agents_coherence.py
+++ b/scripts/check_agents_coherence.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail CI when AGENTS.md router, llms.txt mirrors, or doc paths drift."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Paths that AGENTS.md must cite and that must exist on disk.
+REQUIRED_DOC_PATHS: tuple[str, ...] = (
+    "AGENTS.md",
+    "SYSTEM_PROMPT.md",
+    "llms.txt",
+    ".well-known/llms.txt",
+    "CONTRIBUTING.md",
+    "docs/openspec/agent-onboarding.md",
+    "docs/openspec/agent/_assembly_order.txt",
+    "docs/openspec/agent/paradigm.md",
+    "docs/openspec/llm-performance.md",
+    "docs/openspec/logseq-paradigm.md",
+)
+
+CURSOR_RULES_DIR = ROOT / ".cursor" / "rules"
+
+# Rules intentionally omitted from AGENTS.md index (with documented reason).
+RULE_EXCLUSIONS: dict[str, str] = {}
+
+
+def pyproject_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if match is None:
+        msg = "Could not parse version from pyproject.toml"
+        raise SystemExit(msg)
+    return match.group(1)
+
+
+def _fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def check_agents_file_exists() -> str:
+    agents_path = ROOT / "AGENTS.md"
+    if not agents_path.is_file():
+        _fail("AGENTS.md is missing at repository root")
+    return agents_path.read_text(encoding="utf-8")
+
+
+def check_system_prompt_cited(agents_text: str) -> None:
+    if "SYSTEM_PROMPT.md" not in agents_text:
+        _fail("AGENTS.md must explicitly cite SYSTEM_PROMPT.md")
+
+
+def check_required_paths_exist() -> None:
+    for rel in REQUIRED_DOC_PATHS:
+        path = ROOT / rel
+        if not path.is_file():
+            _fail(f"Required path missing: {rel}")
+
+
+def check_llms_byte_identity() -> None:
+    left = ROOT / "llms.txt"
+    right = ROOT / ".well-known" / "llms.txt"
+    if left.read_bytes() != right.read_bytes():
+        left_hash = hashlib.sha256(left.read_bytes()).hexdigest()
+        right_hash = hashlib.sha256(right.read_bytes()).hexdigest()
+        _fail(
+            "llms.txt and .well-known/llms.txt are not byte-identical "
+            f"(sha256 {left_hash} vs {right_hash})"
+        )
+
+
+def check_agent_onboarding_version(version: str) -> None:
+    path = ROOT / "docs" / "openspec" / "agent-onboarding.md"
+    first_line = path.read_text(encoding="utf-8").splitlines()[0]
+    expected = f"v{version}"
+    if expected not in first_line:
+        _fail(
+            f"docs/openspec/agent-onboarding.md header must reference {expected!r}, "
+            f"got: {first_line!r}"
+        )
+
+
+def check_cursor_rules_indexed(agents_text: str) -> None:
+    if not CURSOR_RULES_DIR.is_dir():
+        _fail(f"Missing Cursor rules directory: {CURSOR_RULES_DIR.relative_to(ROOT)}")
+    for rule_path in sorted(CURSOR_RULES_DIR.glob("*.mdc")):
+        name = rule_path.name
+        if name in RULE_EXCLUSIONS:
+            continue
+        if name not in agents_text and name.replace(".mdc", "") not in agents_text:
+            _fail(
+                f"AGENTS.md must reference Cursor rule {name} "
+                f"(or add to RULE_EXCLUSIONS in check_agents_coherence.py)"
+            )
+
+
+def main() -> None:
+    agents_text = check_agents_file_exists()
+    check_system_prompt_cited(agents_text)
+    check_required_paths_exist()
+    check_llms_byte_identity()
+    version = pyproject_version()
+    check_agent_onboarding_version(version)
+    check_cursor_rules_indexed(agents_text)
+    print("agents coherence OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agents_coherence.py
+++ b/tests/test_agents_coherence.py
@@ -1,0 +1,20 @@
+"""Tests for scripts/check_agents_coherence.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agents_coherence_script_exits_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_agents_coherence.py")],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
Adds `AGENTS.md`, `scripts/check_agents_coherence.py`, `docs/openspec/logseq-paradigm.md`, `.cursorrules` index.

## Test plan

- [x] `make agents-check`
- [x] `uv run pytest tests/test_agents_coherence.py -q`
- [x] `make check`

Made with [Cursor](https://cursor.com)