### PR TITLE
feat(shadow): MATRYCA_SHADOW_DB_ENABLED config flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -483,3 +483,9 @@ MATRYCA_EMBEDDING_MODEL=text-embedding-3-small
 # Range / notes: opt-in alpha; no runtime effect until Phase A consolidation ships
 MATRYCA_MEMORY_GRAPH_ENABLED=false
 
+# Daemon-owned shadow.sqlite read cache (FTS5 + subtree CTE). src/shadow/config.py
+# Default (code): false
+# Template: false
+# Range / notes: opt-in v2.0.0-alpha; config parse only until bootstrap slice ships
+MATRYCA_SHADOW_DB_ENABLED=false
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Shadow DB connection helper (#181)** — `open_shadow_db` / `shadow_db_path` open sandboxed `shadow.sqlite` under `.matryca_semantic_cache/` and apply schema DDL (Phase 2 infra; sync not wired yet).
 - **Shadow incremental sync (#182)** — `post_write` bridge upserts `pages`/`blocks` into `shadow.sqlite` after Markdown commits (read-only on vault files).
 - **Shadow FTS5 query (#183)** — `search_blocks_fts` returns BM25-ranked `BlockHit` rows (not yet wired to MCP dispatch; Phase 3).
+- **`MATRYCA_SHADOW_DB_ENABLED` (#184)** — `shadow_db_enabled()` opt-in flag in `src/shadow/config.py` and `.env.example` (parse only; runtime wiring in PR-0).
 
 ### Changed
 

--- a/docs/roadmaps/ROADMAP_V2_PREPARATION.md
+++ b/docs/roadmaps/ROADMAP_V2_PREPARATION.md
@@ -10,15 +10,17 @@ Matryca Plumber **v2.0.0** adds a daemon-owned **Shadow DB** (`shadow.sqlite`) f
 
 ---
 
-## Where we are today (v1.13)
+## Where we are today (2026-07)
 
-| Layer | v1.13 shipped | v2 scaffold (in tree) | Not wired yet |
-|-------|-----------------|------------------------|---------------|
-| **DDL** | — | [`src/shadow/schema.py`](../../src/shadow/schema.py) + [`tests/test_shadow_schema.py`](../../tests/test_shadow_schema.py) | sync, FTS query helpers |
+| Layer | Shipped | In tree (not fully operational) | Not wired yet |
+|-------|---------|----------------------------------|---------------|
+| **DDL** | [`src/shadow/schema.py`](../../src/shadow/schema.py) + tests | — | — |
+| **Shadow sync** | `open_shadow_db`, per-page `sync_page_to_shadow`, post-write bridge ([#181](https://github.com/MarcoPorcellato/matryca-plumber/issues/181)–[#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182)) | Full bootstrap/reconciliation ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176)) | — |
+| **Shadow query** | `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183)) | — | dispatch routing ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) |
 | **Memory algorithms** | — | [`src/memory/decay.py`](../../src/memory/decay.py) | recall, consolidate, MCP `recall` |
-| **Repository port** | `GraphReadPort` + `MarkdownGraphRepository` (subtree reads) | — | full read routing via shadow |
+| **Repository port** | `GraphReadPort` + `MarkdownGraphRepository` (subtree) | — | shadow adapter + routing |
 | **Read path** | `master_catalog.json` + in-memory BM25; subtree via port | — | shadow routing |
-| **Write path (OG)** | OCC + `.md` + `page_rmw_lock` | — | — (done) |
+| **Write path (OG)** | OCC + `.md` + `page_rmw_lock` | — | — |
 | **Write path (Logseq DB)** | — | — | official CLI/API bridge ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)) |
 
 Child roadmaps: [`ROADMAP_V2_SHADOW_DB.md`](ROADMAP_V2_SHADOW_DB.md) · [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](ROADMAP_V2_BIOLOGICAL_MEMORY.md) · [`../openspec/biological-memory.md`](../openspec/biological-memory.md).
@@ -42,7 +44,7 @@ flowchart LR
 |-------|------|-------------------|--------|
 | **0** | v1.9.12 prerequisites | Daemon/dispatch modular enough for shadow duty cycle; env_parse DRY; documented blockers closed or explicitly tracked | Phase 0 ([#174](https://github.com/MarcoPorcellato/matryca-plumber/issues/174)) **done** · [#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58) **done** · [#59](https://github.com/MarcoPorcellato/matryca-plumber/issues/59) **done** |
 | **1** | GraphRepository ports | `GraphReadPort` + `MarkdownGraphRepository`; `graph_dispatch` delegates at least one read method; parity tests; **default behavior unchanged** | [#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) · Phase 1 ([#175](https://github.com/MarcoPorcellato/matryca-plumber/issues/175)) **done** (subtree + port) |
-| **2** | Shadow incremental sync | `open_shadow_db`; `post_write` upsert `pages`/`blocks`; integration tests on `tmp_path` graph | [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) · Phase 2 issue |
+| **2** | Shadow incremental sync | **Core shipped:** `open_shadow_db`, post-write upsert, FTS5 helper. **Operational completion pending:** bootstrap/reconciliation/freshness ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176)) | [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) · [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176) **open** |
 | **3** | Read routing (alpha) | `MATRYCA_SHADOW_DB_ENABLED=false` default; FTS5/CTE behind flag; BM25/AST fallback when lag or disabled | Phase 3 issue · slices under #24 |
 | **4** | Memory + Logseq DB Safe-Sync | `MATRYCA_MEMORY_GRAPH_ENABLED`; `search_graph(method=recall)`; Logseq DB write via official CLI only | [#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25) · [#139](https://github.com/MarcoPorcellato/matryca-plumber/issues/139) · Phase 4 issue |
 
@@ -72,6 +74,8 @@ flowchart LR
 **Verify:** `make check`; `tests/test_graph_repository.py` parity fixtures.
 
 ### Phase 2 — Shadow sync (read-only on source)
+
+**Status:** core shipped (#181–#183); operational completion (bootstrap, reconciliation, runtime gating) tracked in [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176).
 
 - Sync listens on [`post_write`](../../src/graph/post_write.py) / file watcher — **never** writes to `pages/*.md` from shadow.
 - Path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite` (see schema).

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -1,7 +1,7 @@
 # v2.0 — Shadow DB read path (checklist)
 
 **Detailed index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) — visitor SSOT for all five v2 phases  
-**Status:** DDL scaffold **shipped** — [`src/shadow/schema.py`](../../src/shadow/schema.py) + [`tests/test_shadow_schema.py`](../../tests/test_shadow_schema.py); sync and routing **not wired**  
+**Status:** Phase 2 **core shipped** (connection, post-write upsert, FTS5 query helper); **operational completion pending** (bootstrap/reconciliation, freshness contract, runtime gating). Read routing **not wired**.  
 **Parent epic:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
 **Trackable issue:** [#24 — Shadow DB read path](https://github.com/MarcoPorcellato/matryca-plumber/issues/24)  
 **Prerequisite:** [#17 — GraphRepository abstraction](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) · Phase 2–3 tracking in [`v2_preparation_blueprints.md`](../../v2_preparation_blueprints.md)  
@@ -42,12 +42,13 @@ Default path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite` (exact
 ### Shadow read path (#24)
 
 - [x] Scaffold `shadow.sqlite` DDL (`pages`, `blocks`, `block_refs`, FTS5) — `src/shadow/schema.py`
-- [ ] `GraphRepository` routing ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17))
-- [ ] Async ingestion from Markdown (Classic Logseq or DB Markdown Mirror)
-- [ ] FTS5 query helpers + incremental sync triggers
+- [x] Connection helper — `open_shadow_db` / `shadow_db_path` ([#181](https://github.com/MarcoPorcellato/matryca-plumber/issues/181))
+- [x] Incremental post-write upsert — `sync_page_to_shadow` ([#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182))
+- [x] FTS5 query helper — `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183); dispatch wiring Phase 3)
+- [ ] Full bootstrap / reconciliation / freshness contract (Phase 2 operational — [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176))
+- [ ] `GraphRepository` read routing ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17))
 - [ ] Recursive CTEs (`WITH RECURSIVE`) for sub-tree / thought-chain extraction
-- [ ] Background sync daemon (read-only on source `.md` files)
-- [ ] Opt-in env flag `MATRYCA_SHADOW_DB_ENABLED` (v2.0.0-alpha)
+- [ ] Opt-in env flag `MATRYCA_SHADOW_DB_ENABLED` ([#184](https://github.com/MarcoPorcellato/matryca-plumber/issues/184); config slice in flight)
 - [ ] Preflight / Sovereign UI health surface (no `matryca doctor` — see `llms.txt` §2.3)
 
 ### Rollout (Epic #20)

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -1,5 +1,6 @@
 """Shadow DB (`shadow.sqlite`) — daemon-owned read cache and memory graph layer."""
 
+from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
 from .query import BlockHit, search_blocks_fts
 from .schema import (
@@ -25,6 +26,7 @@ __all__ = [
     "ensure_shadow_sync_bridge",
     "open_shadow_db",
     "search_blocks_fts",
+    "shadow_db_enabled",
     "shadow_db_path",
     "sync_page_to_shadow",
 ]

--- a/src/shadow/config.py
+++ b/src/shadow/config.py
@@ -1,0 +1,17 @@
+"""Environment-driven configuration for the Shadow DB read cache (v2 Phase 3)."""
+
+from __future__ import annotations
+
+from ..utils.env_parse import env_bool
+
+
+def shadow_db_enabled() -> bool:
+    """Return whether the Shadow DB subsystem is enabled (opt-in alpha).
+
+    Parsing only — no runtime wiring in this slice. When false or unset, callers
+    must not create, sync, or read ``shadow.sqlite`` (enforced in follow-up PR-0).
+    """
+    return env_bool("MATRYCA_SHADOW_DB_ENABLED", default=False)
+
+
+__all__ = ["shadow_db_enabled"]

--- a/tests/test_shadow_config.py
+++ b/tests/test_shadow_config.py
@@ -1,0 +1,29 @@
+"""Tests for Shadow DB env flag (#184)."""
+
+from __future__ import annotations
+
+import pytest
+from src.shadow.config import shadow_db_enabled
+
+
+def test_shadow_db_enabled_default_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MATRYCA_SHADOW_DB_ENABLED", raising=False)
+    assert shadow_db_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", ""])
+def test_shadow_db_enabled_false_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", value)
+    assert shadow_db_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_shadow_db_enabled_true_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", value)
+    assert shadow_db_enabled() is True


### PR DESCRIPTION
## Summary
- `shadow_db_enabled()` in `src/shadow/config.py` via `env_bool` (default `false`)
- Document `MATRYCA_SHADOW_DB_ENABLED` in `.env.example` (Advanced / v2 Shadow DB)
- Unit tests in `tests/test_shadow_config.py`
- Step 0 roadmap refresh: Phase 2 **core shipped**; operational completion pending ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176))

**No runtime wiring** — bootstrap, sync gating, and health land in PR-0 after this merges.

## Test plan
- [x] `make check` (1057 passed)
- [x] `tests/test_shadow_config.py`
- [x] `tests/test_env_example_coverage.py`
- [x] Code audit `detect_changes` — low risk, no affected processes

Fixes #184

Made with [Cursor](https://cursor.com)