### PR TITLE
refactor(generational_cache): migrate MATRYCA_* env reads to env_parse (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+- **`env_str` migration for `MATRYCA_BM25_MODE` ([#169](https://github.com/MarcoPorcellato/matryca-plumber/issues/169) / [#194](https://github.com/MarcoPorcellato/matryca-plumber/pull/194))** — `_bm25_mode()` in `generational_cache.py` now reads `MATRYCA_BM25_MODE` via `env_str()` (strips + lowercases; empty → default) instead of a raw `os.environ.get`; `env_str` added to `src/utils/env_parse.py` and exported in `__all__`; `env_str` import hoisted to module level in `generational_cache.py`; loguru warning on unknown mode value. Tests added for unset/empty → default and value → stripped+lowercased. Thanks to @Maqbool61.
+
 ## [1.14.0] - 2026-07-16
 
 **Catalog write-safety, leaf-module dependency direction, and Clean Code Tier F closures**

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
+
 from src.utils.env_parse import env_int, env_str
 
 from .alias_index import (

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -8,7 +8,8 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 
-from src.utils.env_parse import env_int
+from loguru import logger
+from src.utils.env_parse import env_int, env_str
 
 from .alias_index import (
     AliasIndex,
@@ -68,12 +69,8 @@ _DEFAULT_BM25_MODE = "resident"
 
 
 def _bm25_mode() -> str:
-    from src.utils.env_parse import env_str  # noqa: PLC0415
-
     raw = env_str("MATRYCA_BM25_MODE", _DEFAULT_BM25_MODE)
     if raw not in _BM25_VALID_MODES:
-        from loguru import logger
-
         logger.warning(
             "Unknown MATRYCA_BM25_MODE={!r}; expected one of {}; using {!r}",
             raw,

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import math
-import os
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
+
+from src.utils.env_parse import env_int
 
 from .alias_index import (
     AliasIndex,
@@ -30,13 +31,8 @@ _DEFAULT_CACHE_MAX_GRAPHS = 4
 
 
 def _generational_cache_max_graphs() -> int:
-    raw = os.environ.get("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", "").strip()
-    if not raw:
-        return _DEFAULT_CACHE_MAX_GRAPHS
-    try:
-        return max(1, min(32, int(raw)))
-    except ValueError:
-        return _DEFAULT_CACHE_MAX_GRAPHS
+    value = env_int("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", _DEFAULT_CACHE_MAX_GRAPHS)
+    return max(1, min(32, value))
 
 
 def _evict_oldest_graph_caches() -> None:
@@ -67,9 +63,25 @@ def clear_generational_caches() -> None:
         _bm25_cache.clear()
 
 
+_BM25_VALID_MODES = {"resident", "ondemand"}
+_DEFAULT_BM25_MODE = "resident"
+
+
 def _bm25_mode() -> str:
-    raw = os.environ.get("MATRYCA_BM25_MODE", "resident").strip().lower()
-    return raw if raw in {"resident", "ondemand"} else "resident"
+    from src.utils.env_parse import env_str  # noqa: PLC0415
+
+    raw = env_str("MATRYCA_BM25_MODE", _DEFAULT_BM25_MODE)
+    if raw not in _BM25_VALID_MODES:
+        from loguru import logger
+
+        logger.warning(
+            "Unknown MATRYCA_BM25_MODE={!r}; expected one of {}; using {!r}",
+            raw,
+            sorted(_BM25_VALID_MODES),
+            _DEFAULT_BM25_MODE,
+        )
+        return _DEFAULT_BM25_MODE
+    return raw
 
 
 def release_bm25_corpus(graph_root: str | Path) -> None:

--- a/src/utils/env_parse.py
+++ b/src/utils/env_parse.py
@@ -36,4 +36,9 @@ def env_float(key: str, default: float) -> float:
         return default
 
 
-__all__ = ["env_bool", "env_float", "env_int"]
+def env_str(key: str, default: str = "") -> str:
+    raw = os.environ.get(key, "").strip().lower()
+    return raw if raw else default
+
+
+__all__ = ["env_bool", "env_float", "env_int", "env_str"]

--- a/tests/test_env_example_coverage.py
+++ b/tests/test_env_example_coverage.py
@@ -25,7 +25,7 @@ _ENV_HELPER_RE = re.compile(
     r"""_env_(?:bool|int|float|str)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
 )
 _ENV_PARSE_RE = re.compile(
-    r"""env_(?:bool|int|float)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
+    r"""env_(?:bool|int|float|str)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
 )
 _ENV_MAP_RE = re.compile(
     r"""_map_(?:bool|int|float|str)(?:_nonempty)?\(\s*env\s*,\s*["']([A-Z][A-Z0-9_]*)["']""",

--- a/tests/test_env_parse.py
+++ b/tests/test_env_parse.py
@@ -70,3 +70,34 @@ def test_flock_degradation_ignored_when_flock_ok(monkeypatch: pytest.MonkeyPatch
         cap = probe_concurrency_capability()
     assert cap.mode == "full"
     assert cap.flock_available is True
+
+
+# --- env_str tests -----------------------------------------------------------
+
+
+def test_env_str_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils.env_parse import env_str
+
+    monkeypatch.delenv("MATRYCA_TEST_STR", raising=False)
+    assert env_str("MATRYCA_TEST_STR", "fallback") == "fallback"
+
+
+def test_env_str_returns_default_on_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils.env_parse import env_str
+
+    monkeypatch.setenv("MATRYCA_TEST_STR", "")
+    assert env_str("MATRYCA_TEST_STR", "fallback") == "fallback"
+
+
+def test_env_str_strips_and_lowercases_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils.env_parse import env_str
+
+    monkeypatch.setenv("MATRYCA_TEST_STR", "  HELLO  ")
+    assert env_str("MATRYCA_TEST_STR", "fallback") == "hello"
+
+
+def test_env_str_whitespace_only_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils.env_parse import env_str
+
+    monkeypatch.setenv("MATRYCA_TEST_STR", "   ")
+    assert env_str("MATRYCA_TEST_STR", "fallback") == "fallback"

--- a/tests/test_generational_cache.py
+++ b/tests/test_generational_cache.py
@@ -164,9 +164,7 @@ def test_bm25_mode_validates_membership(
 def test_generational_cache_max_graphs_logs_warning_on_invalid_int(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """env_int emits a loguru warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an integer."""
-    import logging
-
+    """env_int emits a loguru warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an int."""
     from loguru import logger
 
     monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", "notanint")

--- a/tests/test_generational_cache.py
+++ b/tests/test_generational_cache.py
@@ -133,20 +133,22 @@ def test_generational_cache_max_graphs_clamp(
     monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", raw)
     assert _generational_cache_max_graphs() == expected
 
+
 # ---------------------------------------------------------------------------
 # env_parse migration tests (issue #169)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        ("resident", "resident"),   # valid default
-        ("ondemand", "ondemand"),   # valid non-default
-        ("RESIDENT", "resident"),   # case-insensitive
-        ("ONDEMAND", "ondemand"),   # case-insensitive
-        ("invalid", "resident"),    # unknown → fallback
-        ("", "resident"),           # empty → default
-        ("garbage", "resident"),    # garbage → fallback
+        ("resident", "resident"),  # valid default
+        ("ondemand", "ondemand"),  # valid non-default
+        ("RESIDENT", "resident"),  # case-insensitive
+        ("ONDEMAND", "ondemand"),  # case-insensitive
+        ("invalid", "resident"),  # unknown → fallback
+        ("", "resident"),  # empty → default
+        ("garbage", "resident"),  # garbage → fallback
     ],
 )
 def test_bm25_mode_validates_membership(
@@ -165,6 +167,7 @@ def test_generational_cache_max_graphs_logs_warning_on_invalid_int(
 ) -> None:
     """env_int emits a warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an integer."""
     import logging
+
     monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", "notanint")
     with caplog.at_level(logging.WARNING):
         result = _generational_cache_max_graphs()

--- a/tests/test_generational_cache.py
+++ b/tests/test_generational_cache.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 from src.graph.alias_index import AliasIndex, build_alias_index
 from src.graph.generational_cache import (
+    _DEFAULT_CACHE_MAX_GRAPHS,
     Bm25Corpus,
     _alias_cache,
     _bm25_cache,
+    _bm25_mode,
     _generational_cache_max_graphs,
     cached_build_alias_index,
     clear_generational_caches,
@@ -130,3 +132,40 @@ def test_generational_cache_max_graphs_clamp(
     invalid input falls back to 4."""
     monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", raw)
     assert _generational_cache_max_graphs() == expected
+
+# ---------------------------------------------------------------------------
+# env_parse migration tests (issue #169)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("resident", "resident"),   # valid default
+        ("ondemand", "ondemand"),   # valid non-default
+        ("RESIDENT", "resident"),   # case-insensitive
+        ("ONDEMAND", "ondemand"),   # case-insensitive
+        ("invalid", "resident"),    # unknown → fallback
+        ("", "resident"),           # empty → default
+        ("garbage", "resident"),    # garbage → fallback
+    ],
+)
+def test_bm25_mode_validates_membership(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: str,
+) -> None:
+    """_bm25_mode() accepts only 'resident'/'ondemand'; anything else falls back."""
+    monkeypatch.setenv("MATRYCA_BM25_MODE", raw)
+    assert _bm25_mode() == expected
+
+
+def test_generational_cache_max_graphs_logs_warning_on_invalid_int(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """env_int emits a warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an integer."""
+    import logging
+    monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", "notanint")
+    with caplog.at_level(logging.WARNING):
+        result = _generational_cache_max_graphs()
+    assert result == _DEFAULT_CACHE_MAX_GRAPHS

--- a/tests/test_generational_cache.py
+++ b/tests/test_generational_cache.py
@@ -163,12 +163,23 @@ def test_bm25_mode_validates_membership(
 
 def test_generational_cache_max_graphs_logs_warning_on_invalid_int(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """env_int emits a warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an integer."""
+    """env_int emits a loguru warning when MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS is not an integer."""
     import logging
 
+    from loguru import logger
+
     monkeypatch.setenv("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", "notanint")
-    with caplog.at_level(logging.WARNING):
+    warning_messages: list[str] = []
+
+    def _sink(message: object) -> None:
+        warning_messages.append(str(message))
+
+    logger.add(_sink, level="WARNING")
+    try:
         result = _generational_cache_max_graphs()
+    finally:
+        logger.remove()
+
     assert result == _DEFAULT_CACHE_MAX_GRAPHS
+    assert any("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS" in m for m in warning_messages)


### PR DESCRIPTION
Closes #169

## Problem
`src/graph/generational_cache.py` was reading two environment variables
via raw `os.environ.get` calls instead of using the shared `env_parse`
utility that already existed for this purpose:

- `_generational_cache_max_graphs()` — read `MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS`
  inline with a silent `ValueError` fallback (no warning emitted)
- `_bm25_mode()` — read `MATRYCA_BM25_MODE` inline with no warning on
  unknown values

This violated the DRY principle and meant invalid env values were
swallowed silently instead of logging a warning like every other env
read in the codebase.

## What Changed

### `src/utils/env_parse.py`
- Added `env_str(key, default)` — strips + lowercases the raw value,
  returns `default` on empty string
- Exported `env_str` in `__all__`

### `src/graph/generational_cache.py`
- Replaced `_generational_cache_max_graphs()` inline `os.environ.get`
  with `env_int("MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS", _DEFAULT_CACHE_MAX_GRAPHS)`,
  then clamp with `max(1, min(32, value))` — invalid values now emit a
  loguru warning instead of silently falling back
- Replaced `_bm25_mode()` inline `os.environ.get` with `env_str()` +
  explicit membership check against `{"resident", "ondemand"}`; unknown
  values log a warning and fall back to `"resident"`
- Removed now-unused `import os`
- Fixed ruff import ordering (autofix via `ruff check --fix`)

### `tests/test_env_example_coverage.py`
- Extended `_ENV_PARSE_RE` to also match `env_str()` calls so the
  key-coverage scanner correctly detects `MATRYCA_BM25_MODE` as read
  (the scanner previously only matched `env_bool/int/float`)

### `tests/test_generational_cache.py`
- Added `_DEFAULT_CACHE_MAX_GRAPHS`, `_bm25_mode` to imports
- Added 7 parametrised `test_bm25_mode_validates_membership` cases:
  valid modes, case-insensitive matching, unknown string, empty string
- Added `test_generational_cache_max_graphs_logs_warning_on_invalid_int`
  asserting a warning is emitted for non-integer input
- Fixed ruff import ordering (autofix via `ruff check --fix`)

## Behaviour Unchanged
- `MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS` unset or valid → identical output
- `MATRYCA_BM25_MODE` unset or valid → identical output
- Only difference: invalid values now log a warning instead of failing silently

## Verification
```bash
# All tests pass
python -m pytest --no-cov -q
# 1031 passed, 1 skipped