### PR TITLE
feat(shadow): FTS5 BM25 routing with strict fallback (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Shadow FTS5 query (#183)** — `search_blocks_fts` returns BM25-ranked `BlockHit` rows (not yet wired to MCP dispatch; Phase 3).
 - **`MATRYCA_SHADOW_DB_ENABLED` (#184)** — `shadow_db_enabled()` opt-in flag in `src/shadow/config.py` and `.env.example` (parse only; runtime wiring in PR-0).
 - **Shadow bootstrap & runtime activation (#248)** — `rebuild_shadow_from_graph`, `shadow_meta` health keys, startup bootstrap via `prepare_matryca_runtime`, watchdog reconciliation by `file_path`, and sync bridge gated on `MATRYCA_SHADOW_DB_ENABLED` (Phase 2 operational completion; no FTS routing).
+- **Shadow FTS routing for `search_graph(bm25)` (#250)** — when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`, `handle_search_bm25` queries FTS5 with BM25-markdown envelope parity; invalid FTS syntax returns validation errors; backend failures fall back to generational BM25.
 
 ### Changed
 

--- a/src/agent/dispatch_search_handlers.py
+++ b/src/agent/dispatch_search_handlers.py
@@ -12,7 +12,6 @@ from ..graph.journal_task_scan import (
     scan_journal_tasks,
 )
 from ..graph.unlinked_mentions import resolve_unlinked_mentions as scan_unlinked_mentions
-from ..rag.local_query import format_keyword_query_markdown
 from .graph_tool_helpers import (
     SearchGraphMethod,
     bounded_int_from_options,
@@ -41,13 +40,16 @@ async def handle_search_bm25(graph_path: str, query: str) -> str:
     if isinstance(limit_raw, str):
         return limit_raw
     limit = limit_raw
-    return await asyncio.to_thread(
-        format_keyword_query_markdown,
-        graph_path,
-        keyword,
-        limit=limit,
-        mode="bm25",
-    )
+
+    def _run() -> str:
+        from ..shadow.fts_format import FtsQueryValidationError, resolve_bm25_search_markdown
+
+        try:
+            return resolve_bm25_search_markdown(graph_path, keyword, limit=limit)
+        except FtsQueryValidationError as exc:
+            return str(exc)
+
+    return await asyncio.to_thread(_run)
 
 
 async def handle_search_semantic(graph_path: str, query: str) -> str:

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -8,6 +8,11 @@ from .bootstrap import (
 )
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
+from .fts_format import (
+    FtsQueryValidationError,
+    format_shadow_fts_markdown,
+    resolve_bm25_search_markdown,
+)
 from .health import ShadowHealthState, resolve_shadow_health
 from .meta import (
     META_GENERATION,
@@ -53,14 +58,17 @@ __all__ = [
     "META_SOURCE_PAGE_COUNT",
     "REQUIRED_META_KEYS",
     "BlockHit",
+    "FtsQueryValidationError",
     "ShadowHealthState",
     "apply_shadow_schema",
     "delete_shadow_page_by_file_path",
     "ensure_shadow_runtime_at_startup",
     "ensure_shadow_sync_bridge",
+    "format_shadow_fts_markdown",
     "handle_shadow_watchdog_change",
     "open_shadow_db",
     "rebuild_shadow_from_graph",
+    "resolve_bm25_search_markdown",
     "resolve_shadow_health",
     "search_blocks_fts",
     "shadow_db_enabled",

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -1,0 +1,132 @@
+"""FTS5 markdown formatter and ``search_graph(bm25)`` routing (v2 PR-B / #250)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from loguru import logger
+
+from ..graph.path_sandbox import resolved_graph_root
+from ..rag.local_query import format_keyword_query_markdown
+from .config import shadow_db_enabled
+from .connection import open_shadow_db
+from .health import ShadowHealthState, resolve_shadow_health
+from .query import BlockHit, search_blocks_fts
+
+_FTS_VALIDATION_PREFIX = "Invalid FTS query for `method=bm25`"
+
+
+class FtsQueryValidationError(ValueError):
+    """User-supplied keyword is not a valid FTS5 ``MATCH`` expression."""
+
+
+def validate_fts_match_query(keyword: str) -> None:
+    """Reject obviously invalid FTS5 query syntax before hitting SQLite."""
+    q = keyword.strip()
+    if not q:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: query is empty after trimming whitespace."
+        )
+    if q.count('"') % 2 != 0:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: unbalanced double quotes in {q!r}."
+        )
+
+
+def _page_rows_for_hits(
+    connection: sqlite3.Connection,
+    hits: list[BlockHit],
+) -> dict[int, tuple[str, str]]:
+    page_ids = {hit.page_id for hit in hits}
+    out: dict[int, tuple[str, str]] = {}
+    for page_id in page_ids:
+        row = connection.execute(
+            "SELECT title, file_path FROM pages WHERE page_id = ?",
+            (page_id,),
+        ).fetchone()
+        if row is not None:
+            out[page_id] = (str(row[0]), str(row[1]))
+    return out
+
+
+def format_shadow_fts_markdown(
+    graph_root: Path | str,
+    keyword: str,
+    *,
+    limit: int = 15,
+) -> str:
+    """Format shadow FTS block hits using the BM25 search_graph markdown envelope."""
+    validate_fts_match_query(keyword)
+    root = resolved_graph_root(graph_root)
+    conn = open_shadow_db(root)
+    try:
+        try:
+            hits = search_blocks_fts(conn, keyword, limit=limit)
+        except sqlite3.OperationalError as exc:
+            if "syntax" in str(exc).lower():
+                raise FtsQueryValidationError(
+                    f"{_FTS_VALIDATION_PREFIX}: {keyword!r} is not valid FTS5 syntax."
+                ) from exc
+            raise
+        page_rows = _page_rows_for_hits(conn, hits)
+    finally:
+        conn.close()
+
+    lines = [
+        "# Local page query",
+        "",
+        f"- **Graph:** `{root}`",
+        f"- **Query:** `{keyword.strip()}`",
+        "- **Mode:** `bm25`",
+        "",
+        f"- **Matches:** {len(hits)}",
+        "",
+        "## Ranked pages (BM25)",
+        "",
+    ]
+    if not hits:
+        lines.append("_No lexical overlap in `pages/**/*.md`._")
+        lines.append("")
+        return "\n".join(lines)
+
+    for hit in hits:
+        title, rel = page_rows.get(hit.page_id, ("?", "?"))
+        lines.append(
+            f"- `{rel}` ({title}) — block `{hit.block_uuid}` — **{hit.rank:.4f}**"
+        )
+        snippet = (hit.content or "").strip().replace("\n", " ")
+        if snippet:
+            lines.append(f"  > {snippet[:240]}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def resolve_bm25_search_markdown(
+    graph_root: Path | str,
+    keyword: str,
+    *,
+    limit: int = 15,
+) -> str:
+    """Route to shadow FTS when enabled and ``ready``; else generational BM25.
+
+    Validation errors from FTS syntax are returned to the caller (no BM25 fallback).
+    Backend failures while shadow is ``ready`` fall back to generational BM25.
+    """
+    root = resolved_graph_root(graph_root)
+    if shadow_db_enabled() and resolve_shadow_health(root) == ShadowHealthState.READY:
+        try:
+            return format_shadow_fts_markdown(root, keyword, limit=limit)
+        except FtsQueryValidationError:
+            raise
+        except Exception:  # noqa: BLE001 — shadow backend failure → v1 fallback
+            logger.exception("Shadow FTS search failed; falling back to generational BM25")
+    return format_keyword_query_markdown(root, keyword, limit=limit, mode="bm25")
+
+
+__all__ = [
+    "FtsQueryValidationError",
+    "format_shadow_fts_markdown",
+    "resolve_bm25_search_markdown",
+    "validate_fts_match_query",
+]

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -92,9 +92,7 @@ def format_shadow_fts_markdown(
 
     for hit in hits:
         title, rel = page_rows.get(hit.page_id, ("?", "?"))
-        lines.append(
-            f"- `{rel}` ({title}) — block `{hit.block_uuid}` — **{hit.rank:.4f}**"
-        )
+        lines.append(f"- `{rel}` ({title}) — block `{hit.block_uuid}` — **{hit.rank:.4f}**")
         snippet = (hit.content or "").strip().replace("\n", " ")
         if snippet:
             lines.append(f"  > {snippet[:240]}")

--- a/tests/test_shadow_fts_routing.py
+++ b/tests/test_shadow_fts_routing.py
@@ -1,0 +1,189 @@
+"""Routing tests for shadow FTS5 in ``search_graph(bm25)`` (#250)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.agent.dispatch_search_handlers import handle_search_bm25
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.connection import open_shadow_db
+from src.shadow.fts_format import (
+    FtsQueryValidationError,
+    format_shadow_fts_markdown,
+    resolve_bm25_search_markdown,
+    validate_fts_match_query,
+)
+from src.shadow.meta import META_LAST_FULL_SYNC_COMPLETED, META_LAST_SYNC_ERROR, get_meta
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _minimal_graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    return graph
+
+
+def _seed_shadow_ready(graph: Path) -> None:
+    _write_page(
+        graph,
+        "pages/FtsRoute.md",
+        "- alpha shadow needle here\n"
+        "  id:: 11111111-1111-4111-8111-111111111111\n"
+        "- unrelated beta content\n"
+        "  id:: 22222222-2222-4222-8222-222222222222\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+
+def test_bm25_envelope_parity_shadow_vs_generational(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/A.md", "alpha needle token\n")
+    _seed_shadow_ready(graph)
+
+    shadow_md = resolve_bm25_search_markdown(graph, "needle", limit=10)
+    with patch("src.shadow.fts_format.shadow_db_enabled", return_value=False):
+        generational_md = resolve_bm25_search_markdown(graph, "needle", limit=10)
+
+    for md in (shadow_md, generational_md):
+        assert md.startswith("# Local page query")
+        assert "- **Graph:**" in md
+        assert "- **Query:**" in md
+        assert "- **Mode:** `bm25`" in md
+        assert "- **Matches:**" in md
+        assert "## Ranked pages (BM25)" in md
+    assert "block `" in shadow_md
+    assert "FtsRoute.md" in shadow_md
+    assert "block `" not in generational_md
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_uses_shadow_when_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _seed_shadow_ready(graph)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+
+    out = await handle_search_bm25(str(graph), "shadow")
+    assert "block `11111111-1111-4111-8111-111111111111`" in out
+    assert "FtsRoute.md" in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_flag_false_uses_generational_bm25(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Banana.md", "banana fruit banana\n")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+
+    out = await handle_search_bm25(str(graph), "banana")
+    assert "Banana.md" in out
+    assert "block `" not in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_shadow_not_ready_falls_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Cherry.md", "cherry cherry\n")
+    _seed_shadow_ready(graph)
+    conn = open_shadow_db(graph)
+    try:
+        conn.execute(
+            "UPDATE shadow_meta SET value = ? WHERE key = ?",
+            ("stale marker", META_LAST_SYNC_ERROR),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = await handle_search_bm25(str(graph), "cherry")
+    assert "Cherry.md" in out
+    assert "block `" not in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_zero_hits_no_fallback(
+    tmp_path: Path,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _seed_shadow_ready(graph)
+
+    out = await handle_search_bm25(str(graph), "zzznomatchzz")
+    assert "- **Matches:** 0" in out
+    assert "_No lexical overlap" in out
+    assert "Invalid FTS query" not in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_invalid_fts_query_no_fallback(
+    tmp_path: Path,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _seed_shadow_ready(graph)
+
+    out = await handle_search_bm25(str(graph), '"unclosed')
+    assert "Invalid FTS query" in out
+    assert "## Ranked pages (BM25)" not in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_backend_failure_falls_back(
+    tmp_path: Path,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Delta.md", "delta delta\n")
+    _seed_shadow_ready(graph)
+
+    with patch(
+        "src.shadow.fts_format.format_shadow_fts_markdown",
+        side_effect=sqlite3.OperationalError("database disk image is malformed"),
+    ):
+        out = await handle_search_bm25(str(graph), "delta")
+    assert "Delta.md" in out
+    assert "Invalid FTS query" not in out
+
+
+@pytest.mark.asyncio
+async def test_handle_search_bm25_empty_keyword_validation(
+    tmp_path: Path,
+) -> None:
+    out = await handle_search_bm25(str(tmp_path), "  ")
+    assert "method=bm25" in out
+
+
+def test_format_shadow_fts_markdown_ready_meta(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _seed_shadow_ready(graph)
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+    finally:
+        conn.close()
+
+    md = format_shadow_fts_markdown(graph, "shadow")
+    assert "needle" in md.lower()
+
+
+def test_validate_fts_match_query_rejects_unbalanced_quotes() -> None:
+    with pytest.raises(FtsQueryValidationError):
+        validate_fts_match_query('"bad')


### PR DESCRIPTION
## Summary

- Route `search_graph(method=bm25)` through shadow FTS5 when `MATRYCA_SHADOW_DB_ENABLED=true` and `resolve_shadow_health == ready`.
- Preserve the generational BM25 markdown envelope (`# Local page query`, ranked pages section, block-level hits with rank/snippet).
- Invalid FTS syntax returns a validation error (no fallback); zero hits return empty results in the same shape; not-ready health or backend failures fall back to generational BM25.

Closes #250

## Gate

Operator soak on real vault completed on #176: `ready`, 1265/1265 pages, idempotent second boot, flag-off unchanged, no shadow→Markdown writes.

## Test plan

- [x] Flag false → generational BM25 path
- [x] Health `error` / not-ready → BM25 fallback (no FTS reads)
- [x] Health `ready` + valid query → FTS hits with envelope parity
- [x] Health `ready` + zero hits → empty markdown, same shape (no fallback)
- [x] Invalid FTS query → validation message (no fallback)
- [x] Simulated SQLite/FTS exception → BM25 fallback
- [x] `make check`


Made with [Cursor](https://cursor.com)