### PR TITLE
feat(shadow): recursive CTE subtree helper (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **`MATRYCA_SHADOW_DB_ENABLED` (#184)** — `shadow_db_enabled()` opt-in flag in `src/shadow/config.py` and `.env.example` (parse only; runtime wiring in PR-0).
 - **Shadow bootstrap & runtime activation (#248)** — `rebuild_shadow_from_graph`, `shadow_meta` health keys, startup bootstrap via `prepare_matryca_runtime`, watchdog reconciliation by `file_path`, and sync bridge gated on `MATRYCA_SHADOW_DB_ENABLED` (Phase 2 operational completion; no FTS routing).
 - **Shadow FTS routing for `search_graph(bm25)` (#250)** — when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`, `handle_search_bm25` queries FTS5 with BM25-markdown envelope parity; invalid FTS syntax returns validation errors; backend failures fall back to generational BM25.
+- **Shadow recursive CTE subtree helper (#253)** — `query_subtree_by_block_uuid` in `src/shadow/subtree.py` reads block subtrees from `shadow.sqlite` with depth-first ordering, visited-rowid cycle guards, SQL-enforced depth/node limits, UTF-8-safe byte truncation, and parity tests against `MarkdownGraphRepository` (no dispatch wiring).
 
 ### Changed
 

--- a/src/shadow/__init__.py
+++ b/src/shadow/__init__.py
@@ -35,6 +35,12 @@ from .schema import (
     SHADOW_SCHEMA_VERSION,
     apply_shadow_schema,
 )
+from .subtree import (
+    SubtreeBlock,
+    SubtreeQueryResult,
+    SubtreeStatus,
+    query_subtree_by_block_uuid,
+)
 from .sync import (
     delete_shadow_page_by_file_path,
     ensure_shadow_sync_bridge,
@@ -60,6 +66,9 @@ __all__ = [
     "BlockHit",
     "FtsQueryValidationError",
     "ShadowHealthState",
+    "SubtreeBlock",
+    "SubtreeQueryResult",
+    "SubtreeStatus",
     "apply_shadow_schema",
     "delete_shadow_page_by_file_path",
     "ensure_shadow_runtime_at_startup",
@@ -67,6 +76,7 @@ __all__ = [
     "format_shadow_fts_markdown",
     "handle_shadow_watchdog_change",
     "open_shadow_db",
+    "query_subtree_by_block_uuid",
     "rebuild_shadow_from_graph",
     "resolve_bm25_search_markdown",
     "resolve_shadow_health",

--- a/src/shadow/subtree.py
+++ b/src/shadow/subtree.py
@@ -1,0 +1,481 @@
+"""Recursive CTE subtree reads from ``shadow.sqlite`` (v2 PR-C1 / #253)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, cast
+
+_DEFAULT_MAX_DEPTH = 64
+_DEFAULT_MAX_NODES = 500
+_DEFAULT_MAX_OUTPUT_BYTES = 256_000
+_TRUNCATION_NOTICE = "\n… [truncated: output byte limit exceeded]\n"
+
+
+class SubtreeStatus(StrEnum):
+    """Outcome of a shadow subtree query."""
+
+    NOT_FOUND = "not_found"
+    COMPLETE = "complete"
+    TRUNCATED = "truncated"
+    INCONSISTENT = "inconsistent"
+
+
+@dataclass(frozen=True, slots=True)
+class SubtreeBlock:
+    """One block row in depth-first subtree order."""
+
+    rowid: int
+    block_uuid: str
+    page_id: int
+    parent_rowid: int | None
+    sort_order: int
+    indent_level: int
+    content: str
+    properties_json: str
+    depth: int
+    path_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class SubtreeQueryResult:
+    """Result of ``query_subtree_by_block_uuid``."""
+
+    status: SubtreeStatus
+    anchor_uuid: str
+    page_id: int | None
+    nodes: tuple[SubtreeBlock, ...]
+    excerpt_markdown: str
+    detail: str | None = None
+
+
+def _clamp_limits(
+    *,
+    max_depth: int,
+    max_nodes: int,
+    max_output_bytes: int,
+) -> tuple[int, int, int]:
+    depth = max(1, min(int(max_depth), 256))
+    nodes = max(1, min(int(max_nodes), 10_000))
+    output_bytes = max(1, min(int(max_output_bytes), 10_000_000))
+    return depth, nodes, output_bytes
+
+
+def _fetch_anchor(
+    connection: sqlite3.Connection,
+    block_uuid: str,
+) -> sqlite3.Row | None:
+    row = connection.execute(
+        """
+        SELECT rowid, block_uuid, page_id, parent_rowid, sort_order,
+               indent_level, content, properties_json
+        FROM blocks
+        WHERE block_uuid = ?
+        """,
+        (block_uuid,),
+    ).fetchone()
+    return cast(sqlite3.Row | None, row)
+
+
+def _has_cross_page_edge(
+    connection: sqlite3.Connection,
+    *,
+    anchor_rowid: int,
+    page_id: int,
+) -> bool:
+    row = connection.execute(
+        """
+        WITH RECURSIVE walk(rowid, page_id) AS (
+            SELECT rowid, page_id FROM blocks WHERE rowid = ?
+            UNION ALL
+            SELECT child.rowid, child.page_id
+            FROM blocks AS child
+            INNER JOIN walk ON child.parent_rowid = walk.rowid
+            WHERE child.page_id = walk.page_id
+        )
+        SELECT 1
+        FROM blocks AS child
+        INNER JOIN walk ON child.parent_rowid = walk.rowid
+        WHERE child.page_id != ?
+        LIMIT 1
+        """,
+        (anchor_rowid, page_id),
+    ).fetchone()
+    return row is not None
+
+
+def _has_cycle_in_subtree(
+    connection: sqlite3.Connection,
+    *,
+    anchor_rowid: int,
+    page_id: int,
+) -> bool:
+    path: set[int] = set()
+
+    def dfs(rowid: int) -> bool:
+        if rowid in path:
+            return True
+        path.add(rowid)
+        children = connection.execute(
+            """
+            SELECT rowid
+            FROM blocks
+            WHERE parent_rowid = ? AND page_id = ?
+            ORDER BY sort_order, rowid
+            """,
+            (rowid, page_id),
+        ).fetchall()
+        for (child_rowid,) in children:
+            if dfs(int(child_rowid)):
+                return True
+        path.remove(rowid)
+        return False
+
+    return dfs(anchor_rowid)
+
+
+def _count_subtree_nodes(
+    connection: sqlite3.Connection,
+    *,
+    anchor_rowid: int,
+    page_id: int,
+    max_depth: int,
+) -> int:
+    depth_cap = max_depth - 1
+    row = connection.execute(
+        """
+        WITH RECURSIVE subtree(
+            rowid, depth, visited
+        ) AS (
+            SELECT rowid, 0, CAST(rowid AS TEXT)
+            FROM blocks
+            WHERE rowid = ?
+            UNION ALL
+            SELECT
+                child.rowid,
+                subtree.depth + 1,
+                subtree.visited || ',' || CAST(child.rowid AS TEXT)
+            FROM blocks AS child
+            INNER JOIN subtree ON child.parent_rowid = subtree.rowid
+            WHERE child.page_id = ?
+              AND subtree.depth < ?
+              AND instr(',' || subtree.visited || ',', ',' || CAST(child.rowid AS TEXT) || ',') = 0
+        )
+        SELECT COUNT(*) FROM subtree
+        """,
+        (anchor_rowid, page_id, depth_cap),
+    ).fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+def _fetch_subtree_rows(
+    connection: sqlite3.Connection,
+    *,
+    anchor_rowid: int,
+    page_id: int,
+    max_depth: int,
+    max_nodes: int,
+) -> list[sqlite3.Row]:
+    depth_cap = max_depth - 1
+    return connection.execute(
+        """
+        WITH RECURSIVE subtree(
+            rowid,
+            block_uuid,
+            page_id,
+            parent_rowid,
+            sort_order,
+            indent_level,
+            content,
+            properties_json,
+            depth,
+            path_key,
+            visited
+        ) AS (
+            SELECT
+                rowid,
+                block_uuid,
+                page_id,
+                parent_rowid,
+                sort_order,
+                indent_level,
+                content,
+                properties_json,
+                0,
+                printf('%020d,%020d', sort_order, rowid),
+                CAST(rowid AS TEXT)
+            FROM blocks
+            WHERE rowid = ?
+            UNION ALL
+            SELECT
+                child.rowid,
+                child.block_uuid,
+                child.page_id,
+                child.parent_rowid,
+                child.sort_order,
+                child.indent_level,
+                child.content,
+                child.properties_json,
+                subtree.depth + 1,
+                subtree.path_key || '/' || printf('%020d,%020d', child.sort_order, child.rowid),
+                subtree.visited || ',' || CAST(child.rowid AS TEXT)
+            FROM blocks AS child
+            INNER JOIN subtree ON child.parent_rowid = subtree.rowid
+            WHERE child.page_id = ?
+              AND subtree.depth < ?
+              AND instr(',' || subtree.visited || ',', ',' || CAST(child.rowid AS TEXT) || ',') = 0
+        )
+        SELECT
+            rowid,
+            block_uuid,
+            page_id,
+            parent_rowid,
+            sort_order,
+            indent_level,
+            content,
+            properties_json,
+            depth,
+            path_key
+        FROM subtree
+        ORDER BY path_key
+        LIMIT ?
+        """,
+        (
+            anchor_rowid,
+            page_id,
+            depth_cap,
+            max_nodes,
+        ),
+    ).fetchall()
+
+
+def _rows_to_blocks(rows: list[sqlite3.Row]) -> tuple[SubtreeBlock, ...]:
+    blocks: list[SubtreeBlock] = []
+    for row in rows:
+        blocks.append(
+            SubtreeBlock(
+                rowid=int(row[0]),
+                block_uuid=str(row[1]),
+                page_id=int(row[2]),
+                parent_rowid=int(row[3]) if row[3] is not None else None,
+                sort_order=int(row[4]),
+                indent_level=int(row[5]),
+                content=str(row[6]),
+                properties_json=str(row[7]),
+                depth=int(row[8]),
+                path_key=str(row[9]),
+            )
+        )
+    return tuple(blocks)
+
+
+def _render_block_lines(block: SubtreeBlock) -> list[str]:
+    unit = "  "
+    prefix = unit * block.indent_level
+    lines = [f"{prefix}- {block.content}\n"]
+    props: dict[str, Any] = {}
+    if block.properties_json:
+        try:
+            loaded = json.loads(block.properties_json)
+            if isinstance(loaded, dict):
+                props = loaded
+        except json.JSONDecodeError:
+            props = {}
+    block_id = str(props.get("id", "")).strip()
+    if block_id:
+        lines.append(f"{prefix}  id:: {block_id}\n")
+    return lines
+
+
+def _apply_output_byte_limit(
+    blocks: tuple[SubtreeBlock, ...],
+    *,
+    max_output_bytes: int,
+) -> tuple[tuple[SubtreeBlock, ...], str, bool]:
+    if not blocks:
+        return blocks, "", False
+
+    selected: list[SubtreeBlock] = []
+    parts: list[str] = []
+    used = 0
+    truncated = False
+
+    for block in blocks:
+        rendered = "".join(_render_block_lines(block))
+        chunk = rendered.encode("utf-8")
+        if not selected:
+            selected.append(block)
+            parts.append(rendered)
+            used = len(chunk)
+            if used > max_output_bytes:
+                truncated = True
+            continue
+        if used + len(chunk) > max_output_bytes:
+            truncated = True
+            break
+        selected.append(block)
+        parts.append(rendered)
+        used += len(chunk)
+
+    excerpt = "".join(parts)
+    if truncated:
+        if excerpt:
+            excerpt = excerpt.rstrip("\n") + _TRUNCATION_NOTICE
+        else:
+            excerpt = _TRUNCATION_NOTICE.lstrip("\n")
+    return tuple(selected), excerpt, truncated
+
+
+def _has_depth_or_node_truncation(
+    connection: sqlite3.Connection,
+    *,
+    anchor_rowid: int,
+    page_id: int,
+    max_depth: int,
+    max_nodes: int,
+    fetched_count: int,
+) -> bool:
+    if fetched_count >= max_nodes:
+        total = _count_subtree_nodes(
+            connection,
+            anchor_rowid=anchor_rowid,
+            page_id=page_id,
+            max_depth=max_depth,
+        )
+        if total > fetched_count:
+            return True
+    if max_depth <= 1:
+        return False
+    deepest = max_depth - 1
+    row = connection.execute(
+        """
+        WITH RECURSIVE at_depth(rowid, depth) AS (
+            SELECT rowid, 0 FROM blocks WHERE rowid = ?
+            UNION ALL
+            SELECT child.rowid, at_depth.depth + 1
+            FROM blocks AS child
+            INNER JOIN at_depth ON child.parent_rowid = at_depth.rowid
+            WHERE child.page_id = ?
+              AND at_depth.depth < ?
+        )
+        SELECT 1
+        FROM blocks AS child
+        INNER JOIN at_depth ON child.parent_rowid = at_depth.rowid
+        WHERE child.page_id = ?
+          AND at_depth.depth = ?
+        LIMIT 1
+        """,
+        (anchor_rowid, page_id, deepest, page_id, deepest),
+    ).fetchone()
+    return row is not None
+
+
+def query_subtree_by_block_uuid(
+    connection: sqlite3.Connection,
+    block_uuid: str,
+    *,
+    max_depth: int = _DEFAULT_MAX_DEPTH,
+    max_nodes: int = _DEFAULT_MAX_NODES,
+    max_output_bytes: int = _DEFAULT_MAX_OUTPUT_BYTES,
+) -> SubtreeQueryResult:
+    """Return the anchor block and descendants in deterministic depth-first order."""
+    anchor_uuid = block_uuid.strip()
+    if not anchor_uuid:
+        return SubtreeQueryResult(
+            status=SubtreeStatus.NOT_FOUND,
+            anchor_uuid=anchor_uuid,
+            page_id=None,
+            nodes=(),
+            excerpt_markdown="",
+            detail="block_uuid is empty",
+        )
+
+    depth_limit, node_limit, byte_limit = _clamp_limits(
+        max_depth=max_depth,
+        max_nodes=max_nodes,
+        max_output_bytes=max_output_bytes,
+    )
+
+    anchor = _fetch_anchor(connection, anchor_uuid)
+    if anchor is None:
+        return SubtreeQueryResult(
+            status=SubtreeStatus.NOT_FOUND,
+            anchor_uuid=anchor_uuid,
+            page_id=None,
+            nodes=(),
+            excerpt_markdown="",
+            detail=f"block `{anchor_uuid}` not found in shadow blocks",
+        )
+
+    anchor_rowid = int(anchor[0])
+    page_id = int(anchor[2])
+
+    if _has_cross_page_edge(
+        connection,
+        anchor_rowid=anchor_rowid,
+        page_id=page_id,
+    ):
+        return SubtreeQueryResult(
+            status=SubtreeStatus.INCONSISTENT,
+            anchor_uuid=anchor_uuid,
+            page_id=page_id,
+            nodes=(),
+            excerpt_markdown="",
+            detail="subtree contains a child block on a different page_id",
+        )
+
+    if _has_cycle_in_subtree(
+        connection,
+        anchor_rowid=anchor_rowid,
+        page_id=page_id,
+    ):
+        return SubtreeQueryResult(
+            status=SubtreeStatus.INCONSISTENT,
+            anchor_uuid=anchor_uuid,
+            page_id=page_id,
+            nodes=(),
+            excerpt_markdown="",
+            detail="subtree contains a parent_rowid cycle",
+        )
+
+    rows = _fetch_subtree_rows(
+        connection,
+        anchor_rowid=anchor_rowid,
+        page_id=page_id,
+        max_depth=depth_limit,
+        max_nodes=node_limit,
+    )
+    blocks = _rows_to_blocks(rows)
+    limited_blocks, excerpt, byte_truncated = _apply_output_byte_limit(
+        blocks,
+        max_output_bytes=byte_limit,
+    )
+
+    truncated = byte_truncated or _has_depth_or_node_truncation(
+        connection,
+        anchor_rowid=anchor_rowid,
+        page_id=page_id,
+        max_depth=depth_limit,
+        max_nodes=node_limit,
+        fetched_count=len(blocks),
+    )
+    status = SubtreeStatus.TRUNCATED if truncated else SubtreeStatus.COMPLETE
+
+    return SubtreeQueryResult(
+        status=status,
+        anchor_uuid=anchor_uuid,
+        page_id=page_id,
+        nodes=limited_blocks,
+        excerpt_markdown=excerpt,
+        detail=None if status == SubtreeStatus.COMPLETE else "subtree limits exceeded",
+    )
+
+
+__all__ = [
+    "SubtreeBlock",
+    "SubtreeQueryResult",
+    "SubtreeStatus",
+    "query_subtree_by_block_uuid",
+]

--- a/tests/test_shadow_subtree.py
+++ b/tests/test_shadow_subtree.py
@@ -1,0 +1,392 @@
+"""Parity and safety tests for shadow recursive CTE subtree reads (#253)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from src.agent.graph_tool_helpers import read_subtree_markdown
+from src.agent.markdown_graph_repository import MarkdownGraphRepository
+from src.shadow.connection import open_shadow_db
+from src.shadow.subtree import SubtreeStatus, query_subtree_by_block_uuid
+from src.shadow.sync import sync_page_into_connection, sync_page_to_shadow
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _sync(graph: Path, rel: str) -> None:
+    sync_page_to_shadow(graph, graph / rel)
+
+
+def _extract_excerpt(markdown: str) -> str:
+    marker = "```markdown\n"
+    start = markdown.find(marker)
+    if start == -1:
+        return markdown
+    start += len(marker)
+    end = markdown.find("\n```", start)
+    if end == -1:
+        return markdown[start:]
+    return markdown[start:end]
+
+
+def _normalize_excerpt(text: str) -> str:
+    return text.replace("\r\n", "\n").rstrip("\n")
+
+
+def _parity_query(page: str, block_uuid: str) -> str:
+    return json.dumps({"page": page, "block_uuid": block_uuid})
+
+
+def test_subtree_root_matches_markdown_repository(tmp_path: Path) -> None:
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(
+        tmp_path,
+        "pages/Demo.md",
+        f"- Root line\n  id:: {block_id}\n  - child one\n  - child two\n",
+    )
+    _sync(tmp_path, "pages/Demo.md")
+
+    query = _parity_query("Demo", block_id)
+    expected = _extract_excerpt(read_subtree_markdown(str(tmp_path), query))
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, block_id)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.COMPLETE
+    assert _normalize_excerpt(result.excerpt_markdown) == _normalize_excerpt(expected)
+    assert [node.block_uuid for node in result.nodes][0] == block_id
+    assert "child one" in result.excerpt_markdown
+
+
+def test_subtree_nested_children_order(tmp_path: Path) -> None:
+    root = "11111111-1111-4111-8111-111111111111"
+    child_a = "22222222-2222-4222-8222-222222222222"
+    child_b = "33333333-3333-4333-8333-333333333333"
+    grand = "44444444-4444-4444-8444-444444444444"
+    _write_page(
+        tmp_path,
+        "pages/Nested.md",
+        (
+            f"- root\n  id:: {root}\n"
+            f"  - alpha\n    id:: {child_a}\n"
+            f"    - grand\n      id:: {grand}\n"
+            f"  - beta\n    id:: {child_b}\n"
+        ),
+    )
+    _sync(tmp_path, "pages/Nested.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, root)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.COMPLETE
+    uuids = [node.block_uuid for node in result.nodes]
+    assert uuids == [root, child_a, grand, child_b]
+
+
+def test_subtree_leaf_block(tmp_path: Path) -> None:
+    root = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    leaf = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    _write_page(
+        tmp_path,
+        "pages/Leaf.md",
+        f"- root\n  id:: {root}\n  - leaf only\n    id:: {leaf}\n",
+    )
+    _sync(tmp_path, "pages/Leaf.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, leaf)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.COMPLETE
+    assert len(result.nodes) == 1
+    assert result.nodes[0].block_uuid == leaf
+    assert "leaf only" in result.excerpt_markdown
+
+
+def test_subtree_not_found(tmp_path: Path) -> None:
+    _write_page(tmp_path, "pages/Empty.md", "- solo\n  id:: abcdef01-2345-4678-89ab-cdef01234567\n")
+    _sync(tmp_path, "pages/Empty.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, "00000000-0000-4000-8000-000000000001")
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.NOT_FOUND
+    assert result.nodes == ()
+
+
+def test_subtree_max_depth_applied_in_query(tmp_path: Path) -> None:
+    ids = [
+        "10000000-0000-4000-8000-000000000001",
+        "20000000-0000-4000-8000-000000000002",
+        "30000000-0000-4000-8000-000000000003",
+    ]
+    _write_page(
+        tmp_path,
+        "pages/Depth.md",
+        (
+            f"- d0\n  id:: {ids[0]}\n"
+            f"  - d1\n    id:: {ids[1]}\n"
+            f"    - d2\n      id:: {ids[2]}\n"
+        ),
+    )
+    _sync(tmp_path, "pages/Depth.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        shallow = query_subtree_by_block_uuid(conn, ids[0], max_depth=2)
+        deep = query_subtree_by_block_uuid(conn, ids[0], max_depth=3)
+    finally:
+        conn.close()
+
+    assert shallow.status == SubtreeStatus.TRUNCATED
+    assert [node.block_uuid for node in shallow.nodes] == ids[:2]
+    assert deep.status == SubtreeStatus.COMPLETE
+    assert len(deep.nodes) == 3
+    assert [node.depth for node in deep.nodes] == [0, 1, 2]
+
+
+def test_subtree_max_nodes_applied_in_query(tmp_path: Path) -> None:
+    lines = ["- root\n  id:: root-uuid-1111-4111-8111-111111111111\n"]
+    for index in range(4):
+        lines.append(f"  - child {index}\n    id:: {index:08x}-1111-4111-8111-111111111111\n")
+    _write_page(tmp_path, "pages/Many.md", "".join(lines))
+    _sync(tmp_path, "pages/Many.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        limited = query_subtree_by_block_uuid(
+            conn,
+            "root-uuid-1111-4111-8111-111111111111",
+            max_nodes=3,
+        )
+        full = query_subtree_by_block_uuid(
+            conn,
+            "root-uuid-1111-4111-8111-111111111111",
+            max_nodes=10,
+        )
+    finally:
+        conn.close()
+
+    assert limited.status == SubtreeStatus.TRUNCATED
+    assert len(limited.nodes) == 3
+    assert full.status == SubtreeStatus.COMPLETE
+    assert len(full.nodes) == 5
+
+
+def test_subtree_max_output_bytes_truncates_on_node_boundary(tmp_path: Path) -> None:
+    root = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(
+        tmp_path,
+        "pages/Bytes.md",
+        (
+            f"- root {'x' * 40}\n  id:: {root}\n"
+            "  - child one padding text\n"
+            "  - child two padding text\n"
+        ),
+    )
+    _sync(tmp_path, "pages/Bytes.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, root, max_output_bytes=80)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.TRUNCATED
+    assert "[truncated: output byte limit exceeded]" in result.excerpt_markdown
+    assert len(result.nodes) >= 1
+    assert "child two" not in result.excerpt_markdown
+
+
+def test_subtree_detects_cross_page_inconsistency(tmp_path: Path) -> None:
+    root = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(tmp_path, "pages/A.md", f"- root\n  id:: {root}\n")
+    _write_page(tmp_path, "pages/B.md", "- other\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n")
+    _sync(tmp_path, "pages/A.md")
+    _sync(tmp_path, "pages/B.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        anchor_row = conn.execute(
+            "SELECT rowid, page_id FROM blocks WHERE block_uuid = ?",
+            (root,),
+        ).fetchone()
+        assert anchor_row is not None
+        foreign = conn.execute(
+            "SELECT rowid, page_id FROM blocks WHERE block_uuid = ?",
+            ("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",),
+        ).fetchone()
+        assert foreign is not None
+        conn.execute(
+            "UPDATE blocks SET parent_rowid = ? WHERE rowid = ?",
+            (int(anchor_row[0]), int(foreign[0])),
+        )
+        conn.commit()
+
+        result = query_subtree_by_block_uuid(conn, root)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.INCONSISTENT
+    assert result.nodes == ()
+
+
+def test_subtree_detects_cycle_inconsistency(tmp_path: Path) -> None:
+    a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    _write_page(
+        tmp_path,
+        "pages/Cycle.md",
+        f"- a\n  id:: {a}\n  - b\n    id:: {b}\n",
+    )
+    _sync(tmp_path, "pages/Cycle.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        rows = {
+            uuid: int(
+                conn.execute(
+                    "SELECT rowid FROM blocks WHERE block_uuid = ?",
+                    (uuid,),
+                ).fetchone()[0]
+            )
+            for uuid in (a, b)
+        }
+        conn.execute(
+            "UPDATE blocks SET parent_rowid = ? WHERE block_uuid = ?",
+            (rows[b], a),
+        )
+        conn.commit()
+
+        result = query_subtree_by_block_uuid(conn, a)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.INCONSISTENT
+
+
+def test_subtree_sort_order_tie_breaks_on_rowid(tmp_path: Path) -> None:
+    page = _write_page(
+        tmp_path,
+        "pages/Tie.md",
+        "- root\n  id:: root-uuid-1111-4111-8111-111111111111\n",
+    )
+    conn = open_shadow_db(tmp_path)
+    try:
+        sync_page_into_connection(conn, tmp_path, page)
+        root_row = conn.execute(
+            "SELECT rowid, page_id FROM blocks WHERE block_uuid = ?",
+            ("root-uuid-1111-4111-8111-111111111111",),
+        ).fetchone()
+        assert root_row is not None
+        page_id = int(root_row[1])
+        conn.executemany(
+            """
+            INSERT INTO blocks (
+                block_uuid, page_id, parent_rowid, sort_order,
+                indent_level, content, properties_json, synced_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'test')
+            """,
+        [
+            (
+                "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                page_id,
+                int(root_row[0]),
+                5,
+                1,
+                "first by rowid",
+                "{}",
+            ),
+            (
+                "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                page_id,
+                int(root_row[0]),
+                5,
+                1,
+                "second by rowid",
+                "{}",
+            ),
+        ],
+        )
+        conn.commit()
+
+        result = query_subtree_by_block_uuid(
+            conn,
+            "root-uuid-1111-4111-8111-111111111111",
+        )
+        child_uuids = [node.block_uuid for node in result.nodes if node.depth == 1]
+    finally:
+        conn.close()
+
+    assert child_uuids == [
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    ]
+
+
+def test_markdown_repository_fixture_parity(tmp_path: Path) -> None:
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(
+        tmp_path,
+        "pages/Repo.md",
+        f"- Root\n  id:: {block_id}\n  - child\n",
+    )
+    _sync(tmp_path, "pages/Repo.md")
+    query = _parity_query("Repo", block_id)
+
+    repo = MarkdownGraphRepository()
+    via_repo = _extract_excerpt(repo.read_subtree_markdown(tmp_path, query))
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, block_id)
+    finally:
+        conn.close()
+
+    assert result.status == SubtreeStatus.COMPLETE
+    assert _normalize_excerpt(result.excerpt_markdown) == _normalize_excerpt(via_repo)
+
+
+def test_subtree_path_key_is_non_ambiguous(tmp_path: Path) -> None:
+    root = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(
+        tmp_path,
+        "pages/Path.md",
+        f"- root\n  id:: {root}\n  - one\n  - two\n",
+    )
+    _sync(tmp_path, "pages/Path.md")
+
+    conn = open_shadow_db(tmp_path)
+    try:
+        result = query_subtree_by_block_uuid(conn, root)
+    finally:
+        conn.close()
+
+    keys = [node.path_key for node in result.nodes]
+    assert len(keys) == len(set(keys))
+    assert keys == sorted(keys)
+    assert all(re.fullmatch(r"[\d,/]+", key) for key in keys)

--- a/tests/test_shadow_subtree.py
+++ b/tests/test_shadow_subtree.py
@@ -147,11 +147,7 @@ def test_subtree_max_depth_applied_in_query(tmp_path: Path) -> None:
     _write_page(
         tmp_path,
         "pages/Depth.md",
-        (
-            f"- d0\n  id:: {ids[0]}\n"
-            f"  - d1\n    id:: {ids[1]}\n"
-            f"    - d2\n      id:: {ids[2]}\n"
-        ),
+        (f"- d0\n  id:: {ids[0]}\n  - d1\n    id:: {ids[1]}\n    - d2\n      id:: {ids[2]}\n"),
     )
     _sync(tmp_path, "pages/Depth.md")
 
@@ -311,26 +307,26 @@ def test_subtree_sort_order_tie_breaks_on_rowid(tmp_path: Path) -> None:
                 indent_level, content, properties_json, synced_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, 'test')
             """,
-        [
-            (
-                "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
-                page_id,
-                int(root_row[0]),
-                5,
-                1,
-                "first by rowid",
-                "{}",
-            ),
-            (
-                "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
-                page_id,
-                int(root_row[0]),
-                5,
-                1,
-                "second by rowid",
-                "{}",
-            ),
-        ],
+            [
+                (
+                    "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                    page_id,
+                    int(root_row[0]),
+                    5,
+                    1,
+                    "first by rowid",
+                    "{}",
+                ),
+                (
+                    "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                    page_id,
+                    int(root_row[0]),
+                    5,
+                    1,
+                    "second by rowid",
+                    "{}",
+                ),
+            ],
         )
         conn.commit()
 


### PR DESCRIPTION
## Summary

- Add `query_subtree_by_block_uuid` in `src/shadow/subtree.py` — recursive CTE over `blocks` with visited-rowid cycle guards, SQL-enforced `max_depth`/`max_nodes`, deterministic DFS `path_key` (`sort_order` + `rowid`), same-`page_id` constraint, and UTF-8 node-boundary byte truncation.
- Result states: `not_found`, `complete`, `truncated`, `inconsistent`.
- Parity tests against `MarkdownGraphRepository` / `read_subtree_markdown` on fixture vaults.

Closes #253

## Out of scope

No `handle_read_subtree` routing, `GraphReadPort`, `ShadowGraphRepository`, or UI (PR-C2).

## Test plan

- [x] Root / nested / leaf subtree parity
- [x] `max_depth`, `max_nodes`, `max_output_bytes` limits
- [x] Cross-page parent and `parent_rowid` cycle → `inconsistent`
- [x] Unknown UUID → `not_found`
- [x] `make check`

Made with [Cursor](https://cursor.com)