### PR TITLE
feat(shadow): open_shadow_db connection helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- **Shadow DB connection helper (#181)** — `open_shadow_db` / `shadow_db_path` open sandboxed `shadow.sqlite` under `.matryca_semantic_cache/` and apply schema DDL (Phase 2 infra; sync not wired yet).
+
 ### Changed
 
 - **`env_str` migration for `MATRYCA_BM25_MODE` ([#169](https://github.com/MarcoPorcellato/matryca-plumber/issues/169) / [#194](https://github.com/MarcoPorcellato/matryca-plumber/pull/194))** — `_bm25_mode()` in `generational_cache.py` now reads `MATRYCA_BM25_MODE` via `env_str()` (strips + lowercases; empty → default) instead of a raw `os.environ.get`; `env_str` added to `src/utils/env_parse.py` and exported in `__all__`; `env_str` import hoisted to module level in `generational_cache.py`; loguru warning on unknown mode value. Tests added for unset/empty → default and value → stripped+lowercased. Thanks to @Maqbool61.

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -1,5 +1,6 @@
 """Shadow DB (`shadow.sqlite`) — daemon-owned read cache and memory graph layer."""
 
+from .connection import open_shadow_db, shadow_db_path
 from .schema import (
     MEMORY_GRAPH_DDL,
     SHADOW_DDL,
@@ -18,4 +19,6 @@ __all__ = [
     "SHADOW_READ_DDL",
     "SHADOW_SCHEMA_VERSION",
     "apply_shadow_schema",
+    "open_shadow_db",
+    "shadow_db_path",
 ]

--- a/src/shadow/connection.py
+++ b/src/shadow/connection.py
@@ -1,0 +1,43 @@
+"""Open ``shadow.sqlite`` under the graph semantic-cache directory (v2 Phase 2)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from .schema import apply_shadow_schema
+
+_SHADOW_CACHE_DIRNAME = ".matryca_semantic_cache"
+_SHADOW_DB_FILENAME = "shadow.sqlite"
+
+
+def shadow_db_path(graph_root: Path | str) -> Path:
+    """Return ``<graph>/.matryca_semantic_cache/shadow.sqlite`` (sandboxed)."""
+    root = resolved_graph_root(graph_root)
+    path = root / _SHADOW_CACHE_DIRNAME / _SHADOW_DB_FILENAME
+    return assert_path_within_graph(path, root)
+
+
+def open_shadow_db(graph_root: Path | str) -> sqlite3.Connection:
+    """Open (or create) ``shadow.sqlite``, apply pragmas + DDL, return connection.
+
+    Caller owns the connection lifetime (``close()``). Path is always under
+    ``graph_root`` via :func:`assert_path_within_graph`.
+    """
+    db_path = shadow_db_path(graph_root)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(db_path))
+    try:
+        apply_shadow_schema(connection)
+        connection.commit()
+    except Exception:
+        connection.close()
+        raise
+    return connection
+
+
+__all__ = [
+    "open_shadow_db",
+    "shadow_db_path",
+]

--- a/tests/test_shadow_connection.py
+++ b/tests/test_shadow_connection.py
@@ -1,0 +1,49 @@
+"""Tests for shadow.sqlite connection helper (#181)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.shadow.connection import open_shadow_db, shadow_db_path
+from src.shadow.schema import SHADOW_SCHEMA_VERSION
+
+
+def test_shadow_db_path_under_cache(tmp_path: Path) -> None:
+    path = shadow_db_path(tmp_path)
+    assert path == tmp_path / ".matryca_semantic_cache" / "shadow.sqlite"
+    assert path.is_relative_to(tmp_path.resolve())
+
+
+def test_open_shadow_db_creates_schema_version(tmp_path: Path) -> None:
+    conn = open_shadow_db(tmp_path)
+    try:
+        row = conn.execute(
+            "SELECT value FROM shadow_meta WHERE key = 'schema_version'",
+        ).fetchone()
+        assert row is not None
+        assert row[0] == str(SHADOW_SCHEMA_VERSION)
+        assert (tmp_path / ".matryca_semantic_cache" / "shadow.sqlite").is_file()
+    finally:
+        conn.close()
+
+
+def test_open_shadow_db_idempotent(tmp_path: Path) -> None:
+    first = open_shadow_db(tmp_path)
+    first.close()
+    second = open_shadow_db(tmp_path)
+    try:
+        tables = {
+            r[0]
+            for r in second.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'",
+            )
+        }
+        assert "pages" in tables
+        assert "blocks" in tables
+    finally:
+        second.close()
+
+
+def test_shadow_db_path_sandboxed_under_graph(tmp_path: Path) -> None:
+    path = shadow_db_path(tmp_path)
+    assert path.resolve().is_relative_to(tmp_path.resolve())


### PR DESCRIPTION
## Summary
Sandboxed `shadow.sqlite` under `.matryca_semantic_cache/` with schema apply via `open_shadow_db` / `shadow_db_path`.

## Test plan
- [x] `tests/test_shadow_connection.py`
- [x] `make check` on rebased branch

Fixes #181