### PR TITLE
feat(shadow): bootstrap runtime activation and reconciliation (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Shadow incremental sync (#182)** — `post_write` bridge upserts `pages`/`blocks` into `shadow.sqlite` after Markdown commits (read-only on vault files).
 - **Shadow FTS5 query (#183)** — `search_blocks_fts` returns BM25-ranked `BlockHit` rows (not yet wired to MCP dispatch; Phase 3).
 - **`MATRYCA_SHADOW_DB_ENABLED` (#184)** — `shadow_db_enabled()` opt-in flag in `src/shadow/config.py` and `.env.example` (parse only; runtime wiring in PR-0).
+- **Shadow bootstrap & runtime activation (#248)** — `rebuild_shadow_from_graph`, `shadow_meta` health keys, startup bootstrap via `prepare_matryca_runtime`, watchdog reconciliation by `file_path`, and sync bridge gated on `MATRYCA_SHADOW_DB_ENABLED` (Phase 2 operational completion; no FTS routing).
 
 ### Changed
 

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -383,6 +383,9 @@ class MaintenanceDaemon:
                 register_page_links_from_path(self.graph_root, path)
             except OSError:
                 logger.exception("Link registry update failed for deleted page {}", path)
+        from ..shadow.bootstrap import handle_shadow_watchdog_change
+
+        handle_shadow_watchdog_change(self.graph_root, path, kind)
         self._cycle_wake.set()
 
     def _start_file_watcher(self) -> None:

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -1,7 +1,25 @@
 """Shadow DB (`shadow.sqlite`) — daemon-owned read cache and memory graph layer."""
 
+from .bootstrap import (
+    ensure_shadow_runtime_at_startup,
+    handle_shadow_watchdog_change,
+    rebuild_shadow_from_graph,
+    shadow_needs_bootstrap,
+)
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
+from .health import ShadowHealthState, resolve_shadow_health
+from .meta import (
+    META_GENERATION,
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_AT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_INCREMENTAL_SYNC_AT,
+    META_LAST_SYNC_ERROR,
+    META_SCHEMA_VERSION,
+    META_SOURCE_PAGE_COUNT,
+    REQUIRED_META_KEYS,
+)
 from .query import BlockHit, search_blocks_fts
 from .schema import (
     MEMORY_GRAPH_DDL,
@@ -12,7 +30,11 @@ from .schema import (
     SHADOW_SCHEMA_VERSION,
     apply_shadow_schema,
 )
-from .sync import ensure_shadow_sync_bridge, sync_page_to_shadow
+from .sync import (
+    delete_shadow_page_by_file_path,
+    ensure_shadow_sync_bridge,
+    sync_page_to_shadow,
+)
 
 __all__ = [
     "MEMORY_GRAPH_DDL",
@@ -21,12 +43,28 @@ __all__ = [
     "SHADOW_PRAGMAS",
     "SHADOW_READ_DDL",
     "SHADOW_SCHEMA_VERSION",
+    "META_GENERATION",
+    "META_INDEXED_PAGE_COUNT",
+    "META_LAST_FULL_SYNC_AT",
+    "META_LAST_FULL_SYNC_COMPLETED",
+    "META_LAST_INCREMENTAL_SYNC_AT",
+    "META_LAST_SYNC_ERROR",
+    "META_SCHEMA_VERSION",
+    "META_SOURCE_PAGE_COUNT",
+    "REQUIRED_META_KEYS",
     "BlockHit",
+    "ShadowHealthState",
     "apply_shadow_schema",
+    "delete_shadow_page_by_file_path",
+    "ensure_shadow_runtime_at_startup",
     "ensure_shadow_sync_bridge",
+    "handle_shadow_watchdog_change",
     "open_shadow_db",
+    "rebuild_shadow_from_graph",
+    "resolve_shadow_health",
     "search_blocks_fts",
     "shadow_db_enabled",
+    "shadow_needs_bootstrap",
     "shadow_db_path",
     "sync_page_to_shadow",
 ]

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -101,10 +101,10 @@ def rebuild_shadow_from_graph(graph_root: Path | str) -> None:
 
 
 def _record_rebuild_error(graph_root: Path, message: str) -> None:
+    """Persist rebuild failure without invalidating the last committed generation."""
     conn = open_shadow_db(graph_root)
     try:
         ensure_meta_defaults(conn)
-        set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "false")
         set_meta(conn, META_LAST_SYNC_ERROR, message)
         conn.commit()
     except Exception:  # noqa: BLE001 — best-effort error meta
@@ -132,9 +132,12 @@ def ensure_shadow_runtime_at_startup(graph_root: Path | str) -> None:
     key = str(root)
     if key in _BOOTSTRAP_CHECKED and not shadow_needs_bootstrap(root):
         return
-    if shadow_needs_bootstrap(root):
-        rebuild_shadow_from_graph(root)
-    _BOOTSTRAP_CHECKED.add(key)
+    try:
+        if shadow_needs_bootstrap(root):
+            rebuild_shadow_from_graph(root)
+        _BOOTSTRAP_CHECKED.add(key)
+    except Exception:  # noqa: BLE001 — must not block MCP/CLI/daemon startup
+        logger.exception("Shadow bootstrap failed for {}", root)
 
 
 def reset_shadow_bootstrap_checked_for_tests() -> None:
@@ -149,20 +152,23 @@ def handle_shadow_watchdog_change(
     """Sync or delete shadow rows after debounced external vault edits."""
     if not shadow_db_enabled():
         return
-    root = resolved_graph_root(graph_root)
-    safe = assert_path_within_graph(path, root)
-    if safe.suffix.lower() != ".md":
-        return
-    rel = safe.relative_to(root).as_posix()
-    if is_shadow_bootstrapping(root):
-        from .runtime_state import defer_sync_path
+    try:
+        root = resolved_graph_root(graph_root)
+        safe = assert_path_within_graph(path, root)
+        if safe.suffix.lower() != ".md":
+            return
+        rel = safe.relative_to(root).as_posix()
+        if is_shadow_bootstrapping(root):
+            from .runtime_state import defer_sync_path
 
-        defer_sync_path(root, rel)
-        return
-    if kind == "deleted":
-        delete_shadow_page_by_file_path(root, rel)
-        return
-    sync_page_to_shadow(root, safe)
+            defer_sync_path(root, rel)
+            return
+        if kind == "deleted":
+            delete_shadow_page_by_file_path(root, rel)
+            return
+        sync_page_to_shadow(root, safe)
+    except Exception:  # noqa: BLE001 — fail-safe like AST bridge
+        logger.exception("Shadow watchdog sync failed for {} ({})", path, kind)
 
 
 __all__ = [

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -1,0 +1,174 @@
+"""Full-graph bootstrap and external-change reconciliation for Shadow DB (v2 PR-0)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from loguru import logger
+
+from ..daemon.file_watcher import FileEventKind
+from ..graph.alias_index import iter_alias_source_paths
+from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from .config import shadow_db_enabled
+from .connection import open_shadow_db, shadow_db_path
+from .meta import (
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_AT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    META_SOURCE_PAGE_COUNT,
+    bump_generation,
+    ensure_meta_defaults,
+    set_meta,
+)
+from .runtime_state import (
+    clear_bootstrapping,
+    is_shadow_bootstrapping,
+    mark_bootstrapping,
+    pop_deferred_sync_paths,
+    rebuild_lock_for,
+)
+from .schema import SHADOW_SCHEMA_VERSION
+from .sync import delete_shadow_page_by_file_path, sync_page_to_shadow
+
+_BOOTSTRAP_CHECKED: set[str] = set()
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def shadow_needs_bootstrap(graph_root: Path | str) -> bool:
+    """Return whether a compatible full sync generation is missing."""
+    root = resolved_graph_root(graph_root)
+    if not shadow_db_path(root).is_file():
+        return True
+    conn = open_shadow_db(root)
+    try:
+        from .meta import get_meta
+
+        schema_raw = get_meta(conn, "schema_version")
+        if schema_raw != str(SHADOW_SCHEMA_VERSION):
+            return True
+        completed = (get_meta(conn, "last_full_sync_completed") or "").strip().lower()
+        return completed != "true"
+    finally:
+        conn.close()
+
+
+def rebuild_shadow_from_graph(graph_root: Path | str) -> None:
+    """Scan ``pages/`` + ``journals/`` and rebuild ``shadow.sqlite`` atomically."""
+    if not shadow_db_enabled():
+        return
+    root = resolved_graph_root(graph_root)
+    with rebuild_lock_for(root):
+        mark_bootstrapping(root)
+        conn = open_shadow_db(root)
+        try:
+            source_paths = iter_alias_source_paths(root)
+            source_count = len(source_paths)
+            synced_at = _utc_now_iso()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                ensure_meta_defaults(conn)
+                set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "false")
+                set_meta(conn, META_LAST_SYNC_ERROR, "")
+                conn.execute("DELETE FROM pages")
+
+                indexed = 0
+                for path in source_paths:
+                    from .sync import sync_page_into_connection
+
+                    sync_page_into_connection(conn, root, path)
+                    indexed += 1
+
+                bump_generation(conn)
+                set_meta(conn, META_LAST_FULL_SYNC_AT, synced_at)
+                set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "true")
+                set_meta(conn, META_SOURCE_PAGE_COUNT, str(source_count))
+                set_meta(conn, META_INDEXED_PAGE_COUNT, str(indexed))
+                set_meta(conn, META_LAST_SYNC_ERROR, "")
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                _record_rebuild_error(root, "full rebuild failed")
+                raise
+        finally:
+            conn.close()
+            clear_bootstrapping(root)
+            _replay_deferred_syncs(root)
+
+
+def _record_rebuild_error(graph_root: Path, message: str) -> None:
+    conn = open_shadow_db(graph_root)
+    try:
+        ensure_meta_defaults(conn)
+        set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "false")
+        set_meta(conn, META_LAST_SYNC_ERROR, message)
+        conn.commit()
+    except Exception:  # noqa: BLE001 — best-effort error meta
+        logger.exception("Failed to persist shadow rebuild error for {}", graph_root)
+    finally:
+        conn.close()
+
+
+def _replay_deferred_syncs(graph_root: Path) -> None:
+    for rel in pop_deferred_sync_paths(graph_root):
+        try:
+            sync_page_to_shadow(graph_root, graph_root / rel)
+        except Exception:  # noqa: BLE001
+            logger.exception("Deferred shadow sync failed for {}", rel)
+
+
+def ensure_shadow_runtime_at_startup(graph_root: Path | str) -> None:
+    """Activate shadow sync bridge and run bootstrap when the flag is enabled."""
+    if not shadow_db_enabled():
+        return
+    root = resolved_graph_root(graph_root)
+    from .sync import ensure_shadow_sync_bridge
+
+    ensure_shadow_sync_bridge()
+    key = str(root)
+    if key in _BOOTSTRAP_CHECKED and not shadow_needs_bootstrap(root):
+        return
+    if shadow_needs_bootstrap(root):
+        rebuild_shadow_from_graph(root)
+    _BOOTSTRAP_CHECKED.add(key)
+
+
+def reset_shadow_bootstrap_checked_for_tests() -> None:
+    _BOOTSTRAP_CHECKED.clear()
+
+
+def handle_shadow_watchdog_change(
+    graph_root: Path | str,
+    path: Path | str,
+    kind: FileEventKind,
+) -> None:
+    """Sync or delete shadow rows after debounced external vault edits."""
+    if not shadow_db_enabled():
+        return
+    root = resolved_graph_root(graph_root)
+    safe = assert_path_within_graph(path, root)
+    if safe.suffix.lower() != ".md":
+        return
+    rel = safe.relative_to(root).as_posix()
+    if is_shadow_bootstrapping(root):
+        from .runtime_state import defer_sync_path
+
+        defer_sync_path(root, rel)
+        return
+    if kind == "deleted":
+        delete_shadow_page_by_file_path(root, rel)
+        return
+    sync_page_to_shadow(root, safe)
+
+
+__all__ = [
+    "ensure_shadow_runtime_at_startup",
+    "handle_shadow_watchdog_change",
+    "rebuild_shadow_from_graph",
+    "reset_shadow_bootstrap_checked_for_tests",
+    "shadow_needs_bootstrap",
+]

--- a/src/shadow/config.py
+++ b/src/shadow/config.py
@@ -8,8 +8,7 @@ from ..utils.env_parse import env_bool
 def shadow_db_enabled() -> bool:
     """Return whether the Shadow DB subsystem is enabled (opt-in alpha).
 
-    Parsing only — no runtime wiring in this slice. When false or unset, callers
-    must not create, sync, or read ``shadow.sqlite`` (enforced in follow-up PR-0).
+    When false or unset, callers must not create, sync, or read ``shadow.sqlite``.
     """
     return env_bool("MATRYCA_SHADOW_DB_ENABLED", default=False)
 

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -1,0 +1,55 @@
+"""Shadow DB runtime health resolution (v2 PR-0)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+
+from ..graph.path_sandbox import resolved_graph_root
+from .config import shadow_db_enabled
+from .connection import open_shadow_db, shadow_db_path
+from .meta import (
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    META_SCHEMA_VERSION,
+    get_meta,
+)
+from .runtime_state import is_shadow_bootstrapping
+from .schema import SHADOW_SCHEMA_VERSION
+
+
+class ShadowHealthState(StrEnum):
+    DISABLED = "disabled"
+    BOOTSTRAPPING = "bootstrapping"
+    READY = "ready"
+    STALE = "stale"
+    ERROR = "error"
+
+
+def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
+    """Resolve the effective Shadow DB health for this process."""
+    if not shadow_db_enabled():
+        return ShadowHealthState.DISABLED
+    root = resolved_graph_root(graph_root)
+    if is_shadow_bootstrapping(root):
+        return ShadowHealthState.BOOTSTRAPPING
+    if not shadow_db_path(root).is_file():
+        return ShadowHealthState.STALE
+
+    conn = open_shadow_db(root)
+    try:
+        schema_raw = get_meta(conn, META_SCHEMA_VERSION)
+        if schema_raw != str(SHADOW_SCHEMA_VERSION):
+            return ShadowHealthState.ERROR
+        sync_error = (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip()
+        if sync_error:
+            return ShadowHealthState.ERROR
+        completed = (get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) or "").strip().lower()
+        if completed == "true":
+            return ShadowHealthState.READY
+        return ShadowHealthState.STALE
+    finally:
+        conn.close()
+
+
+__all__ = ["ShadowHealthState", "resolve_shadow_health"]

--- a/src/shadow/meta.py
+++ b/src/shadow/meta.py
@@ -1,0 +1,96 @@
+"""``shadow_meta`` key contract for Shadow DB health and reconciliation (v2 PR-0)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from .schema import SHADOW_SCHEMA_VERSION
+
+META_SCHEMA_VERSION = "schema_version"
+META_GENERATION = "generation"
+META_LAST_FULL_SYNC_AT = "last_full_sync_at"
+META_LAST_FULL_SYNC_COMPLETED = "last_full_sync_completed"
+META_SOURCE_PAGE_COUNT = "source_page_count"
+META_INDEXED_PAGE_COUNT = "indexed_page_count"
+META_LAST_SYNC_ERROR = "last_sync_error"
+META_LAST_INCREMENTAL_SYNC_AT = "last_incremental_sync_at"
+
+REQUIRED_META_KEYS: tuple[str, ...] = (
+    META_SCHEMA_VERSION,
+    META_GENERATION,
+    META_LAST_FULL_SYNC_AT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_SOURCE_PAGE_COUNT,
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_SYNC_ERROR,
+    META_LAST_INCREMENTAL_SYNC_AT,
+)
+
+
+def get_meta(connection: sqlite3.Connection, key: str) -> str | None:
+    row = connection.execute(
+        "SELECT value FROM shadow_meta WHERE key = ?",
+        (key,),
+    ).fetchone()
+    return None if row is None else str(row[0])
+
+
+def set_meta(connection: sqlite3.Connection, key: str, value: str) -> None:
+    connection.execute(
+        """
+        INSERT INTO shadow_meta (key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (key, value),
+    )
+
+
+def ensure_meta_defaults(connection: sqlite3.Connection) -> None:
+    """Ensure required keys exist (empty string when unset)."""
+    for key in REQUIRED_META_KEYS:
+        connection.execute(
+            "INSERT OR IGNORE INTO shadow_meta (key, value) VALUES (?, ?)",
+            (key, ""),
+        )
+    set_meta(connection, META_SCHEMA_VERSION, str(SHADOW_SCHEMA_VERSION))
+
+
+def read_meta_map(connection: sqlite3.Connection) -> dict[str, str]:
+    ensure_meta_defaults(connection)
+    rows = connection.execute("SELECT key, value FROM shadow_meta").fetchall()
+    return {str(key): str(value) for key, value in rows}
+
+
+def current_generation(connection: sqlite3.Connection) -> int:
+    raw = get_meta(connection, META_GENERATION)
+    if not raw:
+        return 0
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 0
+
+
+def bump_generation(connection: sqlite3.Connection) -> int:
+    generation = current_generation(connection) + 1
+    set_meta(connection, META_GENERATION, str(generation))
+    return generation
+
+
+__all__ = [
+    "META_GENERATION",
+    "META_INDEXED_PAGE_COUNT",
+    "META_LAST_FULL_SYNC_AT",
+    "META_LAST_FULL_SYNC_COMPLETED",
+    "META_LAST_INCREMENTAL_SYNC_AT",
+    "META_LAST_SYNC_ERROR",
+    "META_SCHEMA_VERSION",
+    "META_SOURCE_PAGE_COUNT",
+    "REQUIRED_META_KEYS",
+    "bump_generation",
+    "current_generation",
+    "ensure_meta_defaults",
+    "get_meta",
+    "read_meta_map",
+    "set_meta",
+]

--- a/src/shadow/runtime_state.py
+++ b/src/shadow/runtime_state.py
@@ -1,0 +1,69 @@
+"""In-process Shadow DB coordination (rebuild locks, deferrals)."""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from pathlib import Path
+
+from ..graph.path_sandbox import resolved_graph_root
+
+_rebuild_locks: dict[str, threading.Lock] = {}
+_bootstrapping_roots: set[str] = set()
+_deferred_sync_paths: dict[str, set[str]] = defaultdict(set)
+_state_lock = threading.Lock()
+
+
+def graph_root_key(graph_root: Path | str) -> str:
+    return str(resolved_graph_root(graph_root))
+
+
+def rebuild_lock_for(graph_root: Path | str) -> threading.Lock:
+    key = graph_root_key(graph_root)
+    with _state_lock:
+        return _rebuild_locks.setdefault(key, threading.Lock())
+
+
+def is_shadow_bootstrapping(graph_root: Path | str) -> bool:
+    return graph_root_key(graph_root) in _bootstrapping_roots
+
+
+def mark_bootstrapping(graph_root: Path | str) -> None:
+    with _state_lock:
+        _bootstrapping_roots.add(graph_root_key(graph_root))
+
+
+def clear_bootstrapping(graph_root: Path | str) -> None:
+    with _state_lock:
+        _bootstrapping_roots.discard(graph_root_key(graph_root))
+
+
+def defer_sync_path(graph_root: Path | str, rel_path: str) -> None:
+    with _state_lock:
+        _deferred_sync_paths[graph_root_key(graph_root)].add(rel_path)
+
+
+def pop_deferred_sync_paths(graph_root: Path | str) -> list[str]:
+    with _state_lock:
+        key = graph_root_key(graph_root)
+        paths = sorted(_deferred_sync_paths.pop(key, set()))
+        return paths
+
+
+def reset_shadow_runtime_state_for_tests() -> None:
+    with _state_lock:
+        _rebuild_locks.clear()
+        _bootstrapping_roots.clear()
+        _deferred_sync_paths.clear()
+
+
+__all__ = [
+    "clear_bootstrapping",
+    "defer_sync_path",
+    "graph_root_key",
+    "is_shadow_bootstrapping",
+    "mark_bootstrapping",
+    "pop_deferred_sync_paths",
+    "rebuild_lock_for",
+    "reset_shadow_runtime_state_for_tests",
+]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -7,6 +7,7 @@ successful graph writes via the page-written port.
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
@@ -19,7 +20,10 @@ from loguru import logger
 from ..graph.page_path import page_title_from_path
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
 from ..graph.post_write import PageWrittenEvent, register_page_written_handler
+from .config import shadow_db_enabled
 from .connection import open_shadow_db
+from .meta import META_LAST_INCREMENTAL_SYNC_AT, set_meta
+from .runtime_state import defer_sync_path, is_shadow_bootstrapping
 
 _bridge_lock = threading.Lock()
 _bridge_registered = False
@@ -77,79 +81,119 @@ def _walk_blocks(
     return rows
 
 
-def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
-    """Parse ``page_path`` and upsert its rows into ``shadow.sqlite``.
+def delete_shadow_page_by_file_path(graph_root: Path | str, rel_path: str) -> None:
+    """Remove a page row (and blocks) by sandboxed ``file_path``."""
+    if not shadow_db_enabled():
+        return
+    root = resolved_graph_root(graph_root)
+    conn = open_shadow_db(root)
+    try:
+        conn.execute("DELETE FROM pages WHERE file_path = ?", (rel_path,))
+        set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
-    If the file is missing, remove the corresponding ``pages`` row (cascade).
-    """
+
+def sync_page_into_connection(
+    connection: sqlite3.Connection,
+    graph_root: Path,
+    page_path: Path,
+) -> None:
+    """Upsert one page into an open shadow connection (caller manages transaction)."""
     root = resolved_graph_root(graph_root)
     path = assert_path_within_graph(page_path, root)
     if path.suffix.lower() != ".md":
         return
 
-    conn = open_shadow_db(root)
-    try:
-        title = page_title_from_path(root, path)
-        rel = path.relative_to(root).as_posix()
-        if not path.is_file():
-            conn.execute("DELETE FROM pages WHERE title = ?", (title,))
-            conn.commit()
-            return
+    title = page_title_from_path(root, path)
+    rel = path.relative_to(root).as_posix()
+    if not path.is_file():
+        connection.execute("DELETE FROM pages WHERE file_path = ?", (rel,))
+        return
 
-        stat = path.stat()
-        text = path.read_text(encoding="utf-8")
-        page: LogseqPage = StackMachineParser().parse(text, page_title=title)
-        synced_at = _utc_now_iso()
-        is_journal = 1 if _is_journal_relpath(rel) else 0
-        props_json = _props_json(dict(page.properties or {}))
+    stat = path.stat()
+    text = path.read_text(encoding="utf-8")
+    page: LogseqPage = StackMachineParser().parse(text, page_title=title)
+    synced_at = _utc_now_iso()
+    is_journal = 1 if _is_journal_relpath(rel) else 0
+    props_json = _props_json(dict(page.properties or {}))
 
-        conn.execute("DELETE FROM pages WHERE title = ?", (title,))
-        cur = conn.execute(
+    connection.execute(
+        "DELETE FROM pages WHERE file_path = ? OR title = ?",
+        (rel, title),
+    )
+    cur = connection.execute(
+        """
+        INSERT INTO pages (
+            title, file_path, file_mtime_ns, file_size,
+            is_journal, properties_json, synced_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            title,
+            rel,
+            int(stat.st_mtime_ns),
+            int(stat.st_size),
+            is_journal,
+            props_json,
+            synced_at,
+        ),
+    )
+    page_id = int(cur.lastrowid or 0)
+    if page_id <= 0:
+        raise RuntimeError("shadow pages insert returned no page_id")
+    flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
+    uuid_to_rowid: dict[str, int] = {}
+    for block_uuid, parent_uuid, sort_order, indent, content, props in flat:
+        parent_rowid = uuid_to_rowid.get(parent_uuid) if parent_uuid else None
+        block_cur = connection.execute(
             """
-            INSERT INTO pages (
-                title, file_path, file_mtime_ns, file_size,
-                is_journal, properties_json, synced_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO blocks (
+                block_uuid, page_id, parent_rowid, sort_order,
+                indent_level, content, properties_json, synced_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                title,
-                rel,
-                int(stat.st_mtime_ns),
-                int(stat.st_size),
-                is_journal,
-                props_json,
+                block_uuid,
+                page_id,
+                parent_rowid,
+                sort_order,
+                indent,
+                content,
+                _props_json(props),
                 synced_at,
             ),
         )
-        page_id = int(cur.lastrowid or 0)
-        if page_id <= 0:
-            raise RuntimeError("shadow pages insert returned no page_id")
-        flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
-        uuid_to_rowid: dict[str, int] = {}
-        for block_uuid, parent_uuid, sort_order, indent, content, props in flat:
-            parent_rowid = uuid_to_rowid.get(parent_uuid) if parent_uuid else None
-            block_cur = conn.execute(
-                """
-                INSERT INTO blocks (
-                    block_uuid, page_id, parent_rowid, sort_order,
-                    indent_level, content, properties_json, synced_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    block_uuid,
-                    page_id,
-                    parent_rowid,
-                    sort_order,
-                    indent,
-                    content,
-                    _props_json(props),
-                    synced_at,
-                ),
-            )
-            rowid = int(block_cur.lastrowid or 0)
-            if rowid <= 0:
-                raise RuntimeError(f"shadow blocks insert returned no rowid for {block_uuid}")
-            uuid_to_rowid[block_uuid] = rowid
+        rowid = int(block_cur.lastrowid or 0)
+        if rowid <= 0:
+            raise RuntimeError(f"shadow blocks insert returned no rowid for {block_uuid}")
+        uuid_to_rowid[block_uuid] = rowid
+
+
+def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
+    """Parse ``page_path`` and upsert its rows into ``shadow.sqlite``.
+
+    If the file is missing, remove the corresponding ``pages`` row by ``file_path``.
+  """
+    if not shadow_db_enabled():
+        return
+    root = resolved_graph_root(graph_root)
+    path = assert_path_within_graph(page_path, root)
+    if path.suffix.lower() != ".md":
+        return
+    rel = path.relative_to(root).as_posix()
+    if is_shadow_bootstrapping(root):
+        defer_sync_path(root, rel)
+        return
+
+    conn = open_shadow_db(root)
+    try:
+        sync_page_into_connection(conn, root, path)
+        set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
         conn.commit()
     except Exception:
         conn.rollback()
@@ -169,6 +213,8 @@ def _on_shadow_page_written(event: PageWrittenEvent) -> None:
 
 def ensure_shadow_sync_bridge() -> None:
     """Register shadow upsert on the graph-local post-write port (once)."""
+    if not shadow_db_enabled():
+        return
     global _bridge_registered
     with _bridge_lock:
         if _bridge_registered:
@@ -185,7 +231,9 @@ def reset_shadow_sync_bridge_for_tests() -> None:
 
 
 __all__ = [
+    "delete_shadow_page_by_file_path",
     "ensure_shadow_sync_bridge",
     "reset_shadow_sync_bridge_for_tests",
+    "sync_page_into_connection",
     "sync_page_to_shadow",
 ]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -178,7 +178,7 @@ def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
     """Parse ``page_path`` and upsert its rows into ``shadow.sqlite``.
 
     If the file is missing, remove the corresponding ``pages`` row by ``file_path``.
-  """
+    """
     if not shadow_db_enabled():
         return
     root = resolved_graph_root(graph_root)

--- a/src/utils/runtime_bootstrap.py
+++ b/src/utils/runtime_bootstrap.py
@@ -143,6 +143,9 @@ def prepare_matryca_runtime(
     from ..daemon import register_daemon_post_write_hooks
 
     register_daemon_post_write_hooks(graph_root)
+    from ..shadow.bootstrap import ensure_shadow_runtime_at_startup
+
+    ensure_shadow_runtime_at_startup(graph_root)
     if not eager_graph:
         return
 

--- a/tests/test_shadow_bootstrap.py
+++ b/tests/test_shadow_bootstrap.py
@@ -1,0 +1,275 @@
+"""Bootstrap and reconciliation tests for Shadow DB (#248 / PR-0)."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.config import MatrycaWikiConfig
+from src.shadow.bootstrap import (
+    handle_shadow_watchdog_change,
+    rebuild_shadow_from_graph,
+    reset_shadow_bootstrap_checked_for_tests,
+    shadow_needs_bootstrap,
+)
+from src.shadow.config import shadow_db_enabled
+from src.shadow.connection import open_shadow_db, shadow_db_path
+from src.shadow.health import ShadowHealthState, resolve_shadow_health
+from src.shadow.meta import (
+    META_GENERATION,
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    META_SCHEMA_VERSION,
+    META_SOURCE_PAGE_COUNT,
+    get_meta,
+)
+from src.shadow.runtime_state import reset_shadow_runtime_state_for_tests
+from src.shadow.sync import (
+    reset_shadow_sync_bridge_for_tests,
+    sync_page_to_shadow,
+)
+from src.utils.runtime_bootstrap import prepare_matryca_runtime
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    reset_shadow_runtime_state_for_tests()
+    reset_shadow_bootstrap_checked_for_tests()
+    reset_shadow_sync_bridge_for_tests()
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _minimal_graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    (graph / "journals").mkdir(parents=True)
+    return graph
+
+
+def test_rebuild_indexes_existing_vault(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    _write_page(
+        graph,
+        "journals/2026_07_18.md",
+        "- journal\n  id:: 22222222-2222-4222-8222-222222222222\n",
+    )
+
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 2
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert get_meta(conn, META_SOURCE_PAGE_COUNT) == "2"
+        assert get_meta(conn, META_INDEXED_PAGE_COUNT) == "2"
+        assert get_meta(conn, META_LAST_SYNC_ERROR) == ""
+        assert int(get_meta(conn, META_GENERATION) or "0") == 1
+    finally:
+        conn.close()
+    assert resolve_shadow_health(graph) == ShadowHealthState.READY
+
+
+def test_rebuild_is_idempotent_without_file_changes(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Stable.md",
+        "- stable\n  id:: 33333333-3333-4333-8333-333333333333\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        first_gen = get_meta(conn, META_GENERATION)
+    finally:
+        conn.close()
+
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_GENERATION) == str(int(first_gen or "0") + 1)
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_delete_and_rename_reconcile_by_file_path(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    old = _write_page(
+        graph,
+        "pages/OldName.md",
+        "- old\n  id:: 44444444-4444-4444-8444-444444444444\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    new = graph / "pages" / "NewName.md"
+    old.rename(new)
+    new.write_text(
+        "- renamed\n  id:: 55555555-5555-4555-8555-555555555555\n",
+        encoding="utf-8",
+    )
+    handle_shadow_watchdog_change(graph, old, "deleted")
+    handle_shadow_watchdog_change(graph, new, "created")
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        rows = conn.execute("SELECT title, file_path FROM pages").fetchall()
+        assert rows == [("NewName", "pages/NewName.md")]
+        assert conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_interrupted_rebuild_preserves_prior_generation(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Safe.md",
+        "- safe\n  id:: 66666666-6666-4666-8666-666666666666\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    _write_page(
+        graph,
+        "pages/Broken.md",
+        "- broken\n  id:: 77777777-7777-4777-8777-777777777777\n",
+    )
+
+    def _boom(
+        connection: sqlite3.Connection,
+        graph_root: Path,
+        page_path: Path,
+    ) -> None:
+        if page_path.name == "Broken.md":
+            raise RuntimeError("simulated rebuild failure")
+        from src.shadow.sync import sync_page_into_connection
+
+        sync_page_into_connection(connection, graph_root, page_path)
+
+    with (
+        patch("src.shadow.sync.sync_page_into_connection", side_effect=_boom),
+        pytest.raises(RuntimeError, match="simulated rebuild failure"),
+    ):
+        rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "false"
+        assert "full rebuild failed" in (get_meta(conn, META_LAST_SYNC_ERROR) or "")
+        titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
+        assert titles == {"Safe"}
+        assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    finally:
+        conn.close()
+
+
+def test_incompatible_schema_triggers_bootstrap(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        conn.execute(
+            "UPDATE shadow_meta SET value = ? WHERE key = ?",
+            ("999", META_SCHEMA_VERSION),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert shadow_needs_bootstrap(graph) is True
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+
+
+def test_concurrent_rebuild_defers_incremental_sync(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Base.md",
+        "- base\n  id:: 88888888-8888-4888-8888-888888888888\n",
+    )
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def _slow_rebuild() -> None:
+        conn = open_shadow_db(graph)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            barrier.wait(timeout=5)
+            conn.execute("DELETE FROM pages")
+            conn.commit()
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+            conn.rollback()
+        finally:
+            conn.close()
+
+    def _incremental_during_rebuild() -> None:
+        barrier.wait(timeout=5)
+        sync_page_to_shadow(
+            graph,
+            _write_page(
+                graph,
+                "pages/Late.md",
+                "- late\n  id:: 99999999-9999-4999-8999-999999999999\n",
+            ),
+        )
+
+    from src.shadow.runtime_state import mark_bootstrapping
+
+    mark_bootstrapping(graph)
+    thread = threading.Thread(target=_slow_rebuild)
+    thread.start()
+    worker = threading.Thread(target=_incremental_during_rebuild)
+    worker.start()
+    thread.join(timeout=10)
+    worker.join(timeout=10)
+    assert not errors
+
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
+        assert "Late" in titles
+        assert "Base" in titles
+    finally:
+        conn.close()
+
+
+def test_flag_false_skips_db_creation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/NoDb.md", "- x\n")
+    sync_page_to_shadow(graph, graph / "pages" / "NoDb.md")
+    assert not shadow_db_path(graph).exists()
+    assert shadow_db_enabled() is False
+
+
+def test_startup_bootstrap_via_prepare_matryca_runtime(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Startup.md",
+        "- boot\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+    conn = open_shadow_db(graph)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 1
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+    finally:
+        conn.close()

--- a/tests/test_shadow_bootstrap.py
+++ b/tests/test_shadow_bootstrap.py
@@ -169,13 +169,78 @@ def test_interrupted_rebuild_preserves_prior_generation(tmp_path: Path) -> None:
 
     conn = open_shadow_db(graph)
     try:
-        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "false"
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert get_meta(conn, META_GENERATION) == "1"
         assert "full rebuild failed" in (get_meta(conn, META_LAST_SYNC_ERROR) or "")
         titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
         assert titles == {"Safe"}
         assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
     finally:
         conn.close()
+
+
+def test_prepare_matryca_runtime_flag_false_no_shadow_db(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Quiet.md", "- quiet\n")
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+    assert not shadow_db_path(graph).exists()
+
+
+def test_prepare_matryca_runtime_flag_false_leaves_existing_db_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Legacy.md",
+        "- legacy\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        before = get_meta(conn, META_GENERATION)
+        page_count = conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+    reset_shadow_bootstrap_checked_for_tests()
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_GENERATION) == before
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == page_count
+    finally:
+        conn.close()
+
+
+def test_prepare_matryca_runtime_survives_bootstrap_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Ok.md", "- ok\n")
+    with patch(
+        "src.shadow.bootstrap.rebuild_shadow_from_graph",
+        side_effect=RuntimeError("bootstrap boom"),
+    ):
+        prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+
+def test_watchdog_errors_do_not_propagate(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    page = _write_page(graph, "pages/Wd.md", "- wd\n")
+    with patch(
+        "src.shadow.bootstrap.sync_page_to_shadow",
+        side_effect=RuntimeError("watchdog boom"),
+    ):
+        handle_shadow_watchdog_change(graph, page, "modified")
 
 
 def test_incompatible_schema_triggers_bootstrap(tmp_path: Path) -> None:
@@ -246,6 +311,38 @@ def test_concurrent_rebuild_defers_incremental_sync(tmp_path: Path) -> None:
         titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
         assert "Late" in titles
         assert "Base" in titles
+    finally:
+        conn.close()
+
+
+def test_concurrent_watchdog_and_post_write_replay_coherent_meta(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Seed.md",
+        "- seed\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    from src.shadow.runtime_state import mark_bootstrapping
+
+    mark_bootstrapping(graph)
+    extra = _write_page(
+        graph,
+        "pages/Deferred.md",
+        "- deferred\n  id:: cccccccc-cccc-4ccc-8ccc-cccccccccccc\n",
+    )
+    handle_shadow_watchdog_change(graph, extra, "created")
+    sync_page_to_shadow(graph, extra)
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert get_meta(conn, META_LAST_SYNC_ERROR) == ""
+        assert int(get_meta(conn, META_SOURCE_PAGE_COUNT) or "0") == 2
+        assert int(get_meta(conn, META_INDEXED_PAGE_COUNT) or "0") == 2
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 2
     finally:
         conn.close()
 

--- a/tests/test_shadow_fts.py
+++ b/tests/test_shadow_fts.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from src.shadow.connection import open_shadow_db
 from src.shadow.query import search_blocks_fts
 from src.shadow.sync import sync_page_to_shadow
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
 
 
 def _seed(tmp_path: Path) -> Path:

--- a/tests/test_shadow_sync.py
+++ b/tests/test_shadow_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from src.graph.markdown_blocks import atomic_write_bytes
 from src.graph.post_write import clear_page_written_handlers, emit_page_written
 from src.shadow.connection import open_shadow_db
@@ -12,6 +13,11 @@ from src.shadow.sync import (
     reset_shadow_sync_bridge_for_tests,
     sync_page_to_shadow,
 )
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
 
 
 def _write_page(graph: Path, rel: str, body: str) -> Path:


### PR DESCRIPTION
## Summary

- Implements PR-0 operational completion for Shadow DB (#248 child of #176): full-graph `rebuild_shadow_from_graph`, `shadow_meta` health contract, startup bootstrap via `prepare_matryca_runtime`, watchdog reconciliation by `file_path`, and sync bridge gated on `MATRYCA_SHADOW_DB_ENABLED`.
- Adds `meta.py`, `health.py`, `bootstrap.py`, `runtime_state.py` plus `tests/test_shadow_bootstrap.py`; extends incremental sync to delete/reconcile by `file_path`.
- Explicitly out of scope: FTS dispatch routing, recursive CTE, Sovereign UI health row.

## Test plan

- [x] `make check` — 1065 passed, 82.6% coverage
- [x] Pre-existing vault full index (`pages/` + `journals/`)
- [x] Rename/delete reconciliation by `file_path`
- [x] Interrupted rebuild preserves prior generation
- [x] Idempotent second bootstrap
- [x] Incompatible `schema_version` → error/stale
- [x] Concurrent rebuild defers incremental sync
- [x] Flag false → no DB creation / no bridge registration
- [x] Startup bootstrap via `prepare_matryca_runtime`

Closes #248. Does **not** close #176 (Phase 2 epic stays open until merge + soak).


Made with [Cursor](https://cursor.com)