### PR TITLE
refactor(plumber_config): delegate _env_int to utils.env_parse.env_int

### DIFF
--- a/src/agent/memory_budget.py
+++ b/src/agent/memory_budget.py
@@ -14,7 +14,7 @@ from loguru import logger
 
 from ..graph.generational_cache import clear_generational_caches, release_bm25_corpus
 from ..graph.master_catalog import unload_master_catalog
-from .plumber_config import _env_int
+from ..utils.env_parse import env_int
 from .plumber_modules.semantic_cache_router import (
     clear_semantic_cache_memory,
     purge_expired_semantic_cache,
@@ -25,7 +25,7 @@ _DEFAULT_RAM_BUDGET_MB = 4096
 
 
 def ram_budget_mb() -> int:
-    return max(512, _env_int(_RAM_BUDGET_MB_ENV, _DEFAULT_RAM_BUDGET_MB))
+    return max(512, env_int(_RAM_BUDGET_MB_ENV, _DEFAULT_RAM_BUDGET_MB))
 
 
 def rss_bytes() -> int:

--- a/src/agent/page_prompt_session.py
+++ b/src/agent/page_prompt_session.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..graph.alias_index import AliasIndex, format_alias_index_for_prompt
+from ..utils.env_parse import env_int
 from .llm_context_payload import PayloadSource, prepare_llm_context_payload
-from .plumber_config import PlumberLintConfig, _env_int
+from .plumber_config import PlumberLintConfig
 from .prompt_layout import CANONICAL_TASK_HEADER, normalize_stable_text
 
 _STABLE_CONTENT_HEADER = "Page content:\n"
@@ -22,7 +23,7 @@ class PrefixDriftError(RuntimeError):
 
 
 def alias_prompt_max_chars() -> int:
-    return max(256, _env_int(_ALIAS_PROMPT_MAX_CHARS_ENV, _DEFAULT_ALIAS_PROMPT_MAX_CHARS))
+    return max(256, env_int(_ALIAS_PROMPT_MAX_CHARS_ENV, _DEFAULT_ALIAS_PROMPT_MAX_CHARS))
 
 
 def _cap_alias_footer(text: str, *, max_chars: int) -> str:

--- a/src/agent/plumber_config.py
+++ b/src/agent/plumber_config.py
@@ -14,11 +14,6 @@ from urllib.parse import urlparse
 
 from ..utils.env_parse import env_int
 
-
-def _env_int(key: str, default: int) -> int:
-    return env_int(key, default)
-
-
 DEFAULT_LLM_BASE_URL = "http://localhost:1234/v1"
 DEFAULT_LLM_MODEL_NAME = "local-model"
 DEFAULT_LLM_API_KEY = "dummy-key"
@@ -65,25 +60,25 @@ def _env_str(key: str, default: str) -> str:
 
 def resolve_llm_max_completion_tokens() -> int:
     """Upper bound for structured JSON completions (prevents runaway local-model loops)."""
-    value = _env_int("MATRYCA_LLM_MAX_COMPLETION_TOKENS", DEFAULT_LLM_MAX_COMPLETION_TOKENS)
+    value = env_int("MATRYCA_LLM_MAX_COMPLETION_TOKENS", DEFAULT_LLM_MAX_COMPLETION_TOKENS)
     return max(_MIN_LLM_MAX_COMPLETION_TOKENS, min(_MAX_LLM_MAX_COMPLETION_TOKENS, value))
 
 
 def resolve_llm_max_compression_tokens() -> int:
     """Upper bound for Ermes context-compression completions (markdown, not JSON)."""
-    value = _env_int("MATRYCA_LLM_MAX_COMPRESSION_TOKENS", DEFAULT_LLM_MAX_COMPRESSION_TOKENS)
+    value = env_int("MATRYCA_LLM_MAX_COMPRESSION_TOKENS", DEFAULT_LLM_MAX_COMPRESSION_TOKENS)
     return max(_MIN_LLM_MAX_COMPLETION_TOKENS, min(_MAX_LLM_MAX_COMPRESSION_TOKENS, value))
 
 
 def resolve_llm_prose_completion_max_chars() -> int:
     """Hard character cap after prose sanitization (history pollution guard)."""
-    value = _env_int("MATRYCA_LLM_PROSE_COMPLETION_MAX_CHARS", 12_000)
+    value = env_int("MATRYCA_LLM_PROSE_COMPLETION_MAX_CHARS", 12_000)
     return max(2_000, min(32_000, value))
 
 
 def resolve_cluster_focus_max_chars() -> int:
     """Cap Ermes cluster neighborhood injection (large Louvain clusters)."""
-    value = _env_int("MATRYCA_CLUSTER_FOCUS_MAX_CHARS", 8000)
+    value = env_int("MATRYCA_CLUSTER_FOCUS_MAX_CHARS", 8000)
     return max(1_000, min(24_000, value))
 
 

--- a/src/agent/process_priority.py
+++ b/src/agent/process_priority.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from .plumber_config import PlumberLintConfig, _env_int, _map_bool, load_plumber_lint_config
+from ..utils.env_parse import env_int
+from .plumber_config import PlumberLintConfig, _map_bool, load_plumber_lint_config
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,7 +102,7 @@ def resolve_cpu_sandbox_config(config: PlumberLintConfig | None = None) -> CpuSa
         if explicit is not None
         else (topology.recommended_plumber_cpus if topology is not None else None)
     )
-    nice_level = max(0, min(19, _env_int("MATRYCA_PLUMBER_NICE_LEVEL", 19)))
+    nice_level = max(0, min(19, env_int("MATRYCA_PLUMBER_NICE_LEVEL", 19)))
     return CpuSandboxConfig(
         enabled=enabled and config.low_priority_mode,
         affinity_cpus=affinity,

--- a/tests/test_plumber_config_env_serialization.py
+++ b/tests/test_plumber_config_env_serialization.py
@@ -30,7 +30,7 @@ def test_serialize_thermal_accepts_int() -> None:
 
 
 def test_env_int_warns_on_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None:
-    from src.agent import plumber_config
+    from src.utils import env_parse
 
     warnings: list[str] = []
 
@@ -39,7 +39,7 @@ def test_env_int_warns_on_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr("src.utils.env_parse.logger.warning", _capture)
     monkeypatch.setenv("MATRYCA_TEST_INT_ENV", "not-a-number")
-    assert plumber_config._env_int("MATRYCA_TEST_INT_ENV", 42) == 42
+    assert env_parse.env_int("MATRYCA_TEST_INT_ENV", 42) == 42
     assert any("MATRYCA_TEST_INT_ENV" in warning for warning in warnings)
 
 


### PR DESCRIPTION
## Summary

Fixes #170

`src/agent/plumber_config.py` defined a private `_env_int` helper that
was a thin wrapper duplicating the logic already present in
`src/utils/env_parse.env_int`. Three agent modules (`memory_budget.py`,
`page_prompt_session.py`, `process_priority.py`) imported `_env_int`
from `plumber_config`, coupling them to a redundant parser instead of
the shared utility.

## What was changed

**`src/agent/plumber_config.py`**
- Removed the `_env_int` shim (`def _env_int(key, default): return env_int(key, default)`)
- Kept the existing `from ..utils.env_parse import env_int` import
- Updated the 4 internal call sites to call `env_int(` directly

**`src/agent/memory_budget.py`**
- Replaced `from .plumber_config import _env_int` with `from ..utils.env_parse import env_int`
- Updated the 1 call site in `ram_budget_mb()`

**`src/agent/page_prompt_session.py`**
- Split `from .plumber_config import PlumberLintConfig, _env_int` into two imports:
  `from ..utils.env_parse import env_int` and `from .plumber_config import PlumberLintConfig`
- Updated the 1 call site in `alias_prompt_max_chars()`

**`src/agent/process_priority.py`**
- Split `from .plumber_config import PlumberLintConfig, _env_int, _map_bool, load_plumber_lint_config`
  into two imports: `from ..utils.env_parse import env_int` and the rest from `plumber_config`
- Updated the 1 call site in `resolve_cpu_sandbox_config()`

**`tests/test_plumber_config_env_serialization.py`**
- Updated `test_env_int_warns_on_invalid_value` to import and assert against
  `env_parse.env_int` directly instead of the now-removed