### PR TITLE
feat(shadow): post_write incremental Markdown sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Shadow DB connection helper (#181)** — `open_shadow_db` / `shadow_db_path` open sandboxed `shadow.sqlite` under `.matryca_semantic_cache/` and apply schema DDL (Phase 2 infra; sync not wired yet).
+- **Shadow incremental sync (#182)** — `post_write` bridge upserts `pages`/`blocks` into `shadow.sqlite` after Markdown commits (read-only on vault files).
 
 ### Changed
 

--- a/src/daemon/__init__.py
+++ b/src/daemon/__init__.py
@@ -17,7 +17,10 @@ from .post_write_hooks import (
 
 
 def register_daemon_post_write_hooks(graph_root: Path) -> None:
-    """Wire surgical git commits and identity refresh after successful markdown writes."""
+    """Wire surgical git commits, identity refresh, and shadow sync after writes."""
+    from ..shadow.sync import ensure_shadow_sync_bridge
+
+    ensure_shadow_sync_bridge()
     root = graph_root.expanduser().resolve(strict=False)
 
     def _on_commit(event: PostWriteEvent) -> None:

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -10,6 +10,7 @@ from .schema import (
     SHADOW_SCHEMA_VERSION,
     apply_shadow_schema,
 )
+from .sync import ensure_shadow_sync_bridge, sync_page_to_shadow
 
 __all__ = [
     "MEMORY_GRAPH_DDL",
@@ -19,6 +20,8 @@ __all__ = [
     "SHADOW_READ_DDL",
     "SHADOW_SCHEMA_VERSION",
     "apply_shadow_schema",
+    "ensure_shadow_sync_bridge",
     "open_shadow_db",
     "shadow_db_path",
+    "sync_page_to_shadow",
 ]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -1,0 +1,193 @@
+"""Incremental Markdown → shadow.sqlite sync (v2 Phase 2).
+
+Read-only on source ``.md`` files. Upserts ``pages`` / ``blocks`` after
+successful graph writes via the page-written port.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from logseq_matryca_parser.graph import StackMachineParser
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+from loguru import logger
+
+from ..graph.page_path import page_title_from_path
+from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from ..graph.post_write import PageWrittenEvent, register_page_written_handler
+from .connection import open_shadow_db
+
+_bridge_lock = threading.Lock()
+_bridge_registered = False
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _block_uuid(node: LogseqNode) -> str:
+    props = node.properties or {}
+    explicit = props.get("id")
+    if explicit:
+        return str(explicit).strip()
+    if node.source_uuid:
+        return str(node.source_uuid).strip()
+    return str(node.uuid).strip()
+
+
+def _props_json(props: dict[str, Any] | None) -> str:
+    return json.dumps(props or {}, ensure_ascii=False, sort_keys=True)
+
+
+def _is_journal_relpath(rel: str) -> bool:
+    return rel.startswith("journals/") or "/journals/" in rel
+
+
+def _walk_blocks(
+    nodes: list[LogseqNode],
+    *,
+    parent_uuid: str | None,
+    sort_base: int,
+) -> list[tuple[str, str | None, int, int, str, dict[str, Any]]]:
+    """Flatten outline to ``(uuid, parent_uuid, sort_order, indent, content, props)``."""
+    rows: list[tuple[str, str | None, int, int, str, dict[str, Any]]] = []
+    for index, node in enumerate(nodes):
+        uuid = _block_uuid(node)
+        rows.append(
+            (
+                uuid,
+                parent_uuid,
+                sort_base + index,
+                int(node.indent_level),
+                node.content or "",
+                dict(node.properties or {}),
+            )
+        )
+        rows.extend(
+            _walk_blocks(
+                list(node.children or []),
+                parent_uuid=uuid,
+                sort_base=0,
+            )
+        )
+    return rows
+
+
+def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
+    """Parse ``page_path`` and upsert its rows into ``shadow.sqlite``.
+
+    If the file is missing, remove the corresponding ``pages`` row (cascade).
+    """
+    root = resolved_graph_root(graph_root)
+    path = assert_path_within_graph(page_path, root)
+    if path.suffix.lower() != ".md":
+        return
+
+    conn = open_shadow_db(root)
+    try:
+        title = page_title_from_path(root, path)
+        rel = path.relative_to(root).as_posix()
+        if not path.is_file():
+            conn.execute("DELETE FROM pages WHERE title = ?", (title,))
+            conn.commit()
+            return
+
+        stat = path.stat()
+        text = path.read_text(encoding="utf-8")
+        page: LogseqPage = StackMachineParser().parse(text, page_title=title)
+        synced_at = _utc_now_iso()
+        is_journal = 1 if _is_journal_relpath(rel) else 0
+        props_json = _props_json(dict(page.properties or {}))
+
+        conn.execute("DELETE FROM pages WHERE title = ?", (title,))
+        cur = conn.execute(
+            """
+            INSERT INTO pages (
+                title, file_path, file_mtime_ns, file_size,
+                is_journal, properties_json, synced_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                title,
+                rel,
+                int(stat.st_mtime_ns),
+                int(stat.st_size),
+                is_journal,
+                props_json,
+                synced_at,
+            ),
+        )
+        page_id = int(cur.lastrowid or 0)
+        if page_id <= 0:
+            raise RuntimeError("shadow pages insert returned no page_id")
+        flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
+        uuid_to_rowid: dict[str, int] = {}
+        for block_uuid, parent_uuid, sort_order, indent, content, props in flat:
+            parent_rowid = uuid_to_rowid.get(parent_uuid) if parent_uuid else None
+            block_cur = conn.execute(
+                """
+                INSERT INTO blocks (
+                    block_uuid, page_id, parent_rowid, sort_order,
+                    indent_level, content, properties_json, synced_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    block_uuid,
+                    page_id,
+                    parent_rowid,
+                    sort_order,
+                    indent,
+                    content,
+                    _props_json(props),
+                    synced_at,
+                ),
+            )
+            rowid = int(block_cur.lastrowid or 0)
+            if rowid <= 0:
+                raise RuntimeError(
+                    f"shadow blocks insert returned no rowid for {block_uuid}"
+                )
+            uuid_to_rowid[block_uuid] = rowid
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _on_shadow_page_written(event: PageWrittenEvent) -> None:
+    if event.path.suffix.lower() != ".md":
+        return
+    try:
+        sync_page_to_shadow(event.graph_root, event.path)
+    except Exception:  # noqa: BLE001 — fail-safe like AST bridge
+        logger.exception("Shadow sync failed after write to {}", event.path)
+
+
+def ensure_shadow_sync_bridge() -> None:
+    """Register shadow upsert on the graph-local post-write port (once)."""
+    global _bridge_registered
+    with _bridge_lock:
+        if _bridge_registered:
+            return
+        register_page_written_handler(_on_shadow_page_written)
+        _bridge_registered = True
+
+
+def reset_shadow_sync_bridge_for_tests() -> None:
+    """Allow re-registration after ``clear_page_written_handlers`` (tests only)."""
+    global _bridge_registered
+    with _bridge_lock:
+        _bridge_registered = False
+
+
+__all__ = [
+    "ensure_shadow_sync_bridge",
+    "reset_shadow_sync_bridge_for_tests",
+    "sync_page_to_shadow",
+]

--- a/tests/test_shadow_sync.py
+++ b/tests/test_shadow_sync.py
@@ -1,0 +1,146 @@
+"""Integration tests for shadow incremental sync (#182)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.graph.markdown_blocks import atomic_write_bytes
+from src.graph.post_write import clear_page_written_handlers, emit_page_written
+from src.shadow.connection import open_shadow_db
+from src.shadow.sync import (
+    ensure_shadow_sync_bridge,
+    reset_shadow_sync_bridge_for_tests,
+    sync_page_to_shadow,
+)
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def test_sync_page_to_shadow_upserts_blocks(tmp_path: Path) -> None:
+    page = _write_page(
+        tmp_path,
+        "pages/ShadowSync.md",
+        "- parent block\n"
+        "  id:: 11111111-1111-4111-8111-111111111111\n"
+        "  - child block\n"
+        "    id:: 22222222-2222-4222-8222-222222222222\n",
+    )
+    sync_page_to_shadow(tmp_path, page)
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        pages = conn.execute("SELECT title, file_path FROM pages").fetchall()
+        assert pages == [("ShadowSync", "pages/ShadowSync.md")]
+        blocks = conn.execute(
+            "SELECT block_uuid, content, parent_rowid IS NOT NULL "
+            "FROM blocks ORDER BY sort_order, rowid"
+        ).fetchall()
+        assert len(blocks) == 2
+        uuids = {row[0] for row in blocks}
+        assert "11111111-1111-4111-8111-111111111111" in uuids
+        assert "22222222-2222-4222-8222-222222222222" in uuids
+        child = conn.execute(
+            "SELECT content FROM blocks WHERE block_uuid = ?",
+            ("22222222-2222-4222-8222-222222222222",),
+        ).fetchone()
+        assert child is not None
+        assert "child block" in child[0]
+    finally:
+        conn.close()
+
+
+def test_sync_page_to_shadow_replaces_on_rewrite(tmp_path: Path) -> None:
+    page = _write_page(
+        tmp_path,
+        "pages/Rewrite.md",
+        "- first\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    sync_page_to_shadow(tmp_path, page)
+    page.write_text(
+        "- second\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n",
+        encoding="utf-8",
+    )
+    sync_page_to_shadow(tmp_path, page)
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 1
+        rows = conn.execute("SELECT block_uuid, content FROM blocks").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        assert "second" in rows[0][1]
+    finally:
+        conn.close()
+
+
+def test_sync_page_to_shadow_deletes_missing_file(tmp_path: Path) -> None:
+    page = _write_page(
+        tmp_path,
+        "pages/Gone.md",
+        "- gone\n  id:: cccccccc-cccc-4ccc-8ccc-cccccccccccc\n",
+    )
+    sync_page_to_shadow(tmp_path, page)
+    page.unlink()
+    sync_page_to_shadow(tmp_path, page)
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_post_write_bridge_syncs_via_atomic_write(tmp_path: Path) -> None:
+    clear_page_written_handlers()
+    reset_shadow_sync_bridge_for_tests()
+    ensure_shadow_sync_bridge()
+    try:
+        target = tmp_path / "pages" / "Bridge.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_bytes(
+            target,
+            b"- bridged\n  id:: dddddddd-dddd-4ddd-8ddd-dddddddddddd\n",
+            graph_root=tmp_path,
+            robot_commit_summary="shadow sync test",
+        )
+        conn = open_shadow_db(tmp_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+    finally:
+        clear_page_written_handlers()
+        reset_shadow_sync_bridge_for_tests()
+
+
+def test_emit_page_written_triggers_shadow_sync(tmp_path: Path) -> None:
+    clear_page_written_handlers()
+    reset_shadow_sync_bridge_for_tests()
+    ensure_shadow_sync_bridge()
+    try:
+        page = _write_page(
+            tmp_path,
+            "pages/Emit.md",
+            "- emitted\n  id:: eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee\n",
+        )
+        emit_page_written(graph_root=tmp_path, path=page, summary="emit")
+        conn = open_shadow_db(tmp_path)
+        try:
+            row = conn.execute(
+                "SELECT content FROM blocks WHERE block_uuid = ?",
+                ("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",),
+            ).fetchone()
+            assert row is not None
+            assert "emitted" in row[0]
+        finally:
+            conn.close()
+    finally:
+        clear_page_written_handlers()
+        reset_shadow_sync_bridge_for_tests()


### PR DESCRIPTION
## Summary
Incremental Markdown → shadow.sqlite sync after graph writes; daemon post-write bridge.

## Test plan
- [x] `tests/test_shadow_sync.py`
- [x] stacked on #243

Fixes #182