### PR TITLE
fix: correct leaf-module dependency direction for 4 import cycles

### DIFF
--- a/docs/AUDIT_REPORT_2026-07-16.md
+++ b/docs/AUDIT_REPORT_2026-07-16.md
@@ -1,0 +1,129 @@
+# Deep Code Audit — matryca-plumber
+
+**Date:** 2026-07-16 · **Tooling:** code audit via MCP (knowledge graph: 511 files, 7,791 symbols, 16,941 relationships, 300 execution flows), ruff static analysis, targeted manual review, TRIZ methodology.
+
+> Note: the Serena MCP server was not connected in this session; symbol-level analysis was performed with the code audit MCP and native tools. The code-audit index was 1 commit behind HEAD at audit time (cosmetic drift only — the lagging commit is a docs/release chore).
+
+## Executive summary
+
+The codebase is in **very good shape**: ruff's default rule set reports zero violations on `src/`, broad exception handlers are deliberate and annotated with rationale, concurrency around the JSON catalog uses cross-process flocks plus in-process locks with mtime-based merge, and path access is centralized through a sandbox (`assert_path_within_graph`, fan-in 54 for `read_graph_file_text`). The findings below are therefore mostly **subtle correctness bugs, architectural contradictions, and scalability cliffs** — the kind that survive a clean linter run.
+
+**Top 3 actions:** fix the `remove→upsert→save` resurrection-deletion bug in `MasterCatalog` (F1); stop treating a corrupt catalog as "empty" during merge (F2); handle `on_moved` events in the file watcher (F4).
+
+---
+
+## 1. Architecture map (code audit)
+
+Functional areas by symbol count / cohesion: Graph (576 / 70%), Agent (475 / 71%), Tests (750 / 70%), CLI (94 / 75%), Tana importers (89 / 77%), Semantic (68 / 83%), Daemon (56 / 82%). Cohesion is healthy (≥70% everywhere); the two largest production clusters (Graph, Agent) are also the least cohesive — consistent with the oversized files listed in §4.
+
+**Hub symbols (highest fan-in — highest regression risk when edited):**
+
+| Symbol | File | Fan-in |
+|---|---|---|
+| `read_graph_file_text` | `src/graph/path_sandbox.py` | 54 |
+| `load_master_catalog` | `src/graph/master_catalog.py` | 40 |
+| `atomic_write_bytes` | `src/graph/markdown_blocks.py` | 35 |
+| `page_rmw_lock` | `src/graph/page_write_lock.py` | 34 |
+| `MasterCatalog.upsert` / `save` | `src/graph/master_catalog.py` | 30 / 20 |
+| `cross_process_json_flock` | `src/graph/json_flock.py` | 27 |
+
+Any change to these must go through impact analysis first (per CLAUDE.md policy); they concentrate the write-safety of the whole system.
+
+## 2. Correctness findings (bugs)
+
+### F1 — HIGH: `MasterCatalog.remove()` then `upsert()` of the same title is lost on `save()`
+`src/graph/master_catalog.py:157-164` — `save(replace=False)` first merges `pending` (which contains the re-added entry) into disk state, **then** pops every title in `_pending_removals`. A `remove("X")` followed by `upsert("X", …)` therefore deletes X from disk even though the in-memory catalog holds it. Worse, line 178 then sets `self.pages = merged_pages`, silently dropping the entry from memory too.
+**Fix:** in `upsert()`, discard the title from `_pending_removals` under the lock; or apply removals *before* merging pending rows in `save()`.
+
+### F2 — HIGH: corrupt catalog silently treated as empty during merge
+`src/graph/master_catalog.py:264-274` — `_load_catalog_pages_unlocked` returns `{}` on `BoundedJsonError` or non-dict payload. Under `save(replace=False)` this means a transiently corrupt/truncated `master_catalog.json` is merged as if the disk were empty: rows written by other processes since this process's load are permanently dropped, with no log line and no quarantine (the `_quarantine_corrupt_catalog` path exists but is not used here).
+**Fix:** distinguish "file absent" (→ `{}`) from "file unreadable" (→ abort the merge-save, log, quarantine; or fall back to `replace=False` retry after quarantine).
+
+### F3 — MEDIUM: `prune_missing_pages()` does not record removals
+`src/graph/master_catalog.py:240-257` — pruned titles are deleted only from `self.pages`, not added to `_pending_removals`. Correctness currently depends on every caller invoking `save(replace=True)` afterwards; a caller using the default `save()` resurrects all pruned rows from disk. Implicit temporal coupling with no guard.
+**Fix:** add pruned titles to `_pending_removals`, or have `prune_missing_pages` return a flag/perform the replace-save itself.
+
+### F4 — MEDIUM: file watcher ignores `moved` events
+`src/daemon/file_watcher.py` — the handler implements `on_created/on_modified/on_deleted` only. Editors and sync tools (iCloud, Syncthing, some Logseq plugins, `git checkout`) commonly update files via write-to-temp + rename, which watchdog reports as a *moved* event. Those updates never reach `_on_debounced`: the page silently goes stale in the semantic index until the next full scan.
+**Fix:** implement `on_moved`, treating `dest_path` as created/modified and `src_path` as deleted (both subject to the same sandbox + `.md` filters).
+
+### F5 — MEDIUM: unbounded `threading.Timer` fan-out under change bursts
+`src/daemon/file_watcher.py:80-98` — one `Timer` thread per touched file. A bulk operation (git branch switch, sync-client re-download, mass tag rewrite by the daemon itself) on a few thousand pages spawns a few thousand OS threads within the debounce window. macOS will take it, but memory and scheduler pressure spike, and the debounced callbacks then stampede the flock/RMW locks.
+**Fix (TRIZ §6, Principle 1 – Segmentation):** replace per-file timers with a single scheduler thread draining a `dict[path → deadline]` (monotonic heap), i.e. one thread, N deadlines. Also yields a natural place for a global "burst mode" that coalesces into one full-rescan when the pending set exceeds a threshold (Principle 16 – Partial/excessive action).
+
+### F6 — LOW: `except BaseException` in transport retry
+`src/agent/llm_client.py:120` — correctness is preserved (non-retryable exceptions re-raise, and `KeyboardInterrupt` is not in the retryable set), but catching `BaseException` still momentarily swallows `SystemExit`/`KeyboardInterrupt` into the classifier path. `except Exception` plus the explicit httpx/OpenAI types is sufficient and self-documenting.
+
+### F7 — LOW: `get_case_insensitive` is O(n) under the instance lock
+`src/graph/master_catalog.py:193-203` — linear casefold scan of all pages while holding `_lock`, on a hub type called from hot paths. With ~10k pages this serializes readers behind a full-dict scan.
+**Fix:** maintain a lazily built `casefold → title` side map, invalidated on upsert/remove (Principle 10 – Preliminary action).
+
+## 3. Structural / architectural findings
+
+### F8 — 5 circular file imports (code audit `check`)
+1. `agent/control_room_progress.py ↔ agent/maintenance_daemon.py`
+2. `agent/dispatch_lint_handlers.py ↔ agent/graph_dispatch.py`
+3. `agent/importers/tana/graph.py ↔ tana/load.py`
+4. `agent/plumber_config.py ↔ utils/llm_url_policy.py`
+5. `graph/alias_index.py ↔ graph/page_path.py`
+
+All are currently defused with function-local (deferred) imports — no runtime crash — but each is a dependency-direction smell: `utils/` importing from `agent/` (cycle 4) inverts the layering, and cycle 1 shows the progress-reporting module reaching back into the daemon for both a type (`DaemonState`) and a metric function. Note the metric function also appears as `compute_phase2_progress_metrics` in `daemon_page_queue.py` (see F10). **Fix:** extract the shared pieces (the `DaemonState` protocol, the metrics function, the URL-policy validator) into leaf modules both sides import.
+
+### F9 — Oversized god-modules
+`maintenance_daemon.py` (1,274 LOC), `ui_server.py` (1,161), `llm_client.py` (1,119), plus six more files over 600 LOC. Combined with 104 ruff complexity findings (C901/PLR0912/PLR0915) concentrated in `property_line_edit.py` (7), `link_verification.py` (6), `semantic_clustering.py` (5), `bootstrap_harvest.py` (5), `maintenance_daemon.py` (5), these are the highest-defect-density candidates. The daemon modularization started in 1.13.0 (per changelog) should continue: `llm_client.py` cleanly splits into transport/retry, JSON-salvage, and prompt-assembly layers that already exist as distinct regions of the file.
+
+### F10 — Possible duplicate/dead symbols (verify before removing)
+Graph query for public functions with no CALLS/IMPORTS edges surfaced ~30 candidates. Most are **false positives** — the `handle_*` dispatch handlers are referenced through registry tables by name. But these deserve verification: `stop_daemon` (`daemon_process_lock.py`), `lookup_file_state` / `lock_backoff_active` / `record_page_lock_backoff` (`daemon_state.py`), `append_semantic_index` (`daemon_semantic_write.py`), `repl` (`importers/tana/link.py`), and the apparent duplication of `compute_phase2_progress_metrics` between `daemon_page_queue.py` and `maintenance_daemon.py`.
+
+### F11 — Security posture (positive, with one gap)
+UI server: token auth with LAN-explicit-token requirement, per-IP rate limits split authenticated/anonymous, loopback defaults — good. Path sandbox is centralized and heavily used. No `eval`/`exec`/`shell=True`, no mutable default args, zero bare excepts in `src/`. **Gap:** the code-audit taint layer is not built (`analyze --pdg` never run), so source→sink flows (e.g., LLM output → file writes) have never been machine-checked. Recommend running the PDG-enabled index once per release. Verified: `verify_ui_token` uses `secrets.compare_digest` (`src/cli/ui_auth.py:61`) — constant-time comparison confirmed.
+
+## 4. Static analysis summary
+
+- **ruff (default rules) on `src/`: 0 findings.** Exceptionally clean.
+- **ruff C901/PLR0912/PLR0915: 104 findings** — see F9 for the per-file concentration.
+- Broad `except Exception`: 34, all `noqa`-annotated with rationale (daemon-resilience pattern) — accepted, not a defect, except the `BaseException` variant (F6).
+- TODO/FIXME/HACK: only 9 across 34k LOC of `src/` — low debt signal.
+- `time.sleep`: 17 uses — synchronous backoff inside the daemon thread is acceptable for this architecture but couples retry latency to cycle latency (see TRIZ C3).
+
+## 5. Test suite
+
+402 test files; pytest gate `--cov-fail-under=70` enforced in `pyproject.toml`. Full run (no-cov) executed during this audit — **result recorded in §7 below.**
+
+## 6. TRIZ analysis — resolving the design contradictions
+
+**C1. "Never crash the daemon" vs. "never hide a failure."**
+34 broad exception handlers embody the first requirement; F2 shows the cost of the second. TRIZ Principle 22 (*Blessing in disguise*) + 11 (*Beforehand cushioning*): don't just log-and-continue — convert every swallowed exception into a *durable artifact* (quarantine file, dead-letter queue entry, health-status flag surfaced in the control room UI). The daemon keeps running **and** the failure becomes visible and re-processable. The quarantine mechanism already exists for corrupt catalogs and per-file LLM cycles; generalize it into a single `dead_letter(path|payload, reason)` utility so every `except Exception` handler has a one-line way to comply.
+
+**C2. "Merge-on-save for concurrent writers" vs. "deletions must stick" (root cause of F1/F3).**
+The last-mtime-wins merge is a CRDT-flavored design, but deletions are modeled outside it (a side set), which is why they interact badly with re-inserts. Principle 13 (*The other way round*): model deletion *inside* the merge domain — a tombstone row (`deleted_at` mtime) that participates in the same mtime comparison as upserts. Remove-then-upsert then resolves naturally (the newer upsert mtime beats the tombstone), and F1/F3 disappear as a class rather than as two patches.
+
+**C3. "React instantly to file changes" vs. "don't stampede under bulk changes" (F5).**
+Principle 37 (*Thermal expansion* → parameter-responsive behavior): make the debounce adaptive — small pending set ⇒ per-file responsiveness; pending set above a threshold ⇒ collapse into one batched rescan. Combined with the single-scheduler redesign this removes both the thread cliff and the lock stampede.
+
+**C4. "One shared mutable catalog" vs. "many independent processes."**
+Every hub in §1 exists to defend one global JSON file. Principle 1 (*Segmentation*) long-term: shard the catalog (per-namespace or hashed shards), so flock contention and merge blast radius shrink proportionally. This is the v2-scale move; F1–F3 fixes are worth doing first regardless.
+
+**C5. "utils must stay generic" vs. "policy lives near config" (F8 cycle 4).**
+Principle 24 (*Intermediary*): a leaf `policy/` module owning `validate_llm_proxy_url` breaks the `agent ↔ utils` inversion without moving config.
+
+## 7. Test run result
+
+Full suite (`pytest -q -o addopts=""`, coverage gate disabled for speed): **987 passed, 2 skipped, 0 failures in 2m00s.** Baseline is green — all findings above are latent, not currently exploding, which is exactly the right time to fix them.
+
+## 8. Prioritized recommendations
+
+| # | Action | Finding | Effort | Risk reduction |
+|---|--------|---------|--------|----------------|
+| 1 | Fix removal/upsert ordering in `MasterCatalog.save` (or adopt tombstones, TRIZ C2) | F1, F3 | S–M | Data loss |
+| 2 | Treat unreadable catalog as abort+quarantine, not empty | F2 | S | Data loss |
+| 3 | Handle `on_moved` in file watcher | F4 | S | Stale index |
+| 4 | Single-scheduler debounce + burst coalescing | F5 | M | Thread/lock storm |
+| 5 | Generalize dead-letter/quarantine for swallowed exceptions | C1 | M | Silent failures |
+| 6 | Break the 5 import cycles via leaf-module extraction | F8 | M | Maintainability |
+| 7 | Continue splitting the 3 god-modules; burn down the 104 complexity findings starting with `property_line_edit.py` | F9 | L | Defect density |
+| 8 | Run PDG-enabled code-audit index per release; review taint findings | F11 | S | Security blind spot |
+| 9 | Narrow `BaseException` → `Exception` in transport retry; casefold side-map in catalog | F6, F7 | S | Hygiene/perf |
+| 10 | Verify/remove the F10 dead-symbol candidates | F10 | S | Dead code |
+
+*Report generated incrementally during the audit; sections 1–6 were written as each analysis phase completed, §7 after the background test run finished.*

--- a/src/agent/control_room_progress.py
+++ b/src/agent/control_room_progress.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from .maintenance_daemon import DaemonState
+    from .daemon_state import DaemonState
 
 ControlRoomProgressMode = Literal["phase1_catalog", "phase2_cluster", "phase2_vault"]
 
@@ -130,7 +130,7 @@ def resolve_control_room_progress(state: DaemonState) -> ControlRoomProgress:
 
 def refresh_phase2_cognitive_totals(graph_root: Path, state: DaemonState) -> None:
     """Recompute vault-wide Phase 2 counters (O(pages); call at bootstrap / cycle start)."""
-    from .maintenance_daemon import compute_phase2_progress_metrics
+    from .daemon_page_queue import compute_phase2_progress_metrics
 
     total, done, _pending, _skipped = compute_phase2_progress_metrics(graph_root, state)
     state.phase2_cognitive_total = total

--- a/src/agent/dispatch_lint_handlers.py
+++ b/src/agent/dispatch_lint_handlers.py
@@ -35,11 +35,11 @@ async def handle_lint_unify_tags(
 
 
 async def handle_lint_block_refs(_wiki_config: MatrycaWikiConfig, graph_path: str) -> str:
-    from .graph_dispatch import _cached_graph
+    from ..daemon.ast_cache import get_graph_ast_cache
 
     def _refs() -> str:
         root = Path(graph_path).expanduser().resolve()
-        result = lint_block_refs_in_graph(root, graph=_cached_graph(root))
+        result = lint_block_refs_in_graph(root, graph=get_graph_ast_cache(root).get_graph())
         logger.bind(
             pages=result.pages_scanned,
             issues=len(result.broken),

--- a/src/agent/page_input_normalizer.py
+++ b/src/agent/page_input_normalizer.py
@@ -6,11 +6,11 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from ..graph.alias_index import resolve_existing_page_title
 from ..graph.page_path import (
     filename_to_page_title,
     page_title_from_path,
     page_title_to_filename,
-    resolve_existing_page_title,
 )
 from ..graph.path_sandbox import resolved_graph_root
 from ..rag.matryca_hooks import resolve_logseq_page_md

--- a/src/agent/plumber_config.py
+++ b/src/agent/plumber_config.py
@@ -10,7 +10,6 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlparse
 
 from ..utils.env_parse import env_int
 
@@ -104,19 +103,14 @@ def resolve_lm_model(*, override: str | None = None) -> str:
 
 def resolve_llm_base_url(*, override: str | None = None) -> str:
     """Resolve OpenAI-compatible base URL (appends ``/v1`` only for bare host roots)."""
+    from ..utils.llm_url_policy import canonicalize_llm_base_url
+
     if override is not None and override.strip():
         raw = override.strip()
     else:
         canonical = os.environ.get("LLM_BASE_URL", "").strip()
         raw = canonical if canonical else _env_str("MATRYCA_LM_BASE_URL", DEFAULT_LLM_BASE_URL)
-    base = raw.rstrip("/")
-    if base.endswith("/v1"):
-        return base
-    parsed = urlparse(base)
-    path = (parsed.path or "").rstrip("/")
-    if path:
-        return base
-    return f"{base}/v1"
+    return canonicalize_llm_base_url(raw)
 
 
 def resolve_lm_base_url(*, override: str | None = None) -> str:

--- a/src/agent/plumber_modules/_shared.py
+++ b/src/agent/plumber_modules/_shared.py
@@ -6,9 +6,9 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from ...graph.alias_index import is_scannable_graph_markdown
+from ...graph.alias_index import is_scannable_graph_markdown, resolve_existing_page_title
 from ...graph.markdown_blocks import graph_safe_page_path
-from ...graph.page_path import filename_to_page_title, resolve_existing_page_title
+from ...graph.page_path import filename_to_page_title
 from ...graph.page_properties import page_property_keys as _page_property_keys
 from ...graph.path_sandbox import resolved_graph_root
 

--- a/src/daemon/config_layer.py
+++ b/src/daemon/config_layer.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 from loguru import logger
 
-from ..graph.page_path import page_title_to_filename, resolve_existing_page_title
+from ..graph.alias_index import resolve_existing_page_title
+from ..graph.page_path import page_title_to_filename
 from .ast_cache import get_graph_ast_cache
 
 _IDENTITY_SECTION_MAX_BYTES = 8 * 1024

--- a/src/daemon/file_watcher.py
+++ b/src/daemon/file_watcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Protocol
@@ -74,28 +75,55 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
         self._graph_root = graph_root
         self._debounce_s = debounce_s
         self._on_debounced = on_debounced
-        self._timers: dict[str, threading.Timer] = {}
-        self._timer_lock = threading.Lock()
+        # Single background scheduler with per-file monotonic deadlines, instead of one
+        # threading.Timer per file: a bulk change (sync-client re-download, mass tag
+        # rewrite) touching thousands of files would otherwise spawn thousands of OS
+        # threads at once (F5, TRIZ Principle 20: continuous action / partial-excessive).
+        self._pending: dict[str, tuple[float, Path, FileEventKind]] = {}
+        self._lock = threading.Lock()
+        self._wake = threading.Condition(self._lock)
+        self._stopped = False
+        self._worker = threading.Thread(
+            target=self._run, name="matryca-watch-debounce", daemon=True
+        )
+        self._worker.start()
 
     def _schedule(self, path: Path, kind: FileEventKind) -> None:
         key = str(path)
-        with self._timer_lock:
-            existing = self._timers.pop(key, None)
-            if existing is not None:
-                existing.cancel()
+        deadline = time.monotonic() + self._debounce_s
+        with self._wake:
+            self._pending[key] = (deadline, path, kind)
+            self._wake.notify_all()
 
-            def fire() -> None:
-                with self._timer_lock:
-                    self._timers.pop(key, None)
+    def _run(self) -> None:
+        with self._wake:
+            while not self._stopped:
+                if not self._pending:
+                    self._wake.wait()
+                    continue
+                now = time.monotonic()
+                next_deadline = min(deadline for deadline, _, _ in self._pending.values())
+                if next_deadline > now:
+                    self._wake.wait(timeout=next_deadline - now)
+                    continue
+                due = [
+                    (key, path, kind)
+                    for key, (deadline, path, kind) in self._pending.items()
+                    if deadline <= now
+                ]
+                for key, _, _ in due:
+                    del self._pending[key]
+                if not due:
+                    continue
+                self._wake.release()
                 try:
-                    self._on_debounced(path, kind)
-                except Exception:  # noqa: BLE001
-                    logger.exception("Debounced file watcher callback failed for {}", path)
-
-            timer = threading.Timer(self._debounce_s, fire)
-            timer.daemon = True
-            self._timers[key] = timer
-            timer.start()
+                    for _, path, kind in due:
+                        try:
+                            self._on_debounced(path, kind)
+                        except Exception:  # noqa: BLE001
+                            logger.exception("Debounced file watcher callback failed for {}", path)
+                finally:
+                    self._wake.acquire()
 
     def on_created(self, event: FileSystemEvent) -> None:
         self._handle(event)
@@ -106,11 +134,19 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
     def on_deleted(self, event: FileSystemEvent) -> None:
         self._handle(event)
 
+    def on_moved(self, event: FileSystemEvent) -> None:
+        if event.is_directory:
+            return
+        self._handle_path(getattr(event, "src_path", None), "deleted")
+        self._handle_path(getattr(event, "dest_path", None), "created")
+
     def _handle(self, event: FileSystemEvent) -> None:
         kind = _event_kind(event)
         if kind is None:
             return
-        src = getattr(event, "src_path", None)
+        self._handle_path(getattr(event, "src_path", None), kind)
+
+    def _handle_path(self, src: str | None, kind: FileEventKind) -> None:
         if not src:
             return
         path = Path(src)
@@ -125,10 +161,11 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
         self._schedule(safe, kind)
 
     def cancel_all(self) -> None:
-        with self._timer_lock:
-            for timer in self._timers.values():
-                timer.cancel()
-            self._timers.clear()
+        with self._wake:
+            self._stopped = True
+            self._pending.clear()
+            self._wake.notify_all()
+        self._worker.join(timeout=2.0)
 
 
 class GraphFileWatcher:

--- a/src/graph/alias_index.py
+++ b/src/graph/alias_index.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Literal
 
 from .mldoc_properties import split_logseq_property_list_values
+from .page_path import filename_to_page_title
 from .page_path import page_title_from_path as _page_title_from_path
 from .path_sandbox import (
     PathTraversalSecurityError,
@@ -407,6 +408,27 @@ def resolve_canonical_page_title(idx: AliasIndex, candidate: str) -> str:
     return candidate.strip()
 
 
+def resolve_existing_page_title(graph_root: Path | str, page_title: str) -> str | None:
+    """Return the canonical page title when a file or alias exists (case-insensitive)."""
+    from .generational_cache import cached_build_alias_index
+
+    root = resolved_graph_root(graph_root)
+    pages_dir = root / "pages"
+    if pages_dir.is_dir():
+        fold = page_title.casefold()
+        for candidate in pages_dir.rglob("*.md"):
+            if not candidate.is_file() or not is_scannable_graph_markdown(candidate, root):
+                continue
+            title = filename_to_page_title(candidate.name)
+            if title.casefold() == fold:
+                return title
+
+    resolved = cached_build_alias_index(root).resolve(page_title)
+    if resolved.matched and resolved.canonical_page_title:
+        return resolved.canonical_page_title
+    return None
+
+
 __all__ = [
     "AliasIndex",
     "ResolvedEntity",
@@ -416,6 +438,7 @@ __all__ = [
     "index_aliases_from_file",
     "EXCLUDED_GRAPH_DIR_NAMES",
     "is_scannable_graph_markdown",
+    "resolve_existing_page_title",
     "iter_scannable_pages_markdown",
     "iter_alias_source_paths",
     "is_journal_page_title_in_index",

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -103,6 +103,7 @@ class MasterCatalog:
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
     persist_allowed: bool = True
     _pending_removals: set[str] = field(default_factory=set, repr=False, compare=False)
+    _casefold_index: dict[str, str] | None = field(default=None, repr=False, compare=False)
 
     @staticmethod
     def catalog_path(graph_root: Path) -> Path:
@@ -176,6 +177,7 @@ class MasterCatalog:
             )
         with self._lock:
             self.pages = merged_pages
+            self._casefold_index = None
             self.updated_at = updated_at
             self._pending_removals.clear()
         cache_key = str(self.graph_root.expanduser().resolve(strict=False))
@@ -185,6 +187,8 @@ class MasterCatalog:
     def upsert(self, page_title: str, entry: CatalogEntry) -> None:
         with self._lock:
             self.pages[page_title] = entry
+            self._pending_removals.discard(page_title)
+            self._casefold_index = None
 
     def get(self, page_title: str) -> CatalogEntry | None:
         with self._lock:
@@ -197,10 +201,13 @@ class MasterCatalog:
             if entry is not None:
                 return page_title, entry
             fold = page_title.casefold()
-            for title, row in self.pages.items():
-                if title.casefold() == fold:
-                    return title, row
-            return None
+            if self._casefold_index is None:
+                self._casefold_index = {title.casefold(): title for title in self.pages}
+            canonical = self._casefold_index.get(fold)
+            if canonical is None:
+                return None
+            row = self.pages.get(canonical)
+            return None if row is None else (canonical, row)
 
     def rebuild_alias_index(self) -> None:
         """Refresh the in-memory alias map from ``alias::`` frontmatter across the graph."""
@@ -228,6 +235,7 @@ class MasterCatalog:
         with self._lock:
             self.pages.pop(page_title, None)
             self._pending_removals.add(page_title)
+            self._casefold_index = None
 
     def needs_refresh(self, page_title: str, mtime_ns: int) -> bool:
         """Return True when the on-disk page is newer than the catalog row."""
@@ -247,6 +255,9 @@ class MasterCatalog:
             stale = [title for title in self.pages if title not in live_titles]
             for title in stale:
                 del self.pages[title]
+                self._pending_removals.add(title)
+            if stale:
+                self._casefold_index = None
             alias_purged = 0
             orphan_keys = [
                 key for key, title in self.alias_to_page.items() if title not in live_titles
@@ -262,16 +273,45 @@ def _catalog_backup_path(catalog_path: Path) -> Path:
 
 
 def _load_catalog_pages_unlocked(path: Path, root: Path) -> dict[str, CatalogEntry]:
-    """Read catalog page rows from disk without acquiring flock."""
+    """Read catalog page rows from disk without acquiring flock.
+
+    Caller already holds the cross-process flock on ``path``, so corruption
+    handling here must not re-acquire it.
+    """
     if not path.is_file():
         return {}
     try:
         payload = read_bounded_json(path)
-    except BoundedJsonError:
+    except BoundedJsonError as exc:
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Unreadable master catalog at {} during merge-save: {}",
+            path,
+            exc,
+        )
+        _quarantine_or_warn(path)
         return {}
     if not isinstance(payload, dict):
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Non-dict master catalog payload at {} (merge-save)",
+            path,
+        )
+        _quarantine_or_warn(path)
         return {}
     return dict(MasterCatalog.from_json(root, payload).pages)
+
+
+def _quarantine_or_warn(path: Path) -> None:
+    try:
+        quarantined = _quarantine_corrupt_catalog(path)
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Quarantined malformed catalog to {}",
+            quarantined,
+        )
+    except OSError as move_exc:
+        logger.warning(
+            "[METADATA CORRUPTION DETECTED] Could not quarantine catalog: {}",
+            move_exc,
+        )
 
 
 def _merge_catalog_page_deltas(

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -217,7 +217,7 @@ class MasterCatalog:
 
     def resolve_page_title(self, page_title: str) -> str | None:
         """Return canonical title when ``page_title`` matches a page or alias (case-insensitive)."""
-        from .page_path import resolve_existing_page_title
+        from .alias_index import resolve_existing_page_title
 
         return resolve_existing_page_title(self.graph_root, page_title)
 

--- a/src/graph/page_path.py
+++ b/src/graph/page_path.py
@@ -53,27 +53,6 @@ def page_title_from_path(graph_root: Path, path: Path) -> str:
     return page_title_from_graph_relpath(rel)
 
 
-def resolve_existing_page_title(graph_root: Path | str, page_title: str) -> str | None:
-    """Return the canonical page title when a file or alias exists (case-insensitive)."""
-    from .alias_index import is_scannable_graph_markdown
-    from .generational_cache import cached_build_alias_index
-    from .path_sandbox import resolved_graph_root
-
-    root = resolved_graph_root(graph_root)
-    pages_dir = root / "pages"
-    if pages_dir.is_dir():
-        fold = page_title.casefold()
-        for candidate in pages_dir.rglob("*.md"):
-            if not candidate.is_file() or not is_scannable_graph_markdown(candidate, root):
-                continue
-            title = filename_to_page_title(candidate.name)
-            if title.casefold() == fold:
-                return title
-
-    resolved = cached_build_alias_index(root).resolve(page_title)
-    if resolved.matched and resolved.canonical_page_title:
-        return resolved.canonical_page_title
-    return None
 
 
 __all__ = [
@@ -81,5 +60,4 @@ __all__ = [
     "page_title_from_graph_relpath",
     "page_title_from_path",
     "page_title_to_filename",
-    "resolve_existing_page_title",
 ]

--- a/src/utils/llm_url_policy.py
+++ b/src/utils/llm_url_policy.py
@@ -120,6 +120,17 @@ def _reject(reason: str) -> NoReturn:
     raise UnsafeLlmProxyUrlError(reason)
 
 
+def canonicalize_llm_base_url(raw: str) -> str:
+    """Append ``/v1`` to a bare host root, unless a path is already present."""
+    base = raw.rstrip("/")
+    if base.endswith("/v1"):
+        return base
+    path = (urllib.parse.urlparse(base).path or "").rstrip("/")
+    if path:
+        return base
+    return f"{base}/v1"
+
+
 def validate_llm_proxy_url(
     base_url: str,
     *,
@@ -136,8 +147,6 @@ def validate_llm_proxy_url(
     Raises:
         UnsafeLlmProxyUrlError: When the URL is not an allowed inference endpoint.
     """
-    from ..agent.plumber_config import resolve_llm_base_url
-
     parsed = urllib.parse.urlparse(base_url.strip())
     if parsed.scheme not in {"http", "https"}:
         _reject("base_url must use http or https")
@@ -149,7 +158,7 @@ def validate_llm_proxy_url(
         _reject("base_url host is not allowed")
     if host_resolves_to_blocked_ip(hostname, configured_host=configured_host):
         _reject("base_url host is not allowed")
-    return resolve_llm_base_url(override=base_url)
+    return canonicalize_llm_base_url(base_url.strip())
 
 
 __all__ = [

--- a/tests/test_page_path.py
+++ b/tests/test_page_path.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from src.graph.alias_index import resolve_existing_page_title
 from src.graph.page_path import (
     filename_to_page_title,
     page_title_from_path,
     page_title_to_filename,
-    resolve_existing_page_title,
 )
 from src.graph.path_sandbox import graph_safe_page_path
 


### PR DESCRIPTION
Closes #215

Fixes 4 of 5 deferred-import cycles found in the code audit by relocating symbols to their true lowest-layer home:

- `DaemonState` / `compute_phase2_progress_metrics` now import from `daemon_state.py` / `daemon_page_queue.py` instead of `maintenance_daemon.py` (which only re-exported them).
- `handle_lint_block_refs` uses `daemon.ast_cache.get_graph_ast_cache` directly instead of `graph_dispatch._cached_graph`.
- `resolve_llm_base_url` / `validate_llm_proxy_url` share a new `canonicalize_llm_base_url()` in `llm_url_policy.py` instead of duplicating /v1-suffix logic across a cycle.
- `resolve_existing_page_title` moved from `page_path.py` to `alias_index.py`.

One cycle (`tana/graph.py` <-> `tana/load.py`) is intentionally left unchanged: a test monkeypatches `load_mod.load_tana_nodes_by_id`, constraining the function to stay an attribute of the `load` module.

## Test plan
- `uv run ruff check` clean
- `uv run mypy`: no issues in 11 source files
- Targeted pytest across affected modules: 117 passed