### PR TITLE
refactor: expose public API on SessionAliasRegistry to remove SLF001 (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Changed
 - **Tech Debt (#62):** `flock_available()` in `platform_lock.py`; unified `_format_node_markdown` in `matryca_hooks.py`; `BootstrapHarvestStatus` imported from `bootstrap_harvest.py`.
+- **Tech Debt (#64):** Added `SessionAliasRegistry.register_alias()` and `alias_items()` public methods in `alias_state.py` subclass; updated `graph_tool_helpers.py` and `tests/test_alias_state.py` to use the subclass — all `# noqa: SLF001` suppressions removed.
 
 ## [1.11.2] - 2026-06-24
 

--- a/src/agent/alias_state.py
+++ b/src/agent/alias_state.py
@@ -8,10 +8,29 @@ from collections.abc import ItemsView
 from pathlib import Path
 from typing import cast
 
-from logseq_matryca_parser.agent_press import XRAY_STATE_FILENAME, SessionAliasRegistry
+from logseq_matryca_parser.agent_press import XRAY_STATE_FILENAME
+from logseq_matryca_parser.agent_press import SessionAliasRegistry as _SessionAliasRegistry
 
 from ..graph.markdown_blocks import atomic_write_bytes
 from ..graph.page_write_lock import page_rmw_lock
+
+
+class SessionAliasRegistry(_SessionAliasRegistry):  # type: ignore[misc]
+    """Thin public-API extension of the upstream registry.
+
+    Adds :meth:`register_alias` and :meth:`alias_items` so callers never need
+    to touch the private ``_alias_to_uuid`` / ``_uuid_to_alias`` dicts directly.
+    """
+
+    def register_alias(self, alias: int, target_uuid: str) -> None:
+        """Register *alias* → *target_uuid* in both internal maps."""
+        self._alias_to_uuid[alias] = target_uuid
+        self._uuid_to_alias[target_uuid] = alias
+
+    def alias_items(self) -> ItemsView[int, str]:
+        """Return an items view of the alias → UUID mapping for persistence."""
+        return self._alias_to_uuid.items()  # type: ignore[no-any-return]
+
 
 _ALIAS_TARGET_RE = re.compile(r"^\[\s*(\d+)\s*\]$")
 
@@ -34,7 +53,7 @@ def load_alias_registry(graph_root: str | Path) -> SessionAliasRegistry:
         return SessionAliasRegistry()
     with page_rmw_lock(path):
         try:
-            return SessionAliasRegistry.load_from_disk(path)
+            return cast(SessionAliasRegistry, SessionAliasRegistry.load_from_disk(path))
         except json.JSONDecodeError as exc:
             msg = f"Corrupt {XRAY_STATE_FILENAME}: {exc}. Re-run xray_page read."
             raise ValueError(msg) from exc
@@ -88,14 +107,13 @@ def resolve_pipe_target(graph_root: str | Path, target: str) -> str:
 
 
 def safe_update_alias(registry: SessionAliasRegistry, alias: int, target_uuid: str) -> None:
-    """Scoped v1.9.x compatibility helper to update the upstream registry."""
-    registry._alias_to_uuid[alias] = target_uuid  # noqa: SLF001
-    registry._uuid_to_alias[target_uuid] = alias  # noqa: SLF001
+    """Compatibility shim — delegates to :meth:`SessionAliasRegistry.register_alias`."""
+    registry.register_alias(alias, target_uuid)
 
 
 def safe_alias_items(registry: SessionAliasRegistry) -> ItemsView[int, str]:
-    """Iterate alias→UUID pairs for persistence without leaking private access."""
-    return cast(ItemsView[int, str], registry._alias_to_uuid.items())  # noqa: SLF001
+    """Iterate alias→UUID pairs for persistence via the public registry API."""
+    return registry.alias_items()
 
 
 __all__ = [

--- a/src/agent/graph_tool_helpers.py
+++ b/src/agent/graph_tool_helpers.py
@@ -146,10 +146,15 @@ def _persistable_alias_map(
 
 def read_xray_page_markdown(graph_path: str, page_name: str) -> str:
     """Parse a page, assign ``[n]`` aliases, persist them, and return X-Ray markdown."""
-    from logseq_matryca_parser.agent_press import SessionAliasRegistry, to_xray_markdown
+    from logseq_matryca_parser.agent_press import to_xray_markdown
 
     from ..rag.matryca_hooks import get_spatial_context, resolve_logseq_page_md
-    from .alias_state import alias_file_path, safe_update_alias, save_alias_registry
+    from .alias_state import (
+        SessionAliasRegistry,
+        alias_file_path,
+        safe_update_alias,
+        save_alias_registry,
+    )
 
     title = page_name.strip()
     if not title:

--- a/tests/test_alias_state.py
+++ b/tests/test_alias_state.py
@@ -6,8 +6,9 @@ import json
 from pathlib import Path
 
 import pytest
-from logseq_matryca_parser.agent_press import XRAY_STATE_FILENAME, SessionAliasRegistry
+from logseq_matryca_parser.agent_press import XRAY_STATE_FILENAME
 from src.agent.alias_state import (
+    SessionAliasRegistry,
     alias_file_path,
     load_alias_registry,
     resolve_pipe_target,
@@ -21,8 +22,7 @@ BLOCK_UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 def _registry_with(mapping: dict[int, str]) -> SessionAliasRegistry:
     registry = SessionAliasRegistry()
     for alias, block_uuid in mapping.items():
-        registry._alias_to_uuid[alias] = block_uuid  # noqa: SLF001
-        registry._uuid_to_alias[block_uuid] = alias  # noqa: SLF001
+        registry.register_alias(alias, block_uuid)
     return registry
 
 


### PR DESCRIPTION
## What
Removes all `# noqa: SLF001` suppressions by adding a proper public API to `SessionAliasRegistry`.

## Changes

**`src/agent/alias_state.py`**
- Subclasses upstream `_SessionAliasRegistry` with a local `SessionAliasRegistry` that adds:
  - `register_alias(alias, target_uuid)` — replaces direct `_alias_to_uuid` / `_uuid_to_alias` mutation
  - `alias_items()` — replaces direct `_alias_to_uuid.items()` access

**`src/agent/graph_tool_helpers.py`**
- Imports `SessionAliasRegistry` from `alias_state` instead of `logseq_matryca_parser` directly

**`tests/test_alias_state.py`**
- Imports `SessionAliasRegistry` from `alias_state`
- `_registry_with()` helper uses `register_alias()` instead of private attr mutation

## Verification
```
make check
# 975 passed, 1 skipped — 81.80% coverage ✅
# ruff: All checks passed ✅
# mypy: no errors ✅
```

Closes #64