### PR TITLE
test(graph): forbid graph→rag imports, allowlist generational_cache.py (closes #171)

### DIFF
--- a/tests/test_graph_layer_boundary.py
+++ b/tests/test_graph_layer_boundary.py
@@ -25,3 +25,24 @@ def test_graph_modules_do_not_import_daemon() -> None:
         if "from ..daemon" in text or "from src.daemon" in text:
             offenders.append(str(path.relative_to(graph_dir.parents[1])))
     assert offenders == []
+
+
+def test_graph_modules_do_not_import_rag() -> None:
+    graph_dir = Path(__file__).resolve().parents[1] / "src" / "graph"
+    offenders: list[str] = []
+    for path in sorted(graph_dir.rglob("*.py")):
+        # generational_cache.py uses lazy `from src.rag.local_query import
+        # tokenize` inside functions — tracked for clean-up in a follow-up PR.
+        if path.name == "generational_cache.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        if (
+            "from ..rag" in text
+            or "from src.rag" in text
+            or "import rag" in text
+        ):
+            offenders.append(str(path.relative_to(graph_dir.parents[1])))
+    assert offenders == [], (
+        "src/graph/ must not import src/rag/ (domain should not depend on "
+        "retrieval adapters). Offending files:\n" + "\n".join(offenders)
+    )

--- a/tests/test_graph_layer_boundary.py
+++ b/tests/test_graph_layer_boundary.py
@@ -36,11 +36,7 @@ def test_graph_modules_do_not_import_rag() -> None:
         if path.name == "generational_cache.py":
             continue
         text = path.read_text(encoding="utf-8")
-        if (
-            "from ..rag" in text
-            or "from src.rag" in text
-            or "import rag" in text
-        ):
+        if "from ..rag" in text or "from src.rag" in text or "import rag" in text:
             offenders.append(str(path.relative_to(graph_dir.parents[1])))
     assert offenders == [], (
         "src/graph/ must not import src/rag/ (domain should not depend on "


### PR DESCRIPTION
closes #171

## What

Extends `tests/test_graph_layer_boundary.py` with a new test
`test_graph_modules_do_not_import_rag()` that enforces the architectural
rule: `src/graph/` must not import `src/rag/` (domain layer must not
depend on retrieval adapters).

---

## Why

`tests/test_graph_layer_boundary.py` already guards against `graph→agent`
and `graph→daemon` imports (#134). There was no equivalent guard for
`graph→rag`, leaving the boundary silently unprotected. Any contributor
could accidentally introduce a `from src.rag import ...` in a graph module
with no CI failure.

---

## Changes

### `tests/test_graph_layer_boundary.py`
Added `test_graph_modules_do_not_import_rag()` which:
- Walks all `src/graph/**/*.py` files
- Flags any file containing `from ..rag`, `from src.rag`, or `import rag`
- Skips `generational_cache.py` (see below)
- Asserts the offenders list is empty with a clear error message

---

## Existing offender — `generational_cache.py`

Running the scan found one pre-existing violation:
`src/graph/generational_cache.py` uses lazy inline imports of
`from src.rag.local_query import tokenize` inside three functions
(lines 213, 309, 386).

Following the same pattern as the daemon test (which allowlists
`daemon_checkpoint.py`), the new test skips `generational_cache.py`
with a comment marking it for a follow-up PR. The guard will
immediately catch any **new** `graph→rag` imports going forward.

Fixing `generational_cache.py` itself requires abstracting or relocating
the `tokenize` dependency — happy to open a follow-up PR for that
separately if useful.

---

## Verification

uv run pytest tests/test_graph_layer_boundary.py -v