### PR TITLE
fix: close catalog write-safety gaps found in code audit

### DIFF
--- a/docs/AUDIT_REPORT_2026-07-16.md
+++ b/docs/AUDIT_REPORT_2026-07-16.md
@@ -1,0 +1,129 @@
+# Deep Code Audit — matryca-plumber
+
+**Date:** 2026-07-16 · **Tooling:** code audit via MCP (knowledge graph: 511 files, 7,791 symbols, 16,941 relationships, 300 execution flows), ruff static analysis, targeted manual review, TRIZ methodology.
+
+> Note: the Serena MCP server was not connected in this session; symbol-level analysis was performed with the code audit MCP and native tools. The code-audit index was 1 commit behind HEAD at audit time (cosmetic drift only — the lagging commit is a docs/release chore).
+
+## Executive summary
+
+The codebase is in **very good shape**: ruff's default rule set reports zero violations on `src/`, broad exception handlers are deliberate and annotated with rationale, concurrency around the JSON catalog uses cross-process flocks plus in-process locks with mtime-based merge, and path access is centralized through a sandbox (`assert_path_within_graph`, fan-in 54 for `read_graph_file_text`). The findings below are therefore mostly **subtle correctness bugs, architectural contradictions, and scalability cliffs** — the kind that survive a clean linter run.
+
+**Top 3 actions:** fix the `remove→upsert→save` resurrection-deletion bug in `MasterCatalog` (F1); stop treating a corrupt catalog as "empty" during merge (F2); handle `on_moved` events in the file watcher (F4).
+
+---
+
+## 1. Architecture map (code audit)
+
+Functional areas by symbol count / cohesion: Graph (576 / 70%), Agent (475 / 71%), Tests (750 / 70%), CLI (94 / 75%), Tana importers (89 / 77%), Semantic (68 / 83%), Daemon (56 / 82%). Cohesion is healthy (≥70% everywhere); the two largest production clusters (Graph, Agent) are also the least cohesive — consistent with the oversized files listed in §4.
+
+**Hub symbols (highest fan-in — highest regression risk when edited):**
+
+| Symbol | File | Fan-in |
+|---|---|---|
+| `read_graph_file_text` | `src/graph/path_sandbox.py` | 54 |
+| `load_master_catalog` | `src/graph/master_catalog.py` | 40 |
+| `atomic_write_bytes` | `src/graph/markdown_blocks.py` | 35 |
+| `page_rmw_lock` | `src/graph/page_write_lock.py` | 34 |
+| `MasterCatalog.upsert` / `save` | `src/graph/master_catalog.py` | 30 / 20 |
+| `cross_process_json_flock` | `src/graph/json_flock.py` | 27 |
+
+Any change to these must go through impact analysis first (per CLAUDE.md policy); they concentrate the write-safety of the whole system.
+
+## 2. Correctness findings (bugs)
+
+### F1 — HIGH: `MasterCatalog.remove()` then `upsert()` of the same title is lost on `save()`
+`src/graph/master_catalog.py:157-164` — `save(replace=False)` first merges `pending` (which contains the re-added entry) into disk state, **then** pops every title in `_pending_removals`. A `remove("X")` followed by `upsert("X", …)` therefore deletes X from disk even though the in-memory catalog holds it. Worse, line 178 then sets `self.pages = merged_pages`, silently dropping the entry from memory too.
+**Fix:** in `upsert()`, discard the title from `_pending_removals` under the lock; or apply removals *before* merging pending rows in `save()`.
+
+### F2 — HIGH: corrupt catalog silently treated as empty during merge
+`src/graph/master_catalog.py:264-274` — `_load_catalog_pages_unlocked` returns `{}` on `BoundedJsonError` or non-dict payload. Under `save(replace=False)` this means a transiently corrupt/truncated `master_catalog.json` is merged as if the disk were empty: rows written by other processes since this process's load are permanently dropped, with no log line and no quarantine (the `_quarantine_corrupt_catalog` path exists but is not used here).
+**Fix:** distinguish "file absent" (→ `{}`) from "file unreadable" (→ abort the merge-save, log, quarantine; or fall back to `replace=False` retry after quarantine).
+
+### F3 — MEDIUM: `prune_missing_pages()` does not record removals
+`src/graph/master_catalog.py:240-257` — pruned titles are deleted only from `self.pages`, not added to `_pending_removals`. Correctness currently depends on every caller invoking `save(replace=True)` afterwards; a caller using the default `save()` resurrects all pruned rows from disk. Implicit temporal coupling with no guard.
+**Fix:** add pruned titles to `_pending_removals`, or have `prune_missing_pages` return a flag/perform the replace-save itself.
+
+### F4 — MEDIUM: file watcher ignores `moved` events
+`src/daemon/file_watcher.py` — the handler implements `on_created/on_modified/on_deleted` only. Editors and sync tools (iCloud, Syncthing, some Logseq plugins, `git checkout`) commonly update files via write-to-temp + rename, which watchdog reports as a *moved* event. Those updates never reach `_on_debounced`: the page silently goes stale in the semantic index until the next full scan.
+**Fix:** implement `on_moved`, treating `dest_path` as created/modified and `src_path` as deleted (both subject to the same sandbox + `.md` filters).
+
+### F5 — MEDIUM: unbounded `threading.Timer` fan-out under change bursts
+`src/daemon/file_watcher.py:80-98` — one `Timer` thread per touched file. A bulk operation (git branch switch, sync-client re-download, mass tag rewrite by the daemon itself) on a few thousand pages spawns a few thousand OS threads within the debounce window. macOS will take it, but memory and scheduler pressure spike, and the debounced callbacks then stampede the flock/RMW locks.
+**Fix (TRIZ §6, Principle 1 – Segmentation):** replace per-file timers with a single scheduler thread draining a `dict[path → deadline]` (monotonic heap), i.e. one thread, N deadlines. Also yields a natural place for a global "burst mode" that coalesces into one full-rescan when the pending set exceeds a threshold (Principle 16 – Partial/excessive action).
+
+### F6 — LOW: `except BaseException` in transport retry
+`src/agent/llm_client.py:120` — correctness is preserved (non-retryable exceptions re-raise, and `KeyboardInterrupt` is not in the retryable set), but catching `BaseException` still momentarily swallows `SystemExit`/`KeyboardInterrupt` into the classifier path. `except Exception` plus the explicit httpx/OpenAI types is sufficient and self-documenting.
+
+### F7 — LOW: `get_case_insensitive` is O(n) under the instance lock
+`src/graph/master_catalog.py:193-203` — linear casefold scan of all pages while holding `_lock`, on a hub type called from hot paths. With ~10k pages this serializes readers behind a full-dict scan.
+**Fix:** maintain a lazily built `casefold → title` side map, invalidated on upsert/remove (Principle 10 – Preliminary action).
+
+## 3. Structural / architectural findings
+
+### F8 — 5 circular file imports (code audit `check`)
+1. `agent/control_room_progress.py ↔ agent/maintenance_daemon.py`
+2. `agent/dispatch_lint_handlers.py ↔ agent/graph_dispatch.py`
+3. `agent/importers/tana/graph.py ↔ tana/load.py`
+4. `agent/plumber_config.py ↔ utils/llm_url_policy.py`
+5. `graph/alias_index.py ↔ graph/page_path.py`
+
+All are currently defused with function-local (deferred) imports — no runtime crash — but each is a dependency-direction smell: `utils/` importing from `agent/` (cycle 4) inverts the layering, and cycle 1 shows the progress-reporting module reaching back into the daemon for both a type (`DaemonState`) and a metric function. Note the metric function also appears as `compute_phase2_progress_metrics` in `daemon_page_queue.py` (see F10). **Fix:** extract the shared pieces (the `DaemonState` protocol, the metrics function, the URL-policy validator) into leaf modules both sides import.
+
+### F9 — Oversized god-modules
+`maintenance_daemon.py` (1,274 LOC), `ui_server.py` (1,161), `llm_client.py` (1,119), plus six more files over 600 LOC. Combined with 104 ruff complexity findings (C901/PLR0912/PLR0915) concentrated in `property_line_edit.py` (7), `link_verification.py` (6), `semantic_clustering.py` (5), `bootstrap_harvest.py` (5), `maintenance_daemon.py` (5), these are the highest-defect-density candidates. The daemon modularization started in 1.13.0 (per changelog) should continue: `llm_client.py` cleanly splits into transport/retry, JSON-salvage, and prompt-assembly layers that already exist as distinct regions of the file.
+
+### F10 — Possible duplicate/dead symbols (verify before removing)
+Graph query for public functions with no CALLS/IMPORTS edges surfaced ~30 candidates. Most are **false positives** — the `handle_*` dispatch handlers are referenced through registry tables by name. But these deserve verification: `stop_daemon` (`daemon_process_lock.py`), `lookup_file_state` / `lock_backoff_active` / `record_page_lock_backoff` (`daemon_state.py`), `append_semantic_index` (`daemon_semantic_write.py`), `repl` (`importers/tana/link.py`), and the apparent duplication of `compute_phase2_progress_metrics` between `daemon_page_queue.py` and `maintenance_daemon.py`.
+
+### F11 — Security posture (positive, with one gap)
+UI server: token auth with LAN-explicit-token requirement, per-IP rate limits split authenticated/anonymous, loopback defaults — good. Path sandbox is centralized and heavily used. No `eval`/`exec`/`shell=True`, no mutable default args, zero bare excepts in `src/`. **Gap:** the code-audit taint layer is not built (`analyze --pdg` never run), so source→sink flows (e.g., LLM output → file writes) have never been machine-checked. Recommend running the PDG-enabled index once per release. Verified: `verify_ui_token` uses `secrets.compare_digest` (`src/cli/ui_auth.py:61`) — constant-time comparison confirmed.
+
+## 4. Static analysis summary
+
+- **ruff (default rules) on `src/`: 0 findings.** Exceptionally clean.
+- **ruff C901/PLR0912/PLR0915: 104 findings** — see F9 for the per-file concentration.
+- Broad `except Exception`: 34, all `noqa`-annotated with rationale (daemon-resilience pattern) — accepted, not a defect, except the `BaseException` variant (F6).
+- TODO/FIXME/HACK: only 9 across 34k LOC of `src/` — low debt signal.
+- `time.sleep`: 17 uses — synchronous backoff inside the daemon thread is acceptable for this architecture but couples retry latency to cycle latency (see TRIZ C3).
+
+## 5. Test suite
+
+402 test files; pytest gate `--cov-fail-under=70` enforced in `pyproject.toml`. Full run (no-cov) executed during this audit — **result recorded in §7 below.**
+
+## 6. TRIZ analysis — resolving the design contradictions
+
+**C1. "Never crash the daemon" vs. "never hide a failure."**
+34 broad exception handlers embody the first requirement; F2 shows the cost of the second. TRIZ Principle 22 (*Blessing in disguise*) + 11 (*Beforehand cushioning*): don't just log-and-continue — convert every swallowed exception into a *durable artifact* (quarantine file, dead-letter queue entry, health-status flag surfaced in the control room UI). The daemon keeps running **and** the failure becomes visible and re-processable. The quarantine mechanism already exists for corrupt catalogs and per-file LLM cycles; generalize it into a single `dead_letter(path|payload, reason)` utility so every `except Exception` handler has a one-line way to comply.
+
+**C2. "Merge-on-save for concurrent writers" vs. "deletions must stick" (root cause of F1/F3).**
+The last-mtime-wins merge is a CRDT-flavored design, but deletions are modeled outside it (a side set), which is why they interact badly with re-inserts. Principle 13 (*The other way round*): model deletion *inside* the merge domain — a tombstone row (`deleted_at` mtime) that participates in the same mtime comparison as upserts. Remove-then-upsert then resolves naturally (the newer upsert mtime beats the tombstone), and F1/F3 disappear as a class rather than as two patches.
+
+**C3. "React instantly to file changes" vs. "don't stampede under bulk changes" (F5).**
+Principle 37 (*Thermal expansion* → parameter-responsive behavior): make the debounce adaptive — small pending set ⇒ per-file responsiveness; pending set above a threshold ⇒ collapse into one batched rescan. Combined with the single-scheduler redesign this removes both the thread cliff and the lock stampede.
+
+**C4. "One shared mutable catalog" vs. "many independent processes."**
+Every hub in §1 exists to defend one global JSON file. Principle 1 (*Segmentation*) long-term: shard the catalog (per-namespace or hashed shards), so flock contention and merge blast radius shrink proportionally. This is the v2-scale move; F1–F3 fixes are worth doing first regardless.
+
+**C5. "utils must stay generic" vs. "policy lives near config" (F8 cycle 4).**
+Principle 24 (*Intermediary*): a leaf `policy/` module owning `validate_llm_proxy_url` breaks the `agent ↔ utils` inversion without moving config.
+
+## 7. Test run result
+
+Full suite (`pytest -q -o addopts=""`, coverage gate disabled for speed): **987 passed, 2 skipped, 0 failures in 2m00s.** Baseline is green — all findings above are latent, not currently exploding, which is exactly the right time to fix them.
+
+## 8. Prioritized recommendations
+
+| # | Action | Finding | Effort | Risk reduction |
+|---|--------|---------|--------|----------------|
+| 1 | Fix removal/upsert ordering in `MasterCatalog.save` (or adopt tombstones, TRIZ C2) | F1, F3 | S–M | Data loss |
+| 2 | Treat unreadable catalog as abort+quarantine, not empty | F2 | S | Data loss |
+| 3 | Handle `on_moved` in file watcher | F4 | S | Stale index |
+| 4 | Single-scheduler debounce + burst coalescing | F5 | M | Thread/lock storm |
+| 5 | Generalize dead-letter/quarantine for swallowed exceptions | C1 | M | Silent failures |
+| 6 | Break the 5 import cycles via leaf-module extraction | F8 | M | Maintainability |
+| 7 | Continue splitting the 3 god-modules; burn down the 104 complexity findings starting with `property_line_edit.py` | F9 | L | Defect density |
+| 8 | Run PDG-enabled code-audit index per release; review taint findings | F11 | S | Security blind spot |
+| 9 | Narrow `BaseException` → `Exception` in transport retry; casefold side-map in catalog | F6, F7 | S | Hygiene/perf |
+| 10 | Verify/remove the F10 dead-symbol candidates | F10 | S | Dead code |
+
+*Report generated incrementally during the audit; sections 1–6 were written as each analysis phase completed, §7 after the background test run finished.*

--- a/src/daemon/file_watcher.py
+++ b/src/daemon/file_watcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Protocol
@@ -74,28 +75,55 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
         self._graph_root = graph_root
         self._debounce_s = debounce_s
         self._on_debounced = on_debounced
-        self._timers: dict[str, threading.Timer] = {}
-        self._timer_lock = threading.Lock()
+        # Single background scheduler with per-file monotonic deadlines, instead of one
+        # threading.Timer per file: a bulk change (sync-client re-download, mass tag
+        # rewrite) touching thousands of files would otherwise spawn thousands of OS
+        # threads at once (F5, TRIZ Principle 20: continuous action / partial-excessive).
+        self._pending: dict[str, tuple[float, Path, FileEventKind]] = {}
+        self._lock = threading.Lock()
+        self._wake = threading.Condition(self._lock)
+        self._stopped = False
+        self._worker = threading.Thread(
+            target=self._run, name="matryca-watch-debounce", daemon=True
+        )
+        self._worker.start()
 
     def _schedule(self, path: Path, kind: FileEventKind) -> None:
         key = str(path)
-        with self._timer_lock:
-            existing = self._timers.pop(key, None)
-            if existing is not None:
-                existing.cancel()
+        deadline = time.monotonic() + self._debounce_s
+        with self._wake:
+            self._pending[key] = (deadline, path, kind)
+            self._wake.notify_all()
 
-            def fire() -> None:
-                with self._timer_lock:
-                    self._timers.pop(key, None)
+    def _run(self) -> None:
+        with self._wake:
+            while not self._stopped:
+                if not self._pending:
+                    self._wake.wait()
+                    continue
+                now = time.monotonic()
+                next_deadline = min(deadline for deadline, _, _ in self._pending.values())
+                if next_deadline > now:
+                    self._wake.wait(timeout=next_deadline - now)
+                    continue
+                due = [
+                    (key, path, kind)
+                    for key, (deadline, path, kind) in self._pending.items()
+                    if deadline <= now
+                ]
+                for key, _, _ in due:
+                    del self._pending[key]
+                if not due:
+                    continue
+                self._wake.release()
                 try:
-                    self._on_debounced(path, kind)
-                except Exception:  # noqa: BLE001
-                    logger.exception("Debounced file watcher callback failed for {}", path)
-
-            timer = threading.Timer(self._debounce_s, fire)
-            timer.daemon = True
-            self._timers[key] = timer
-            timer.start()
+                    for _, path, kind in due:
+                        try:
+                            self._on_debounced(path, kind)
+                        except Exception:  # noqa: BLE001
+                            logger.exception("Debounced file watcher callback failed for {}", path)
+                finally:
+                    self._wake.acquire()
 
     def on_created(self, event: FileSystemEvent) -> None:
         self._handle(event)
@@ -106,11 +134,19 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
     def on_deleted(self, event: FileSystemEvent) -> None:
         self._handle(event)
 
+    def on_moved(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        self._handle_path(getattr(event, "src_path", None), "deleted")
+        self._handle_path(getattr(event, "dest_path", None), "created")
+
     def _handle(self, event: FileSystemEvent) -> None:
         kind = _event_kind(event)
         if kind is None:
             return
-        src = getattr(event, "src_path", None)
+        self._handle_path(getattr(event, "src_path", None), kind)
+
+    def _handle_path(self, src: str | None, kind: FileEventKind) -> None:
         if not src:
             return
         path = Path(src)
@@ -125,10 +161,11 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
         self._schedule(safe, kind)
 
     def cancel_all(self) -> None:
-        with self._timer_lock:
-            for timer in self._timers.values():
-                timer.cancel()
-            self._timers.clear()
+        with self._wake:
+            self._stopped = True
+            self._pending.clear()
+            self._wake.notify_all()
+        self._worker.join(timeout=2.0)
 
 
 class GraphFileWatcher:

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -103,6 +103,7 @@ class MasterCatalog:
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
     persist_allowed: bool = True
     _pending_removals: set[str] = field(default_factory=set, repr=False, compare=False)
+    _casefold_index: dict[str, str] | None = field(default=None, repr=False, compare=False)
 
     @staticmethod
     def catalog_path(graph_root: Path) -> Path:
@@ -176,6 +177,7 @@ class MasterCatalog:
             )
         with self._lock:
             self.pages = merged_pages
+            self._casefold_index = None
             self.updated_at = updated_at
             self._pending_removals.clear()
         cache_key = str(self.graph_root.expanduser().resolve(strict=False))
@@ -185,6 +187,8 @@ class MasterCatalog:
     def upsert(self, page_title: str, entry: CatalogEntry) -> None:
         with self._lock:
             self.pages[page_title] = entry
+            self._pending_removals.discard(page_title)
+            self._casefold_index = None
 
     def get(self, page_title: str) -> CatalogEntry | None:
         with self._lock:
@@ -197,10 +201,13 @@ class MasterCatalog:
             if entry is not None:
                 return page_title, entry
             fold = page_title.casefold()
-            for title, row in self.pages.items():
-                if title.casefold() == fold:
-                    return title, row
-            return None
+            if self._casefold_index is None:
+                self._casefold_index = {title.casefold(): title for title in self.pages}
+            canonical = self._casefold_index.get(fold)
+            if canonical is None:
+                return None
+            row = self.pages.get(canonical)
+            return None if row is None else (canonical, row)
 
     def rebuild_alias_index(self) -> None:
         """Refresh the in-memory alias map from ``alias::`` frontmatter across the graph."""
@@ -228,6 +235,7 @@ class MasterCatalog:
         with self._lock:
             self.pages.pop(page_title, None)
             self._pending_removals.add(page_title)
+            self._casefold_index = None
 
     def needs_refresh(self, page_title: str, mtime_ns: int) -> bool:
         """Return True when the on-disk page is newer than the catalog row."""
@@ -247,6 +255,9 @@ class MasterCatalog:
             stale = [title for title in self.pages if title not in live_titles]
             for title in stale:
                 del self.pages[title]
+                self._pending_removals.add(title)
+            if stale:
+                self._casefold_index = None
             alias_purged = 0
             orphan_keys = [
                 key for key, title in self.alias_to_page.items() if title not in live_titles
@@ -262,16 +273,45 @@ def _catalog_backup_path(catalog_path: Path) -> Path:
 
 
 def _load_catalog_pages_unlocked(path: Path, root: Path) -> dict[str, CatalogEntry]:
-    """Read catalog page rows from disk without acquiring flock."""
+    """Read catalog page rows from disk without acquiring flock.
+
+    Caller already holds the cross-process flock on ``path``, so corruption
+    handling here must not re-acquire it.
+    """
     if not path.is_file():
         return {}
     try:
         payload = read_bounded_json(path)
-    except BoundedJsonError:
+    except BoundedJsonError as exc:
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Unreadable master catalog at {} during merge-save: {}",
+            path,
+            exc,
+        )
+        _quarantine_or_warn(path)
         return {}
     if not isinstance(payload, dict):
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Non-dict master catalog payload at {} (merge-save)",
+            path,
+        )
+        _quarantine_or_warn(path)
         return {}
     return dict(MasterCatalog.from_json(root, payload).pages)
+
+
+def _quarantine_or_warn(path: Path) -> None:
+    try:
+        quarantined = _quarantine_corrupt_catalog(path)
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Quarantined malformed catalog to {}",
+            quarantined,
+        )
+    except OSError as move_exc:
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Could not quarantine catalog: {}",
+            move_exc,
+        )
 
 
 def _merge_catalog_page_deltas(


### PR DESCRIPTION
## Summary
- `upsert()` clears a pending removal, so a remove-then-upsert cycle no longer resurrects the old row on save.
- `prune_missing_pages()` now records its removals so a plain save can't undo a prune.
- Corrupt/non-dict catalog JSON is now logged and quarantined during merge-save instead of silently dropped.
- `file_watcher.py` now handles `on_moved` (rename), routing it as delete+create.
- Per-file `threading.Timer` fan-out replaced with a single debounce scheduler thread.
- `get_case_insensitive` now uses a cached, invalidated-on-write lowercase index instead of a full linear scan under lock.

Closes #210

## Test plan
- [x] `ruff check` clean on both files
- [x] `mypy --strict` clean on both files
- [x] `pytest tests/test_file_watcher.py tests/test_master_catalog.py` — 26 passed