### PR TITLE
chore(cursor): 11-prompt-maintainer rule

### DIFF
--- a/.cursor/rules/11-prompt-maintainer.mdc
+++ b/.cursor/rules/11-prompt-maintainer.mdc
@@ -1,0 +1,27 @@
+---
+description: Checklist when touching prompt builders, agent fragments, or MCP tool docstrings
+alwaysApply: false
+---
+
+# Prompt maintainer checklist (Matryca Plumber)
+
+Load on demand when editing Tier-1 prompts, `docs/openspec/agent/` fragments, or MCP tool contracts.
+
+**Rule routing:** Complements [`06-auto-changelog.mdc`](06-auto-changelog.mdc), [`07-env-example.mdc`](07-env-example.mdc), [`AGENTS.md`](../AGENTS.md).
+
+## Trigger → Azione
+
+| Hai modificato | Devi eseguire |
+|----------------|---------------|
+| `docs/openspec/agent/*.md` | `make build-system-prompt && make check-system-prompt` |
+| `src/agent/**/prompts.py`, `src/graph/**/prompts.py` (builder Tier-1A) | `uv run pytest tests/test_daemon_prompts.py --update-prompt-hashes` → `git add tests/prompt_hash_snapshots.json` |
+| `src/agent/**/prompts.py` (builder Tier-1B writer) | Come sopra + verifica che nessuna stringa contenga `English only` |
+| `mcp_server.py` (docstrings tool) | Aggiorna `docs/openspec/agent/mcp-tools.md` (+ `tool-reference.md` se serve) → `make build-system-prompt`; alla release MCP sync anche `llms.txt` §2 |
+| `tests/prompt_hash_snapshots.json` | Il commit message deve contenere `prompt(<builder>): <motivo>` |
+
+## Non fare
+
+- Non editare `SYSTEM_PROMPT.md` direttamente — è generato (`<!-- GENERATED — do not edit -->`).
+- Non aggiungere frammenti `docs/openspec/agent/*.md` senza riga in `_assembly_order.txt` — `make check-system-prompt` fallisce.
+- Non aggiungere stringhe system inline in `llm_client.py` — usa un builder di dominio che importa solo `src/agent/prompts/core.py`.
+- Non impostare `alwaysApply: true` su nuove rule senza approvazione esplicita.

--- a/.cursorrules
+++ b/.cursorrules
@@ -15,3 +15,4 @@ Load task-specific rules from [`.cursor/rules/`](.cursor/rules/). Contributor ro
 | `08-github-workflow-standards.mdc` | GitHub issues/PRs (on request) |
 | `09-github-identity-marco-porcellato.mdc` | Maintainer voice on GitHub |
 | `10-tooling-static-analysis-policy.mdc` | Vendor-agnostic public repo policy |
+| `11-prompt-maintainer.mdc` | Prompt fragments, Tier-1 builders, MCP docstrings (on request) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This file routes coding assistants to the correct instruction layer. **Do not lo
 | [`08-github-workflow-standards.mdc`](.cursor/rules/08-github-workflow-standards.mdc) | GitHub issues/PRs (on request) |
 | [`09-github-identity-marco-porcellato.mdc`](.cursor/rules/09-github-identity-marco-porcellato.mdc) | GitHub actions as maintainer |
 | [`10-tooling-static-analysis-policy.mdc`](.cursor/rules/10-tooling-static-analysis-policy.mdc) | Public docs / CI — vendor-agnostic tooling |
+| [`11-prompt-maintainer.mdc`](.cursor/rules/11-prompt-maintainer.mdc) | Prompt fragments, Tier-1 builders, MCP docstrings (on request) |
 
 ## Runtime agent surfaces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **`SYSTEM_PROMPT.md` assembly** — [`docs/openspec/agent/`](docs/openspec/agent/) fragments, `make build-system-prompt`, `make check-system-prompt` (fragment `build-hash` in generated banner); Soft Gate decision tree in `soft-gate.md`.
 - **Prompt hash snapshots** — `tests/prompt_hash_snapshots.json` + `pytest tests/test_daemon_prompts.py --update-prompt-hashes`; `tests/test_llm_client_prompt_injection.py` verifies DI on `InstructorLLMClient`.
 - **Assembly guard** — `build_system_prompt.py` fails when `docs/openspec/agent/*.md` exists but is missing from `_assembly_order.txt`.
+- **Cursor rule `11-prompt-maintainer`** — on-request trigger→action checklist for prompt fragments, Tier-1 builders, and MCP docstrings; indexed in [`.cursorrules`](.cursorrules) and [`AGENTS.md`](AGENTS.md).
 
 ### Changed
 


### PR DESCRIPTION
Adds `.cursor/rules/11-prompt-maintainer.mdc` (`alwaysApply: false`, trigger→action table). Updates `.cursorrules` index and `AGENTS.md`. Depends on PR-4 for `docs/openspec/agent/mcp-tools.md`.

## Test plan

- [x] `make agents-check`
- [x] `make check`

Made with [Cursor](https://cursor.com)