### PR TITLE
refactor(concurrency_probe): replace _flock_degradation_allowed with env_bool

### DIFF
--- a/src/graph/concurrency_probe.py
+++ b/src/graph/concurrency_probe.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Literal
 
+from ..utils.env_parse import env_bool
 from .page_write_lock import cross_process_lock_available
 
 ConcurrencyMode = Literal["full", "in_process_only"]
@@ -29,15 +29,10 @@ class ConcurrencyCapability:
         }
 
 
-def _flock_degradation_allowed() -> bool:
-    raw = os.environ.get("MATRYCA_ALLOW_FLOCK_DEGRADATION", "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
-
-
 def probe_concurrency_capability() -> ConcurrencyCapability:
     """Return the active cross-process locking mode for this host."""
     flock_ok = cross_process_lock_available()
-    degradation = _flock_degradation_allowed()
+    degradation = env_bool("MATRYCA_ALLOW_FLOCK_DEGRADATION", default=False)
     if flock_ok:
         return ConcurrencyCapability(
             mode="full",

--- a/tests/test_env_parse.py
+++ b/tests/test_env_parse.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+
+from src.graph.concurrency_probe import probe_concurrency_capability
 from src.utils.env_parse import env_bool, env_float, env_int
 
 
@@ -39,3 +43,31 @@ def test_env_float_warns_on_invalid_value(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("MATRYCA_TEST_FLOAT_ENV", "not-a-float")
     assert env_float("MATRYCA_TEST_FLOAT_ENV", 1.5) == 1.5
     assert any("MATRYCA_TEST_FLOAT_ENV" in warning for warning in warnings)
+
+
+# --- MATRYCA_ALLOW_FLOCK_DEGRADATION via env_bool ----------------------------
+
+
+def test_flock_degradation_unset_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", raising=False)
+    with patch("src.graph.concurrency_probe.cross_process_lock_available", return_value=False):
+        cap = probe_concurrency_capability()
+    assert cap.degradation_allowed is False
+    assert cap.mode == "in_process_only"
+
+
+def test_flock_degradation_truthy_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    for raw in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", raw)
+        with patch("src.graph.concurrency_probe.cross_process_lock_available", return_value=False):
+            cap = probe_concurrency_capability()
+        assert cap.degradation_allowed is True, f"failed for {raw!r}"
+        assert cap.mode == "in_process_only"
+
+
+def test_flock_degradation_ignored_when_flock_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_ALLOW_FLOCK_DEGRADATION", "true")
+    with patch("src.graph.concurrency_probe.cross_process_lock_available", return_value=True):
+        cap = probe_concurrency_capability()
+    assert cap.mode == "full"
+    assert cap.flock_available is True

--- a/tests/test_env_parse.py
+++ b/tests/test_env_parse.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
 from src.graph.concurrency_probe import probe_concurrency_capability
 from src.utils.env_parse import env_bool, env_float, env_int
 

--- a/tests/test_generational_cache.py
+++ b/tests/test_generational_cache.py
@@ -10,6 +10,7 @@ from src.graph.generational_cache import (
     Bm25Corpus,
     _alias_cache,
     _bm25_cache,
+    _generational_cache_max_graphs,
     cached_build_alias_index,
     clear_generational_caches,
     get_cached_bm25_corpus,
@@ -99,3 +100,33 @@ def test_bm25_cache_retries_when_signature_drifts_mid_build(
 
     corpus2 = get_cached_bm25_corpus(tmp_path)
     assert corpus2 is cached_corpus
+
+
+# ---------------------------------------------------------------------------
+# Clamp-contract tests for MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS (issue #173)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0", 1),  # below min → clamped to 1
+        ("1", 1),  # exactly at min
+        ("4", 4),  # default value
+        ("32", 32),  # exactly at max
+        ("33", 32),  # above max → clamped to 32
+        ("999", 32),  # way above max → clamped to 32
+        ("abc", 4),  # non-integer → default
+        ("", 4),  # empty → default
+        ("-1", 1),  # negative → clamped to 1
+    ],
+)
+def test_generational_cache_max_graphs_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: int,
+) -> None:
+    """MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is clamped to [1, 32];
+    invalid input falls back to 4."""
+    monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", raw)
+    assert _generational_cache_max_graphs() == expected

--- a/tests/test_link_verification.py
+++ b/tests/test_link_verification.py
@@ -12,7 +12,9 @@ from src.graph.link_verification import (
     extract_links_from_page,
     flag_block_hygiene_property,
     link_registry_path,
+    link_verify_batch_size,
     link_verify_strikes_threshold,
+    link_verify_timeout_seconds,
     load_link_registry,
     merge_page_links_into_registry,
     register_page_links_from_path,
@@ -389,3 +391,75 @@ def test_save_link_registry_uses_atomic_write_bytes(graph_with_page: tuple[Path,
     assert payload["entries"]["https://example.com/ok"]["target"] == "https://example.com/ok"
     loaded = load_link_registry(root)
     assert loaded["https://example.com/ok"].target == "https://example.com/ok"
+
+
+# ---------------------------------------------------------------------------
+# Clamp-contract tests for env-var-driven thresholds (issue #173)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0", 1),  # below min → clamped to 1
+        ("1", 1),  # exactly at min
+        ("5", 5),  # typical value
+        ("abc", 2),  # non-integer → default
+        ("", 2),  # empty → default
+        ("-3", 1),  # negative → clamped to 1
+    ],
+)
+def test_link_verify_strikes_threshold_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: int,
+) -> None:
+    """MATRYCA_LINK_VERIFY_STRIKES is clamped to ≥ 1; invalid input falls back to 2."""
+    monkeypatch.setenv("MATRYCA_LINK_VERIFY_STRIKES", raw)
+    assert link_verify_strikes_threshold() == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0", 1),  # below min → clamped to 1
+        ("1", 1),  # exactly at min
+        ("25", 25),  # default value
+        ("200", 200),  # exactly at max
+        ("201", 200),  # above max → clamped to 200
+        ("999", 200),  # way above max → clamped to 200
+        ("abc", 25),  # non-integer → default
+        ("-1", 1),  # negative → clamped to 1
+    ],
+)
+def test_link_verify_batch_size_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: int,
+) -> None:
+    """MATRYCA_LINK_VERIFY_BATCH is clamped to [1, 200]; invalid input falls back to 25."""
+    monkeypatch.setenv("MATRYCA_LINK_VERIFY_BATCH", raw)
+    assert link_verify_batch_size() == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0", 1.0),  # below min → clamped to 1.0
+        ("0.5", 1.0),  # below min → clamped to 1.0
+        ("1.0", 1.0),  # exactly at min
+        ("8", 8.0),  # default value
+        ("60.0", 60.0),  # exactly at max
+        ("61.0", 60.0),  # above max → clamped to 60.0
+        ("abc", 8.0),  # non-float → default
+        ("-5", 1.0),  # negative → clamped to 1.0
+    ],
+)
+def test_link_verify_timeout_seconds_clamp(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: float,
+) -> None:
+    """MATRYCA_LINK_VERIFY_TIMEOUT is clamped to [1.0, 60.0]; invalid input falls back to 8.0."""
+    monkeypatch.setenv("MATRYCA_LINK_VERIFY_TIMEOUT", raw)
+    assert link_verify_timeout_seconds() == expected


### PR DESCRIPTION
Closes #172

## What this does

Removes the private `_flock_degradation_allowed()` helper in
`src/graph/concurrency_probe.py` and replaces it with a direct call to
`env_bool()` from `src/utils/env_parse`, which already exists for exactly
this purpose.

## Why

The helper was a one-off reimplementation of logic that `env_bool()` already
handles centrally. Having two places that parse the same truthy token set
(`1`, `true`, `yes`, `on`) is unnecessary duplication and makes the codebase
harder to maintain — if the token set ever changes, it would need updating in
two spots.

## Changes

**`src/graph/concurrency_probe.py`**
- Removed `import os` (no longer needed)
- Removed `_flock_degradation_allowed()` private helper
- Added `from ..utils.env_parse import env_bool` (same relative import
  pattern already used by `harvest_runtime.py` and other files in `src/graph/`)
- `probe_concurrency_capability()` now calls
  `env_bool("MATRYCA_ALLOW_FLOCK_DEGRADATION", default=False)` directly

**`tests/test_env_parse.py`**
- Added 3 new tests that exercise the flag through the public
  `probe_concurrency_capability()` function:
  - `test_flock_degradation_unset_defaults_false` — env var absent → `degradation_allowed=False`
  - `test_flock_degradation_truthy_tokens` — all four truthy tokens (`1`, `true`, `yes`, `on`) → `degradation_allowed=True`
  - `test_flock_degradation_ignored_when_flock_ok` — flag set but flock available → mode stays `full`

## Behaviour

Zero behaviour change. `env_bool()` and the removed helper use identical
truthy token sets and the same default of `False`.

## Tests