### PR TITLE
refactor(prompts): Tier-1A/1B domain builders, DI on InstructorLLMClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 - **L0 write safety** — `src/graph/safety/validators.py` (`reject_id_line_deletion`, `reject_protected_zones_modification`) invoked before semantic index commits; `tests/test_safety_validators.py`.
 - **Agent instruction router** — root [`AGENTS.md`](AGENTS.md) maps Cursor vs runtime vault audiences; `make agents-check` / `scripts/check_agents_coherence.py` guard path drift, `llms.txt` byte-identity, and `SYSTEM_PROMPT.md` citation.
+- **Tier-1 prompt architecture** — `src/agent/prompts/core.py` (`SystemPromptBuilder`, Tier-1A/B templates); domain builders under `semantic_lint/`, `bootstrap/`, `compression/`, `plumber_modules/marpa/`, `plumber_modules/llm_prompts/`, `graph/insights/`; constructor injection on `InstructorLLMClient`.
 - **Paradigm SSOT** — [`docs/openspec/logseq-paradigm.md`](docs/openspec/logseq-paradigm.md) → [`docs/openspec/agent/paradigm.md`](docs/openspec/agent/paradigm.md).
 - **`SYSTEM_PROMPT.md` assembly** — [`docs/openspec/agent/`](docs/openspec/agent/) fragments, `make build-system-prompt`, `make check-system-prompt` (fragment `build-hash` in generated banner); Soft Gate decision tree in `soft-gate.md`.
+- **Prompt hash snapshots** — `tests/prompt_hash_snapshots.json` + `pytest tests/test_daemon_prompts.py --update-prompt-hashes`; `tests/test_llm_client_prompt_injection.py` verifies DI on `InstructorLLMClient`.
 - **Assembly guard** — `build_system_prompt.py` fails when `docs/openspec/agent/*.md` exists but is missing from `_assembly_order.txt`.
+
+### Changed
+
+- **Semantic lint prompt** — rule (6) dead-zone invariant; harvest/insights prompts aligned to cross-lingual output (no English-only hardcoding).
 
 ## [1.11.2] - 2026-06-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,18 @@ Matryca Plumber enforces **`[tool.mypy] strict = true`** on `src/` and `tests/` 
 
 Verification: `uv run mypy src tests` (also run via `make typecheck` / `make check`).
 
+### Tier-1 daemon prompt hashes
+
+`tests/test_daemon_prompts.py` pins **SHA-256** snapshots of each Tier-1 **system prompt** in [`tests/prompt_hash_snapshots.json`](tests/prompt_hash_snapshots.json) (budget/substring asserts run in the same file).
+
+**If you intentionally change a builder:**
+
+```bash
+uv run pytest tests/test_daemon_prompts.py --update-prompt-hashes
+git add tests/prompt_hash_snapshots.json
+# commit message: prompt(builder-name): <why the contract changed>
+```
+
 ### `SYSTEM_PROMPT.md` assembly
 
 Runtime cognitive law is assembled from [`docs/openspec/agent/`](docs/openspec/agent/) fragments — **do not edit** [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) by hand.

--- a/docs/openspec/llm-performance.md
+++ b/docs/openspec/llm-performance.md
@@ -30,10 +30,20 @@ Every local LLM call that reads page text should follow:
 
 | Module | Role |
 |--------|------|
+| [`prompts/core.py`](../../src/agent/prompts/core.py) | `SystemPromptBuilder` protocol, Tier-1A/B compile helpers (domain builders import **only** this module) |
+| [`semantic_lint/prompts.py`](../../src/agent/semantic_lint/prompts.py) | Tier-1A semantic lint compiler (rules 1–6) |
+| [`bootstrap/prompts.py`](../../src/agent/bootstrap/prompts.py) | Tier-1A harvest summaries |
+| [`plumber_modules/marpa/prompts.py`](../../src/agent/plumber_modules/marpa/prompts.py) | Tier-1A MARPA classify |
+| [`plumber_modules/llm_prompts/`](../../src/agent/plumber_modules/llm_prompts/) | Tier-1A entity/seed/tag prompts |
+| [`compression/prompts.py`](../../src/agent/compression/prompts.py) | Tier-1B session compression |
+| [`graph/insights/prompts.py`](../../src/graph/insights/prompts.py) | Tier-1A `GraphInsightsLLMResult` |
+| [`graph/safety/validators.py`](../../src/graph/safety/validators.py) | L0 hard rejection before LLM-backed disk writes |
 | [`prompt_layout.py`](../../src/agent/prompt_layout.py) | `build_cache_aligned_prompt(content, task_instruction)` |
-| [`semantic_lint_prompts.py`](../../src/agent/semantic_lint_prompts.py) | `build_semantic_lint_system_prompt()` — shared across index + cognitive pipeline |
+| [`semantic_lint_prompts.py`](../../src/agent/semantic_lint_prompts.py) | Deprecated re-export → `semantic_lint.prompts` |
 | [`page_prompt_session.py`](../../src/agent/page_prompt_session.py) | One `PagePromptSession` per file per daemon cycle |
-| [`llm_context_payload.py`](../../src/agent/llm_context_payload.py) | Shrinks giant pages to Phase 1 summary / skeleton before they enter the stable block |
+| [`llm_context_payload.py`](../../src/agent/llm_context_payload.py) | Shrinks giant pages before they enter the stable block |
+
+**Maintainer checklist:** new cognitive module → add domain `prompts.py` builder + extend `tests/test_daemon_prompts.py` (system prompt only, no SHA256 snapshots).
 
 ### Per-page session lifecycle
 

--- a/src/agent/bootstrap/__init__.py
+++ b/src/agent/bootstrap/__init__.py
@@ -1,0 +1,5 @@
+"""Bootstrap prompt builders."""
+
+from .prompts import HarvestPromptBuilder, build_harvest_system_prompt
+
+__all__ = ["HarvestPromptBuilder", "build_harvest_system_prompt"]

--- a/src/agent/bootstrap/prompts.py
+++ b/src/agent/bootstrap/prompts.py
@@ -1,0 +1,43 @@
+"""Bootstrap harvest system prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..prompts.core import PromptContext, compile_tier1a_prompt
+
+
+@dataclass(frozen=True, slots=True)
+class HarvestPromptBuilder:
+    """Tier-1A compiler prompt for Phase-1 catalog summaries."""
+
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role="You are Matryca Plumber's bootstrap harvester for Logseq OG.",
+            invariants=(
+                "Write one crisp sentence summarizing the page in the same language "
+                "as the content.",
+                "suggested_tags: 0-5 tags when clearly inferable.",
+                "Optional MARPA domain only when clearly inferable: "
+                "mappa|area|risorsa|progetto|archivio.",
+            ),
+            output=(
+                "Return JSON only matching BootstrapSummaryResult. "
+                "Fields: summary, suggested_tags, domain."
+            ),
+            abort=(
+                "If the page body is empty or unreadable, return an empty summary "
+                "and omit domain."
+            ),
+            ctx=ctx,
+        )
+
+
+def build_harvest_system_prompt() -> str:
+    return HarvestPromptBuilder().build()
+
+
+__all__ = ["HarvestPromptBuilder", "build_harvest_system_prompt"]

--- a/src/agent/compression/__init__.py
+++ b/src/agent/compression/__init__.py
@@ -1,0 +1,5 @@
+"""Compression prompt builders."""
+
+from .prompts import CompressionPromptBuilder, build_compression_system_prompt
+
+__all__ = ["CompressionPromptBuilder", "build_compression_system_prompt"]

--- a/src/agent/compression/prompts.py
+++ b/src/agent/compression/prompts.py
@@ -1,0 +1,39 @@
+"""Context compression system prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..prompts.core import PromptContext, compile_tier1b_prompt
+
+
+@dataclass(frozen=True, slots=True)
+class CompressionPromptBuilder:
+    """Tier-1B writer prompt for epistemic session condensation."""
+
+    tier: Literal["1B"] = "1B"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1b_prompt(
+            role="You are Matryca Plumber Context Compressor.",
+            goal=(
+                "Condense maintenance-session history into dense markdown titled "
+                "'## Consolidated Epistemic State'."
+            ),
+            style=(
+                "Use bullet lists and short headings. Preserve page titles processed, "
+                "MARPA domains assigned, lint corrections applied, entity merges, dangling "
+                "links healed, block UUIDs referenced, errors/skips, and open tasks. "
+                "Omit filler."
+            ),
+            guardrails="Output markdown only. Do not prescribe destructive graph edits.",
+            ctx=ctx,
+        )
+
+
+def build_compression_system_prompt() -> str:
+    return CompressionPromptBuilder().build()
+
+
+__all__ = ["CompressionPromptBuilder", "build_compression_system_prompt"]

--- a/src/agent/context_compressor.py
+++ b/src/agent/context_compressor.py
@@ -11,7 +11,7 @@ from typing import Literal, TypedDict
 from loguru import logger
 
 from ..utils.json_repair import sanitize_prose_llm_completion
-from .prompt_constraints import finalize_system_prompt
+from .compression.prompts import build_compression_system_prompt
 
 _CJK_RE = re.compile(r"[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff]")
 _MESSAGE_OVERHEAD_TOKENS = 4
@@ -20,15 +20,7 @@ _PRESERVE_TAIL_TURNS = 2
 TOKEN_ESTIMATE_SAFETY_MULTIPLIER = 1.12
 MAX_EXECUTION_HISTORY_MESSAGES = 48
 
-_COMPRESSION_SYSTEM_INSTRUCTIONS = (
-    "You are Matryca Plumber Context Compressor. Condense maintenance-session history "
-    "into dense markdown titled '## Consolidated Epistemic State'. Preserve: page titles "
-    "processed, MARPA domains assigned, lint corrections applied, entity merges, dangling "
-    "links healed, block UUIDs referenced, errors/skips, and open tasks. "
-    "Use bullet lists and short headings. Omit filler. Output markdown only."
-)
-
-COMPRESSION_SYSTEM_PROMPT = finalize_system_prompt(_COMPRESSION_SYSTEM_INSTRUCTIONS)
+COMPRESSION_SYSTEM_PROMPT = build_compression_system_prompt()
 
 
 class ChatMessage(TypedDict):

--- a/src/agent/llm_client.py
+++ b/src/agent/llm_client.py
@@ -20,7 +20,7 @@ from openai.lib._pydantic import to_strict_json_schema as _openai_to_strict_json
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ..daemon.config_layer import inject_identity_into_system_prompt
-from ..graph.insights_engine import INSIGHTS_SYSTEM_PROMPT
+from ..graph.insights.prompts import InsightsPromptBuilder
 from ..utils.agent_debug_log import agent_debug_log, completion_usage_tokens
 from ..utils.json_repair import (
     collapse_all_degenerate_llm_runs,
@@ -31,8 +31,9 @@ from ..utils.json_repair import (
     sanitize_prose_llm_completion,
 )
 from ..utils.token_logger import OperationType, TokenLogger
+from .bootstrap.prompts import HarvestPromptBuilder
+from .compression.prompts import CompressionPromptBuilder
 from .context_compressor import (
-    COMPRESSION_SYSTEM_PROMPT,
     MAX_EXECUTION_HISTORY_MESSAGES,
     ChatMessage,
     condense_messages,
@@ -58,18 +59,22 @@ from .plumber_llm import (
     InferredPropertiesResult,
     MarpaClassificationResult,
 )
-from .plumber_modules.marpa_framework import (
-    build_marpa_classify_system_prompt,
-    build_marpa_classify_user_prompt,
+from .plumber_modules.llm_prompts import (
+    ContextualSeedPromptBuilder,
+    EntityOverlapPromptBuilder,
+    TagPropertiesPromptBuilder,
 )
+from .plumber_modules.marpa.prompts import MarpaClassifyPromptBuilder
+from .plumber_modules.marpa_framework import build_marpa_classify_user_prompt
 from .plumber_modules.semantic_cache_router import (
     cache_get,
     cache_put,
     semantic_cache_key,
     validate_cached_model,
 )
-from .prompt_constraints import finalize_system_prompt
 from .prompt_layout import build_cache_aligned_prompt
+from .prompts.core import SystemPromptBuilder
+from .semantic_lint.prompts import SemanticLintPromptBuilder
 
 _LLM_HTTP_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=5.0, pool=5.0)
 
@@ -607,11 +612,27 @@ class InstructorLLMClient:
         model: str | None = None,
         api_key: str | None = None,
         token_logger: TokenLogger | None = None,
+        semantic_lint_builder: SystemPromptBuilder | None = None,
+        marpa_builder: SystemPromptBuilder | None = None,
+        harvest_builder: SystemPromptBuilder | None = None,
+        contextual_seed_builder: SystemPromptBuilder | None = None,
+        entity_overlap_builder: SystemPromptBuilder | None = None,
+        tag_properties_builder: SystemPromptBuilder | None = None,
+        compression_builder: SystemPromptBuilder | None = None,
+        insights_builder: SystemPromptBuilder | None = None,
     ) -> None:
         self.token_logger = token_logger or TokenLogger()
         self._explicit_model = model
         self._explicit_base_url = base_url
         self._explicit_api_key = api_key
+        self._semantic_lint_builder = semantic_lint_builder or SemanticLintPromptBuilder()
+        self._marpa_builder = marpa_builder or MarpaClassifyPromptBuilder()
+        self._harvest_builder = harvest_builder or HarvestPromptBuilder()
+        self._contextual_seed_builder = contextual_seed_builder or ContextualSeedPromptBuilder()
+        self._entity_overlap_builder = entity_overlap_builder or EntityOverlapPromptBuilder()
+        self._tag_properties_builder = tag_properties_builder or TagPropertiesPromptBuilder()
+        self._compression_builder = compression_builder or CompressionPromptBuilder()
+        self._insights_builder = insights_builder or InsightsPromptBuilder()
         self.base_url = resolve_validated_llm_base_url(override=base_url)
         self.model = resolve_llm_model_name(override=model)
         self.api_key = resolve_llm_api_key(override=api_key)
@@ -762,7 +783,7 @@ class InstructorLLMClient:
 
     def _compress_history_via_llm(self, compression_prompt: str) -> str:
         started = time.perf_counter()
-        compression_system = inject_identity_into_system_prompt(COMPRESSION_SYSTEM_PROMPT)
+        compression_system = inject_identity_into_system_prompt(self._compression_builder.build())
         response = call_openai_with_transport_retries(
             lambda: self._raw_client.chat.completions.create(
                 model=self.model,
@@ -929,10 +950,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=ContextualSeedResult,
-            system_prompt=finalize_system_prompt(
-                "You seed new Logseq pages from local context. Return JSON only. "
-                "Write a neutral, concise definition without markdown headings."
-            ),
+            system_prompt=self._contextual_seed_builder.build(),
             stateless=True,
             telemetry_target=source_page,
             telemetry_operation="Semantic Linting",
@@ -957,10 +975,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=EntityOverlapResult,
-            system_prompt=finalize_system_prompt(
-                "You are an entity consolidation linter for Logseq. Prefer one canonical title "
-                "and register the other as alias. Never suggest merging file contents."
-            ),
+            system_prompt=self._entity_overlap_builder.build(),
             stateless=True,
             telemetry_target=title_a,
             telemetry_operation="Semantic Linting",
@@ -988,10 +1003,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=InferredPropertiesResult,
-            system_prompt=finalize_system_prompt(
-                "Infer Logseq block properties from context. Use empty string when unknown. "
-                "Return JSON with a properties object."
-            ),
+            system_prompt=self._tag_properties_builder.build(),
             stateless=True,
             telemetry_target=page_title,
             telemetry_operation="Semantic Linting",
@@ -1030,7 +1042,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=MarpaClassificationResult,
-            system_prompt=build_marpa_classify_system_prompt(),
+            system_prompt=self._marpa_builder.build(),
             stateless=True,
             telemetry_target=page_title,
             telemetry_operation="Semantic Linting",
@@ -1062,10 +1074,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=BootstrapSummaryResult,
-            system_prompt=finalize_system_prompt(
-                "You are Matryca Plumber's bootstrap harvester. Return JSON only. "
-                "Write one crisp English sentence summarizing the page."
-            ),
+            system_prompt=self._harvest_builder.build(),
             stateless=True,
             telemetry_target=page_title,
             telemetry_operation="Concept Indexing",
@@ -1088,7 +1097,7 @@ class InstructorLLMClient:
         result, _ = self._completion_with_structured_output(
             prompt=prompt,
             response_model=GraphInsightsLLMResult,
-            system_prompt=INSIGHTS_SYSTEM_PROMPT,
+            system_prompt=self._insights_builder.build(),
             stateless=True,
             telemetry_target=str(graph_root),
             telemetry_operation="Concept Indexing",

--- a/src/agent/plumber_modules/llm_prompts/__init__.py
+++ b/src/agent/plumber_modules/llm_prompts/__init__.py
@@ -1,0 +1,81 @@
+"""LLM task system prompts for plumber cognitive modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...prompts.core import PromptContext, compile_tier1a_prompt
+
+
+@dataclass(frozen=True, slots=True)
+class ContextualSeedPromptBuilder:
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role="You seed new Logseq pages from local context.",
+            invariants=(
+                "Write a neutral, concise definition without markdown headings.",
+                "Do not invent facts absent from the supplied context.",
+            ),
+            output="Return JSON only matching ContextualSeedResult.",
+            abort="If context is insufficient, return a minimal neutral stub definition.",
+            ctx=ctx,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EntityOverlapPromptBuilder:
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role="You are an entity consolidation linter for Logseq.",
+            invariants=(
+                "Prefer one canonical title and register the other as alias.",
+                "Never suggest merging file contents or deleting pages.",
+            ),
+            output="Return JSON only matching EntityOverlapResult.",
+            abort="If overlap is unclear, prefer keeping titles separate.",
+            ctx=ctx,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TagPropertiesPromptBuilder:
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role="You infer Logseq block properties from page context.",
+            invariants=(
+                "Use empty string for unknown property values.",
+                "Only emit keys requested in the task instruction.",
+            ),
+            output="Return JSON only matching InferredPropertiesResult with a properties object.",
+            abort="If a key cannot be inferred, set it to an empty string.",
+            ctx=ctx,
+        )
+
+
+def build_contextual_seed_system_prompt() -> str:
+    return ContextualSeedPromptBuilder().build()
+
+
+def build_entity_overlap_system_prompt() -> str:
+    return EntityOverlapPromptBuilder().build()
+
+
+def build_tag_properties_system_prompt() -> str:
+    return TagPropertiesPromptBuilder().build()
+
+
+__all__ = [
+    "ContextualSeedPromptBuilder",
+    "EntityOverlapPromptBuilder",
+    "TagPropertiesPromptBuilder",
+    "build_contextual_seed_system_prompt",
+    "build_entity_overlap_system_prompt",
+    "build_tag_properties_system_prompt",
+]

--- a/src/agent/plumber_modules/marpa/__init__.py
+++ b/src/agent/plumber_modules/marpa/__init__.py
@@ -1,0 +1,5 @@
+"""MARPA cognitive framework prompts."""
+
+from .prompts import MarpaClassifyPromptBuilder, build_marpa_classify_system_prompt
+
+__all__ = ["MarpaClassifyPromptBuilder", "build_marpa_classify_system_prompt"]

--- a/src/agent/plumber_modules/marpa/prompts.py
+++ b/src/agent/plumber_modules/marpa/prompts.py
@@ -1,0 +1,39 @@
+"""MARPA classification system prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...prompts.core import PromptContext, compile_tier1a_prompt
+
+
+@dataclass(frozen=True, slots=True)
+class MarpaClassifyPromptBuilder:
+    """Tier-1A compiler prompt for MARPA domain classification."""
+
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role="You are the MARPA semantic taxonomy compiler for Logseq OG.",
+            invariants=(
+                "Assign exactly one domain from the user-provided catalog.",
+                "Populate inferred_properties for missing structural fields "
+                "(deadline, status, owner).",
+                "Use standardized Logseq property keys; leave values empty when unknown.",
+            ),
+            output="Return JSON only matching MarpaClassificationResult.",
+            abort=(
+                "If the page content is blank, assign archivio only when clearly dormant; "
+                "otherwise omit domain."
+            ),
+            ctx=ctx,
+        )
+
+
+def build_marpa_classify_system_prompt() -> str:
+    return MarpaClassifyPromptBuilder().build()
+
+
+__all__ = ["MarpaClassifyPromptBuilder", "build_marpa_classify_system_prompt"]

--- a/src/agent/plumber_modules/marpa_framework.py
+++ b/src/agent/plumber_modules/marpa_framework.py
@@ -19,9 +19,9 @@ from ...graph.page_properties import inject_page_properties, page_property_keys
 from ...graph.page_write_lock import page_rmw_lock
 from ...graph.path_sandbox import read_graph_file_text, resolved_graph_root
 from ..plumber_llm import MarpaClassificationResult
-from ..prompt_constraints import finalize_system_prompt
 from ..prompt_layout import build_cache_aligned_prompt
 from ._shared import ModuleOutcome, is_blank_page_content
+from .marpa.prompts import build_marpa_classify_system_prompt
 
 MarpaDomain = Literal["mappa", "area", "risorsa", "progetto", "archivio"]
 
@@ -37,18 +37,6 @@ MARPA_DOMAIN_DEFINITIONS = (
     "- archivio: Closed or dormant node — completed, cancelled, or superseded material removed "
     "from active planning surfaces."
 )
-
-_MARPA_CLASSIFY_SYSTEM_INSTRUCTIONS = (
-    "You are the MARPA semantic taxonomy compiler for Logseq OG. Return JSON only. "
-    "Assign exactly one domain from the user-provided catalog. "
-    "Populate inferred_properties for missing structural fields (deadline, status, owner). "
-    "Use standardized Logseq property keys; leave values empty when unknown."
-)
-
-
-def build_marpa_classify_system_prompt() -> str:
-    """System prompt for MARPA domain classification (English instructions, multilingual output)."""
-    return finalize_system_prompt(_MARPA_CLASSIFY_SYSTEM_INSTRUCTIONS)
 
 
 def build_marpa_classify_user_prompt(

--- a/src/agent/prompts/__init__.py
+++ b/src/agent/prompts/__init__.py
@@ -1,0 +1,15 @@
+"""Prompt assembly layer for Tier-1 daemon LLM calls."""
+
+from .core import (
+    PromptContext,
+    SystemPromptBuilder,
+    compile_tier1a_prompt,
+    compile_tier1b_prompt,
+)
+
+__all__ = [
+    "PromptContext",
+    "SystemPromptBuilder",
+    "compile_tier1a_prompt",
+    "compile_tier1b_prompt",
+]

--- a/src/agent/prompts/core.py
+++ b/src/agent/prompts/core.py
@@ -1,0 +1,81 @@
+"""Prompt assembly contracts (Application layer) — domain builders import only this module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from ..prompt_constraints import ALIAS_FIRST_LINK_CONSTRAINT, finalize_system_prompt
+
+__all__ = [
+    "ALIAS_FIRST_LINK_CONSTRAINT",
+    "PromptContext",
+    "SystemPromptBuilder",
+    "compile_tier1a_prompt",
+    "compile_tier1b_prompt",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PromptContext:
+    """Variable knobs for system prompt assembly (stable across per-page KV prefix)."""
+
+    output_language: str | None = None
+    require_json: bool = False
+    schema_name: str | None = None
+    extra_constraints: tuple[str, ...] = ()
+
+
+def _resolve_ctx(ctx: PromptContext | None) -> PromptContext:
+    return PromptContext() if ctx is None else ctx
+
+
+class SystemPromptBuilder(Protocol):
+    """Contract for Tier-1 daemon system prompt builders."""
+
+    tier: Literal["1A", "1B"]
+
+    def build(self, ctx: PromptContext | None = None) -> str: ...
+
+
+def compile_tier1a_prompt(
+    *,
+    role: str,
+    invariants: tuple[str, ...],
+    output: str,
+    abort: str,
+    ctx: PromptContext | None = None,
+    alias_first: bool = False,
+) -> str:
+    """Assemble a Tier-1A compiler system prompt and append cross-lingual tail."""
+    resolved = _resolve_ctx(ctx)
+    sections = [
+        role,
+        "[INVARIANTS]",
+        *invariants,
+        "[OUTPUT]",
+        output,
+        "[ABORT]",
+        abort,
+    ]
+    if alias_first:
+        sections.append(ALIAS_FIRST_LINK_CONSTRAINT)
+    for extra in resolved.extra_constraints:
+        sections.append(extra)
+    return finalize_system_prompt("\n".join(sections))
+
+
+def compile_tier1b_prompt(
+    *,
+    role: str,
+    goal: str,
+    style: str,
+    guardrails: str,
+    ctx: PromptContext | None = None,
+) -> str:
+    """Assemble a Tier-1B writer system prompt and append cross-lingual tail."""
+    resolved = _resolve_ctx(ctx)
+    sections = [role, "[GOAL]", goal, "[STYLE]", style, "[GUARDRAILS]", guardrails]
+    for extra in resolved.extra_constraints:
+        sections.append(extra)
+    return finalize_system_prompt("\n".join(sections))

--- a/src/agent/semantic_lint/__init__.py
+++ b/src/agent/semantic_lint/__init__.py
@@ -1,0 +1,5 @@
+"""Semantic lint prompt builders."""
+
+from .prompts import SemanticLintPromptBuilder, build_semantic_lint_system_prompt
+
+__all__ = ["SemanticLintPromptBuilder", "build_semantic_lint_system_prompt"]

--- a/src/agent/semantic_lint/prompts.py
+++ b/src/agent/semantic_lint/prompts.py
@@ -1,0 +1,65 @@
+"""Semantic lint / index system prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..prompts.core import PromptContext, compile_tier1a_prompt
+
+_SEMANTIC_LINT_INVARIANTS = (
+    "(1) block_uuid must match an id:: line from the page;",
+    "(2) original_text must copy the bullet-line text verbatim "
+    "(exclude id:: / property lines);",
+    "(3) corrected_text must preserve original_text unchanged "
+    "and only add [[WikiLinks]] or #tags;",
+    "(4) never delete, shorten, or paraphrase user prose;",
+    "(5) if unsure, omit the correction.",
+    "(6) never propose edits inside fenced code (```), HTML comments, "
+    "or #+BEGIN_QUERY … #+END_QUERY regions.",
+)
+
+_SEMANTIC_LINT_OUTPUT = (
+    "Return JSON only matching SemanticLintResult. "
+    "Fields: semantic_corrections, summary, cross_references, suggested_tags, moc_pointers. "
+    "lint_type auto_wikilink: wrap recognizable concepts in [[Page Title]] links. "
+    "lint_type tag_hygiene: normalize inline #tags without removing words. "
+    "lint_type anomaly_warning: flag issues only — set corrected_text equal to original_text. "
+    "Resolve wikilinks using the AliasIndex section in the user message when present."
+)
+
+_SEMANTIC_LINT_ABORT = (
+    "If block_uuid is absent from the page catalog, omit that semantic_correction entirely."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticLintPromptBuilder:
+    """Tier-1A compiler prompt for semantic lint and indexing."""
+
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        return compile_tier1a_prompt(
+            role=(
+                "You are Matryca Plumber, a semantic linter and indexer for Logseq OG "
+                "outliner pages. Behave like a strict compiler: analyze block-by-block, "
+                "propose only safe additive micro-corrections, never rewrite whole files."
+            ),
+            invariants=_SEMANTIC_LINT_INVARIANTS,
+            output=_SEMANTIC_LINT_OUTPUT,
+            abort=_SEMANTIC_LINT_ABORT,
+            ctx=ctx,
+            alias_first=True,
+        )
+
+
+_DEFAULT_BUILDER = SemanticLintPromptBuilder()
+
+
+def build_semantic_lint_system_prompt() -> str:
+    """Stable system prompt (alias map lives in the per-page user block for KV reuse)."""
+    return _DEFAULT_BUILDER.build()
+
+
+__all__ = ["SemanticLintPromptBuilder", "build_semantic_lint_system_prompt"]

--- a/src/agent/semantic_lint_prompts.py
+++ b/src/agent/semantic_lint_prompts.py
@@ -1,32 +1,13 @@
-"""Stable system prompts for semantic lint / indexing (KV-cache friendly)."""
+"""Stable system prompts for semantic lint / indexing (KV-cache friendly).
+
+Deprecated import path — use ``src.agent.semantic_lint.prompts`` directly.
+"""
 
 from __future__ import annotations
 
-from .prompt_constraints import ALIAS_FIRST_LINK_CONSTRAINT, finalize_system_prompt
+from .semantic_lint.prompts import (
+    SemanticLintPromptBuilder,
+    build_semantic_lint_system_prompt,
+)
 
-
-def build_semantic_lint_system_prompt() -> str:
-    """Stable system prompt (alias map lives in the per-page user block for KV reuse)."""
-    instructions = (
-        "You are Matryca Plumber, a semantic linter and indexer for Logseq OG outliner pages. "
-        "Behave like a strict compiler: analyze block-by-block, propose only safe additive "
-        "micro-corrections, never rewrite whole files. "
-        "Rules for semantic_corrections: "
-        "(1) block_uuid must match an id:: line from the page; "
-        "(2) original_text must copy the bullet-line text verbatim "
-        "(exclude id:: / property lines); "
-        "(3) corrected_text must preserve original_text unchanged "
-        "and only add [[WikiLinks]] or #tags; "
-        "(4) never delete, shorten, or paraphrase user prose; "
-        "(5) if unsure, omit the correction. "
-        "lint_type auto_wikilink: wrap recognizable concepts in [[Page Title]] links. "
-        "lint_type tag_hygiene: normalize inline #tags without removing words. "
-        "lint_type anomaly_warning: flag issues only — set corrected_text equal to original_text. "
-        "Also populate summary, cross_references, suggested_tags, and moc_pointers. "
-        "Resolve wikilinks using the AliasIndex section in the user message when present. "
-        f"{ALIAS_FIRST_LINK_CONSTRAINT}"
-    )
-    return finalize_system_prompt(instructions)
-
-
-__all__ = ["build_semantic_lint_system_prompt"]
+__all__ = ["SemanticLintPromptBuilder", "build_semantic_lint_system_prompt"]

--- a/src/graph/insights/__init__.py
+++ b/src/graph/insights/__init__.py
@@ -1,0 +1,5 @@
+"""Graph insights prompts."""
+
+from .prompts import InsightsPromptBuilder, build_insights_system_prompt
+
+__all__ = ["InsightsPromptBuilder", "build_insights_system_prompt"]

--- a/src/graph/insights/prompts.py
+++ b/src/graph/insights/prompts.py
@@ -1,0 +1,57 @@
+"""Graph Insights system prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...agent.prompts.core import PromptContext, compile_tier1a_prompt
+
+_JSON_TAIL = (
+    "NEVER GENERATE NESTED UNESCAPED QUOTES OR TRAILING GARBAGE CONTEXT. "
+    "TERMINATE THE JSON BLOCK CLEANLY IMMEDIATELY AFTER THE CLOSING OBJECT BRACKET. "
+    "Return valid JSON only — no markdown fences, no prose after the closing brace."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InsightsPromptBuilder:
+    """Tier-1A compiler prompt for GraphInsightsLLMResult (prose lives inside JSON fields)."""
+
+    tier: Literal["1A"] = "1A"
+
+    def build(self, ctx: PromptContext | None = None) -> str:
+        resolved = PromptContext() if ctx is None else ctx
+        extra = (_JSON_TAIL, *resolved.extra_constraints)
+        merged_ctx = PromptContext(
+            output_language=resolved.output_language,
+            require_json=True,
+            schema_name="GraphInsightsLLMResult",
+            extra_constraints=extra,
+        )
+        return compile_tier1a_prompt(
+            role="You are Matryca Plumber's Graph Insights Engine for Logseq OG.",
+            invariants=(
+                "Analyze structural topology metrics for a personal knowledge graph.",
+                "Surface hidden conceptual clusters, naming drift, and structural debt.",
+                "Cleanup suggestions must be non-destructive short actionable sentences.",
+                "Human-readable report fields must match the language of metric labels "
+                "when localized.",
+            ),
+            output=(
+                "Return JSON only matching GraphInsightsLLMResult. "
+                "Populate ontology_report and cleanup_suggestions as structured fields."
+            ),
+            abort=(
+                "If metrics JSON is empty, return an empty ontology_report and no "
+                "cleanup suggestions."
+            ),
+            ctx=merged_ctx,
+        )
+
+
+def build_insights_system_prompt() -> str:
+    return InsightsPromptBuilder().build()
+
+
+__all__ = ["InsightsPromptBuilder", "build_insights_system_prompt"]

--- a/src/graph/insights_engine.py
+++ b/src/graph/insights_engine.py
@@ -12,6 +12,7 @@ from .alias_index import iter_alias_source_paths, page_title_from_path
 from .cognitive_llm import GraphInsightsLLMResult, InsightsLLM
 from .generated_hub_write import write_generated_hub_page
 from .generational_cache import patch_generational_caches_for_paths
+from .insights.prompts import build_insights_system_prompt
 from .link_tag_hop import (
     _WIKILINK,
     _extract_inline_tags,
@@ -22,7 +23,6 @@ from .markdown_blocks import occ_snapshot
 from .master_catalog import MasterCatalog, load_master_catalog
 from .page_path import filename_to_page_title
 from .path_sandbox import graph_safe_page_path, read_graph_file_text
-from .prompt_constraints import finalize_system_prompt
 
 GRAPH_INSIGHTS_TITLE = "Matryca Graph Insights"
 _DENSE_WIKILINK_THRESHOLD = 25
@@ -413,20 +413,7 @@ def run_graph_insights_engine(
     )
 
 
-INSIGHTS_JSON_CONSTRAINT = (
-    "\n\n[CRITICAL JSON OUTPUT CONSTRAINT]\n"
-    "NEVER GENERATE NESTED UNESCAPED QUOTES OR TRAILING GARBAGE CONTEXT. "
-    "TERMINATE THE JSON BLOCK CLEANLY IMMEDIATELY AFTER THE CLOSING OBJECT BRACKET. "
-    "Return valid JSON only — no markdown fences, no prose after the closing brace."
-)
-
-INSIGHTS_SYSTEM_PROMPT = finalize_system_prompt(
-    "You are Matryca Plumber's Graph Insights Engine. Analyze structural topology metrics "
-    "for a personal Logseq knowledge graph. Write in clear, beautiful English prose. "
-    "Surface hidden conceptual clusters, naming drift, and structural debt without "
-    "prescribing destructive edits. Cleanup suggestions must be non-destructive and "
-    "formatted as short actionable sentences (no markdown bullets)." + INSIGHTS_JSON_CONSTRAINT
-)
+INSIGHTS_SYSTEM_PROMPT = build_insights_system_prompt()
 
 
 __all__ = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,23 @@ _THERMAL_DELAY_ENV_KEYS = (
 )
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--update-prompt-hashes",
+        action="store_true",
+        default=False,
+        help="Rewrite tests/prompt_hash_snapshots.json from current Tier-1 builders",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if config.getoption("--update-prompt-hashes", default=False):
+        from tests.test_daemon_prompts import update_prompt_hash_snapshots
+
+        update_prompt_hash_snapshots()
+        print("Updated tests/prompt_hash_snapshots.json")
+
+
 @pytest.fixture(autouse=True)
 def zero_thermal_delays_in_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Skip real thermal cool-down sleeps unless a test overrides these env vars."""

--- a/tests/prompt_hash_snapshots.json
+++ b/tests/prompt_hash_snapshots.json
@@ -1,0 +1,10 @@
+{
+  "semantic_lint": "3d37b1a437c73e1da0a807da4b5add48a4e19a21d3e6892865f32c2a9fc226f8",
+  "marpa_classify": "d0f8dd937c6dc4b2aa37afddb5a9cbf07b5337a29f4062212e9f27a1f4efffc4",
+  "contextual_seed": "c60b67dc3787fb638849fbfdbc07e0f0494f5afdea85d41727734f3ac51c1512",
+  "entity_overlap": "748be2f2622c18f268810b2be9a7a680235d15bdee34c08c8503fa4124cbc73a",
+  "tag_properties": "3a5836057ecd2ff1174091a4669da4b86e2a3345fc866d2db3a58f02ae1bfde4",
+  "harvest": "83cc85fd7271c5adc38c4cbd478b9fd968690bfca595c2ba6dab1e7bcdfabda7",
+  "insights": "07ee56687f8b845ae2d461e67e48a3e491b0bab0ec3f247ff393eb13f2f43427",
+  "compression": "d4ff5611c20c7a7e3cbd484fbb726323d48cea220a1563b19efade1620b1f0f4"
+}

--- a/tests/test_daemon_prompts.py
+++ b/tests/test_daemon_prompts.py
@@ -1,0 +1,183 @@
+"""Structural asserts for Tier-1 daemon system prompts (living tests).
+
+These tests capture the pre-refactor baseline and MUST be extended when new
+prompt invariants ship (e.g. semantic_lint rule (6) dead zones).
+
+Token budgets apply ONLY to ``builder.build()`` / system prompt strings —
+never to cache-aligned user blocks that include page content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from src.agent.bootstrap.prompts import build_harvest_system_prompt
+from src.agent.compression.prompts import build_compression_system_prompt
+from src.agent.plumber_modules.llm_prompts import (
+    build_contextual_seed_system_prompt,
+    build_entity_overlap_system_prompt,
+    build_tag_properties_system_prompt,
+)
+from src.agent.plumber_modules.marpa.prompts import build_marpa_classify_system_prompt
+from src.agent.semantic_lint.prompts import build_semantic_lint_system_prompt
+from src.graph.insights.prompts import build_insights_system_prompt
+
+_CROSS_LINGUAL_TAIL = "[CRITICAL LANGUAGE CONSTRAINT]"
+
+PROMPT_BUDGETS: dict[str, int] = {
+    "semantic_lint": 2500,
+    "marpa_classify": 2000,
+    "contextual_seed": 2000,
+    "entity_overlap": 2000,
+    "tag_properties": 2000,
+    "harvest": 2000,
+    "compression": 2000,
+    "insights": 2500,
+}
+
+TIER_1A_BUILDERS: dict[str, Callable[[], str]] = {
+    "semantic_lint": build_semantic_lint_system_prompt,
+    "marpa_classify": build_marpa_classify_system_prompt,
+    "contextual_seed": build_contextual_seed_system_prompt,
+    "entity_overlap": build_entity_overlap_system_prompt,
+    "tag_properties": build_tag_properties_system_prompt,
+    "harvest": build_harvest_system_prompt,
+    "insights": build_insights_system_prompt,
+}
+
+TIER_1B_BUILDERS: dict[str, Callable[[], str]] = {
+    "compression": build_compression_system_prompt,
+}
+
+REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
+    "semantic_lint": [
+        "block_uuid",
+        "id::",
+        "(5) if unsure, omit the correction",
+        "(6) never propose edits inside fenced code",
+        "[INVARIANTS]",
+        "[OUTPUT]",
+        _CROSS_LINGUAL_TAIL,
+    ],
+    "marpa_classify": ["Return JSON only", "[INVARIANTS]", _CROSS_LINGUAL_TAIL],
+    "contextual_seed": ["Return JSON only", "[INVARIANTS]", _CROSS_LINGUAL_TAIL],
+    "entity_overlap": ["[INVARIANTS]", _CROSS_LINGUAL_TAIL],
+    "tag_properties": ["Return JSON", "[INVARIANTS]", _CROSS_LINGUAL_TAIL],
+    "harvest": ["Return JSON only", "[INVARIANTS]", _CROSS_LINGUAL_TAIL],
+    "insights": ["Return JSON only", "GraphInsightsLLMResult", _CROSS_LINGUAL_TAIL],
+    "compression": ["[GOAL]", _CROSS_LINGUAL_TAIL],
+}
+
+FORBIDDEN_SUBSTRINGS: dict[str, list[str]] = {
+    "compression": ["return json only"],
+}
+
+GLOBAL_FORBIDDEN = ("english only", "write in english")
+
+_PROMPT_HASH_FILE = Path(__file__).resolve().parent / "prompt_hash_snapshots.json"
+_ALL_BUILDERS: dict[str, Callable[[], str]] = {**TIER_1A_BUILDERS, **TIER_1B_BUILDERS}
+
+
+def _load_known_prompt_hashes() -> dict[str, str]:
+    payload = json.loads(_PROMPT_HASH_FILE.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"{_PROMPT_HASH_FILE.name} must be a JSON object"
+        raise TypeError(msg)
+    return {str(k): str(v) for k, v in payload.items()}
+
+
+def _sha256_prompt(builder: Callable[[], str]) -> str:
+    return hashlib.sha256(builder().encode()).hexdigest()
+
+
+def update_prompt_hash_snapshots() -> None:
+    """Rewrite tests/prompt_hash_snapshots.json from current builders."""
+    known = {name: _sha256_prompt(builder) for name, builder in _ALL_BUILDERS.items()}
+    _PROMPT_HASH_FILE.write_text(
+        json.dumps(known, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("name,builder", list(TIER_1A_BUILDERS.items()))
+def test_tier1a_system_prompt_budget(name: str, builder: Callable[[], str]) -> None:
+    prompt = builder()
+    assert prompt.strip()
+    assert len(prompt) < PROMPT_BUDGETS[name], (
+        f"{name} system prompt length {len(prompt)} exceeds budget {PROMPT_BUDGETS[name]}"
+    )
+
+
+@pytest.mark.parametrize("name,builder", list(TIER_1B_BUILDERS.items()))
+def test_tier1b_system_prompt_budget(name: str, builder: Callable[[], str]) -> None:
+    prompt = builder()
+    assert prompt.strip()
+    assert len(prompt) < PROMPT_BUDGETS[name]
+
+
+@pytest.mark.parametrize("name,builder", list(TIER_1A_BUILDERS.items()))
+def test_tier1a_required_substrings(name: str, builder: Callable[[], str]) -> None:
+    prompt = builder()
+    lowered = prompt.lower()
+    for fragment in REQUIRED_SUBSTRINGS[name]:
+        assert fragment.lower() in lowered, f"{name}: missing required substring {fragment!r}"
+
+
+@pytest.mark.parametrize("name,builder", list({**TIER_1A_BUILDERS, **TIER_1B_BUILDERS}.items()))
+def test_no_english_only_hardcoding(name: str, builder: Callable[[], str]) -> None:
+    lowered = builder().lower()
+    for forbidden in GLOBAL_FORBIDDEN:
+        assert forbidden not in lowered, f"{name}: forbidden hardcoded language rule {forbidden!r}"
+
+
+@pytest.mark.parametrize("name,builder", list(TIER_1B_BUILDERS.items()))
+def test_tier1b_no_return_json_only(name: str, builder: Callable[[], str]) -> None:
+    lowered = builder().lower()
+    for forbidden in FORBIDDEN_SUBSTRINGS.get(name, ()):
+        assert forbidden not in lowered, f"{name}: Tier-1B must not contain {forbidden!r}"
+
+
+def test_semantic_lint_numbered_invariants_ordered() -> None:
+    prompt = build_semantic_lint_system_prompt()
+    pos_1 = prompt.find("(1) block_uuid")
+    pos_6 = prompt.find("(6) never propose edits inside fenced code")
+    pos_output = prompt.find("[OUTPUT]")
+    tail = prompt.find(_CROSS_LINGUAL_TAIL)
+    assert pos_1 != -1 and pos_6 != -1 and pos_output != -1 and tail != -1
+    assert pos_1 < pos_6 < pos_output < tail
+
+
+def test_prompt_hash_stability() -> None:
+    known = _load_known_prompt_hashes()
+    assert set(known) == set(_ALL_BUILDERS), "prompt_hash_snapshots.json keys must match builders"
+    for name, builder in _ALL_BUILDERS.items():
+        actual = _sha256_prompt(builder)
+        expected = known[name]
+        assert actual == expected, (
+            f"{name}: hash changed — update with: "
+            "pytest tests/test_daemon_prompts.py --update-prompt-hashes"
+        )
+
+
+def test_domain_builders_do_not_import_prompt_constraints_directly() -> None:
+    """Enforce Dependency Rule: domain prompt modules import only prompts.core."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "src"
+    domain_dirs = (
+        root / "agent" / "semantic_lint",
+        root / "agent" / "bootstrap",
+        root / "agent" / "compression",
+        root / "agent" / "plumber_modules" / "marpa",
+        root / "agent" / "plumber_modules" / "llm_prompts",
+        root / "graph" / "insights",
+    )
+    forbidden = "prompt_constraints"
+    for directory in domain_dirs:
+        for path in directory.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            assert forbidden not in text, f"{path.relative_to(root)} must not import {forbidden}"

--- a/tests/test_llm_client_prompt_injection.py
+++ b/tests/test_llm_client_prompt_injection.py
@@ -1,0 +1,76 @@
+"""Verify InstructorLLMClient routes system prompts through injected builders."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from src.agent.bootstrap.prompts import HarvestPromptBuilder
+from src.agent.llm_client import InstructorLLMClient
+from src.agent.plumber_llm import BootstrapSummaryResult
+from src.agent.prompts.core import PromptContext
+
+
+class _MarkerBuilder:
+  tier: Literal["1A", "1B"] = "1A"
+
+  def __init__(self, marker: str) -> None:
+      self._marker = marker
+
+  def build(self, ctx: PromptContext | None = None) -> str:
+      _ = ctx
+      return self._marker
+
+
+def test_harvest_page_summary_uses_injected_builder_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    marker = "INJECTED_HARVEST_SYSTEM_PROMPT_MARKER"
+    client = InstructorLLMClient(
+        base_url="http://127.0.0.1:9",
+        api_key="test",
+        model="test",
+        harvest_builder=_MarkerBuilder(marker),
+    )
+    captured: list[str] = []
+
+    def _fake_completion(
+        *,
+        prompt: str,
+        response_model: type[BootstrapSummaryResult],
+        system_prompt: str,
+        stateless: bool = False,
+        telemetry_target: str = "",
+        telemetry_operation: str = "",
+        thermal_profile: str = "cognitive",
+        kv_prefix_hash: str | None = None,
+        log_tokens: bool = True,
+        use_history: bool = True,
+    ) -> tuple[BootstrapSummaryResult, object]:
+        _ = (
+            prompt,
+            response_model,
+            stateless,
+            telemetry_target,
+            telemetry_operation,
+            thermal_profile,
+            kv_prefix_hash,
+            log_tokens,
+            use_history,
+        )
+        captured.append(system_prompt)
+        return BootstrapSummaryResult(summary="ok", suggested_tags=[]), object()
+
+    monkeypatch.setattr(client, "_completion_with_structured_output", _fake_completion)
+    client.harvest_page_summary("Demo Page", "- bullet\n")
+    assert captured == [marker]
+
+
+def test_default_harvest_builder_matches_standalone_function() -> None:
+    client = InstructorLLMClient(
+        base_url="http://127.0.0.1:9",
+        api_key="test",
+        model="test",
+    )
+    assert isinstance(client._harvest_builder, HarvestPromptBuilder)
+    assert client._harvest_builder.build() == HarvestPromptBuilder().build()


### PR DESCRIPTION
Centralizes all system prompts in `src/agent/prompts/`. Zero inline strings in `llm_client.py`. Adds dead-zone rule (6) in semantic lint. `graph_insights` promoted to Tier-1A Pydantic schema.

## Test plan

- [x] `uv run pytest tests/test_daemon_prompts.py tests/test_llm_client_prompt_injection.py -q`
- [x] `make check`

Made with [Cursor](https://cursor.com)