### PR TITLE
feat(shadow): FTS5 search_blocks_fts query helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Shadow DB connection helper (#181)** — `open_shadow_db` / `shadow_db_path` open sandboxed `shadow.sqlite` under `.matryca_semantic_cache/` and apply schema DDL (Phase 2 infra; sync not wired yet).
 - **Shadow incremental sync (#182)** — `post_write` bridge upserts `pages`/`blocks` into `shadow.sqlite` after Markdown commits (read-only on vault files).
+- **Shadow FTS5 query (#183)** — `search_blocks_fts` returns BM25-ranked `BlockHit` rows (not yet wired to MCP dispatch; Phase 3).
 
 ### Changed
 

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -1,6 +1,7 @@
 """Shadow DB (`shadow.sqlite`) — daemon-owned read cache and memory graph layer."""
 
 from .connection import open_shadow_db, shadow_db_path
+from .query import BlockHit, search_blocks_fts
 from .schema import (
     MEMORY_GRAPH_DDL,
     SHADOW_DDL,
@@ -19,9 +20,11 @@ __all__ = [
     "SHADOW_PRAGMAS",
     "SHADOW_READ_DDL",
     "SHADOW_SCHEMA_VERSION",
+    "BlockHit",
     "apply_shadow_schema",
     "ensure_shadow_sync_bridge",
     "open_shadow_db",
+    "search_blocks_fts",
     "shadow_db_path",
     "sync_page_to_shadow",
 ]

--- a/src/shadow/query.py
+++ b/src/shadow/query.py
@@ -1,0 +1,60 @@
+"""FTS5 query helpers for ``shadow.sqlite`` (v2 Phase 2; not wired to dispatch yet)."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BlockHit:
+    """One FTS5 match from the shadow read cache."""
+
+    block_uuid: str
+    content: str
+    page_id: int
+    rank: float
+
+
+def search_blocks_fts(
+    connection: sqlite3.Connection,
+    query: str,
+    *,
+    limit: int = 20,
+) -> list[BlockHit]:
+    """Return blocks matching ``query`` via FTS5 ``MATCH``, ordered by BM25 rank.
+
+    ``query`` is passed as a bound parameter to ``blocks_fts MATCH ?``. Callers
+    should supply FTS5 query syntax (plain tokens are fine for simple search).
+    Empty / whitespace-only queries return an empty list.
+    """
+    q = query.strip()
+    if not q:
+        return []
+    capped = max(1, min(int(limit), 500))
+    rows = connection.execute(
+        """
+        SELECT b.block_uuid, b.content, b.page_id, bm25(blocks_fts) AS rank
+        FROM blocks_fts
+        JOIN blocks AS b ON b.rowid = blocks_fts.rowid
+        WHERE blocks_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?
+        """,
+        (q, capped),
+    ).fetchall()
+    return [
+        BlockHit(
+            block_uuid=str(row[0]),
+            content=str(row[1]),
+            page_id=int(row[2]),
+            rank=float(row[3]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "BlockHit",
+    "search_blocks_fts",
+]

--- a/tests/test_shadow_fts.py
+++ b/tests/test_shadow_fts.py
@@ -1,0 +1,62 @@
+"""Tests for shadow FTS5 query module (#183)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.shadow.connection import open_shadow_db
+from src.shadow.query import search_blocks_fts
+from src.shadow.sync import sync_page_to_shadow
+
+
+def _seed(tmp_path: Path) -> Path:
+    page = tmp_path / "pages" / "FtsDemo.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(
+        "- alpha shadow needle here\n"
+        "  id:: 11111111-1111-4111-8111-111111111111\n"
+        "- unrelated beta content\n"
+        "  id:: 22222222-2222-4222-8222-222222222222\n",
+        encoding="utf-8",
+    )
+    sync_page_to_shadow(tmp_path, page)
+    return page
+
+
+def test_search_blocks_fts_matches_uuid(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    conn = open_shadow_db(tmp_path)
+    try:
+        hits = search_blocks_fts(conn, "shadow")
+        assert len(hits) == 1
+        assert hits[0].block_uuid == "11111111-1111-4111-8111-111111111111"
+        assert "needle" in hits[0].content
+    finally:
+        conn.close()
+
+
+def test_search_blocks_fts_empty_query(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    conn = open_shadow_db(tmp_path)
+    try:
+        assert search_blocks_fts(conn, "   ") == []
+    finally:
+        conn.close()
+
+
+def test_search_blocks_fts_respects_limit(tmp_path: Path) -> None:
+    page = tmp_path / "pages" / "Many.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"- token shared word {i}\n  id:: {i:08x}-1111-4111-8111-111111111111\n"
+        for i in range(5)
+    ]
+    page.write_text("".join(lines), encoding="utf-8")
+    sync_page_to_shadow(tmp_path, page)
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        hits = search_blocks_fts(conn, "shared", limit=2)
+        assert len(hits) == 2
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
FTS5 `search_blocks_fts` → `BlockHit` (BM25). Not wired to `graph_dispatch` yet (Phase 3).

## Test plan
- [x] `tests/test_shadow_fts.py`
- [x] stacked on #244

Fixes #183