### PR TITLE
fix(insights): emit warning on LLM failure before fallback [#114]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Graph Insights silent LLM fallback ([#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114))** — `run_graph_insights_engine` now emits `logger.exception(...)` before falling back to `_fallback_insights(metrics)` when `llm.generate_graph_insights` raises; `llm_used=False` semantics unchanged. Operators can distinguish LLM-enriched vs deterministic insights in logs.
+
 ## [2.0.0-alpha.4] - 2026-07-19
 
 **v2.0.0-alpha.4** — Shadow FTS query length bound ([#279](https://github.com/MarcoPorcellato/matryca-plumber/issues/279) / [#286](https://github.com/MarcoPorcellato/matryca-plumber/pull/286)) after **v2.0.0-alpha.3**. Axis 4 FTS5 gate **fully green** — **52 pass, 0 xfail** ([#278](https://github.com/MarcoPorcellato/matryca-plumber/issues/278) audit probe corrected in [#287](https://github.com/MarcoPorcellato/matryca-plumber/pull/287)). **Not an RC** — Axes 5–7 remain open on [#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261). Supersedes **`v2.0.0-alpha.3`** / PyPI **`2.0.0a3`** for new installs; prior alphas remain on PyPI (not yanked).

--- a/src/graph/insights_engine.py
+++ b/src/graph/insights_engine.py
@@ -7,6 +7,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from loguru import logger
 
 from .alias_index import iter_alias_source_paths, page_title_from_path
 from .cognitive_llm import GraphInsightsLLMResult, InsightsLLM
@@ -393,6 +394,10 @@ def run_graph_insights_engine(
             llm_result = llm.generate_graph_insights(metrics_json=payload, graph_root=root)
             llm_used = True
         except Exception:  # noqa: BLE001 - fallback to deterministic report
+            logger.warning(
+                "Graph Insights LLM call failed — falling back to deterministic report",
+                exc_info=True,
+            )
             llm_result = _fallback_insights(metrics)
     else:
         llm_result = _fallback_insights(metrics)

--- a/src/graph/insights_engine.py
+++ b/src/graph/insights_engine.py
@@ -7,6 +7,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+
 from loguru import logger
 
 from .alias_index import iter_alias_source_paths, page_title_from_path
@@ -394,9 +395,8 @@ def run_graph_insights_engine(
             llm_result = llm.generate_graph_insights(metrics_json=payload, graph_root=root)
             llm_used = True
         except Exception:  # noqa: BLE001 - fallback to deterministic report
-            logger.warning(
-                "Graph Insights LLM call failed — falling back to deterministic report",
-                exc_info=True,
+            logger.exception(
+                "Graph Insights LLM call failed — falling back to deterministic report"
             )
             llm_result = _fallback_insights(metrics)
     else:

--- a/tests/test_insights_engine_llm_fallback.py
+++ b/tests/test_insights_engine_llm_fallback.py
@@ -1,0 +1,151 @@
+"""Tests for Graph Insights LLM fallback observability (issue #114).
+
+Ensures that when ``llm.generate_graph_insights`` raises, the engine:
+- emits a ``logger.warning`` so operators can detect LLM failures in logs, and
+- returns ``llm_used=False`` (deterministic fallback semantics unchanged).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from src.graph.cognitive_llm import GraphInsightsLLMResult, InsightsLLM
+from src.graph.insights_engine import InsightsRunResult, run_graph_insights_engine
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FailingInsightsLLM(InsightsLLM):
+    """Stub LLM that always raises to simulate a network/model failure."""
+
+    def __init__(self, exc: Exception | None = None) -> None:
+        self._exc = exc or RuntimeError("simulated LLM failure")
+
+    def generate_graph_insights(
+        self, *, metrics_json: str, graph_root: Path
+    ) -> GraphInsightsLLMResult:
+        raise self._exc  # type: ignore[misc]
+
+
+class _OkInsightsLLM(InsightsLLM):
+    """Stub LLM that always succeeds."""
+
+    def generate_graph_insights(
+        self, *, metrics_json: str, graph_root: Path
+    ) -> GraphInsightsLLMResult:
+        return GraphInsightsLLMResult(
+            ontology_report="LLM-enriched report.",
+            cleanup_suggestions=["Fix orphan [[Alpha]]."],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_graph_root(tmp_path: Path) -> Path:
+    """Create the minimum vault layout required by the insights engine."""
+    (tmp_path / "pages").mkdir()
+    (tmp_path / "pages" / "Alpha.md").write_text("- note\n", encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_llm_failure_logs_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LLM raises, a warning must be emitted before the fallback."""
+    root = _minimal_graph_root(tmp_path)
+
+    warnings: list[str] = []
+
+    def _capture(msg: str, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+        warnings.append(msg)
+
+    monkeypatch.setattr("src.graph.insights_engine.logger.warning", _capture)
+
+    run_graph_insights_engine(root, llm=_FailingInsightsLLM())
+
+    assert any("fallback" in w.lower() or "llm" in w.lower() for w in warnings), (
+        f"Expected a warning mentioning the LLM fallback; got: {warnings}"
+    )
+
+
+def test_llm_failure_sets_llm_used_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LLM raises, ``InsightsRunResult.llm_used`` must be False."""
+    root = _minimal_graph_root(tmp_path)
+    # Silence the warning so test output is clean
+    monkeypatch.setattr("src.graph.insights_engine.logger.warning", lambda *a, **k: None)
+
+    result: InsightsRunResult = run_graph_insights_engine(root, llm=_FailingInsightsLLM())
+
+    assert result.llm_used is False, (
+        "llm_used should remain False when the LLM raises and the deterministic fallback is used."
+    )
+
+
+def test_llm_success_sets_llm_used_true(tmp_path: Path) -> None:
+    """When the LLM succeeds, ``InsightsRunResult.llm_used`` must be True."""
+    root = _minimal_graph_root(tmp_path)
+
+    result: InsightsRunResult = run_graph_insights_engine(root, llm=_OkInsightsLLM())
+
+    assert result.llm_used is True
+
+
+def test_llm_none_produces_deterministic_output(tmp_path: Path) -> None:
+    """When no LLM is provided the deterministic path runs and llm_used=False."""
+    root = _minimal_graph_root(tmp_path)
+
+    result: InsightsRunResult = run_graph_insights_engine(root, llm=None)
+
+    assert result.llm_used is False
+
+
+def test_llm_failure_still_writes_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback path must still produce a written insights page."""
+    root = _minimal_graph_root(tmp_path)
+    monkeypatch.setattr("src.graph.insights_engine.logger.warning", lambda *a, **k: None)
+
+    result: InsightsRunResult = run_graph_insights_engine(root, llm=_FailingInsightsLLM())
+
+    assert result.output_path.is_file(), (
+        "The insights page must be written even when the LLM call fails."
+    )
+
+
+def test_llm_failure_warning_contains_exc_info(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The warning call must pass ``exc_info=True`` so the traceback is captured."""
+    root = _minimal_graph_root(tmp_path)
+
+    captured_kwargs: list[dict] = []
+
+    def _capture_kwargs(msg: str, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+        captured_kwargs.append(dict(kwargs))
+
+    monkeypatch.setattr("src.graph.insights_engine.logger.warning", _capture_kwargs)
+
+    run_graph_insights_engine(root, llm=_FailingInsightsLLM())
+
+    assert captured_kwargs, "logger.warning was not called"
+    assert any(kw.get("exc_info") for kw in captured_kwargs), (
+        "logger.warning must be called with exc_info=True to capture the traceback"
+    )

--- a/tests/test_insights_engine_llm_fallback.py
+++ b/tests/test_insights_engine_llm_fallback.py
@@ -27,7 +27,7 @@ class _FailingInsightsLLM(InsightsLLM):
     def generate_graph_insights(
         self, *, metrics_json: str, graph_root: Path
     ) -> GraphInsightsLLMResult:
-        raise self._exc  # type: ignore[misc]
+        raise self._exc
 
 
 class _OkInsightsLLM(InsightsLLM):

--- a/tests/test_insights_engine_llm_fallback.py
+++ b/tests/test_insights_engine_llm_fallback.py
@@ -59,24 +59,24 @@ def _minimal_graph_root(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_llm_failure_logs_warning(
+def test_llm_failure_logs_exception(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the LLM raises, a warning must be emitted before the fallback."""
+    """When the LLM raises, logger.exception must be called to capture the traceback."""
     root = _minimal_graph_root(tmp_path)
 
-    warnings: list[str] = []
+    messages: list[str] = []
 
     def _capture(msg: str, *args: object, **kwargs: object) -> None:  # noqa: ARG001
-        warnings.append(msg)
+        messages.append(msg)
 
-    monkeypatch.setattr("src.graph.insights_engine.logger.warning", _capture)
+    monkeypatch.setattr("src.graph.insights_engine.logger.exception", _capture)
 
     run_graph_insights_engine(root, llm=_FailingInsightsLLM())
 
-    assert any("fallback" in w.lower() or "llm" in w.lower() for w in warnings), (
-        f"Expected a warning mentioning the LLM fallback; got: {warnings}"
+    assert any("fallback" in m.lower() or "llm" in m.lower() for m in messages), (
+        f"Expected a message mentioning the LLM fallback; got: {messages}"
     )
 
 
@@ -86,8 +86,8 @@ def test_llm_failure_sets_llm_used_false(
 ) -> None:
     """When the LLM raises, ``InsightsRunResult.llm_used`` must be False."""
     root = _minimal_graph_root(tmp_path)
-    # Silence the warning so test output is clean
-    monkeypatch.setattr("src.graph.insights_engine.logger.warning", lambda *a, **k: None)
+    # Silence the exception log so test output is clean
+    monkeypatch.setattr("src.graph.insights_engine.logger.exception", lambda *a, **k: None)
 
     result: InsightsRunResult = run_graph_insights_engine(root, llm=_FailingInsightsLLM())
 
@@ -120,7 +120,7 @@ def test_llm_failure_still_writes_page(
 ) -> None:
     """The fallback path must still produce a written insights page."""
     root = _minimal_graph_root(tmp_path)
-    monkeypatch.setattr("src.graph.insights_engine.logger.warning", lambda *a, **k: None)
+    monkeypatch.setattr("src.graph.insights_engine.logger.exception", lambda *a, **k: None)
 
     result: InsightsRunResult = run_graph_insights_engine(root, llm=_FailingInsightsLLM())
 
@@ -129,23 +129,20 @@ def test_llm_failure_still_writes_page(
     )
 
 
-def test_llm_failure_warning_contains_exc_info(
+def test_llm_failure_uses_logger_exception(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The warning call must pass ``exc_info=True`` so the traceback is captured."""
+    """The exception must be logged with logger.exception to capture the traceback."""
     root = _minimal_graph_root(tmp_path)
 
-    captured_kwargs: list[dict] = []
+    called: list[bool] = []
 
-    def _capture_kwargs(msg: str, *args: object, **kwargs: object) -> None:  # noqa: ARG001
-        captured_kwargs.append(dict(kwargs))
+    def _capture_exception(msg: str, *args: object, **kwargs: object) -> None:  # noqa: ARG001
+        called.append(True)
 
-    monkeypatch.setattr("src.graph.insights_engine.logger.warning", _capture_kwargs)
+    monkeypatch.setattr("src.graph.insights_engine.logger.exception", _capture_exception)
 
     run_graph_insights_engine(root, llm=_FailingInsightsLLM())
 
-    assert captured_kwargs, "logger.warning was not called"
-    assert any(kw.get("exc_info") for kw in captured_kwargs), (
-        "logger.warning must be called with exc_info=True to capture the traceback"
-    )
+    assert called, "logger.exception was not called"


### PR DESCRIPTION
## Summary

- When llm.generate_graph_insights() raises, emit logger.warning with exc_info=True
- Ensures operators can detect LLM failures in logs
- Maintains deterministic fallback behavior with llm_used=False

## Test plan

- [x] `make check` passes locally (or `make ci` for format-check too)
- [x] OCC / CRLF: graph writes preserve `id::` lines and page frontmatter at line 0
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [ ] If CLI/MCP/env changed: [`llms.txt`](../llms.txt) and [`.well-known/llms.txt`](../.well-known/llms.txt) stay in sync

## Issue linking

Closes #114
