### PR TITLE
feat(shadow): route subtree reads through ShadowGraphRepository (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Shadow bootstrap & runtime activation (#248)** — `rebuild_shadow_from_graph`, `shadow_meta` health keys, startup bootstrap via `prepare_matryca_runtime`, watchdog reconciliation by `file_path`, and sync bridge gated on `MATRYCA_SHADOW_DB_ENABLED` (Phase 2 operational completion; no FTS routing).
 - **Shadow FTS routing for `search_graph(bm25)` (#250)** — when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`, `handle_search_bm25` queries FTS5 with BM25-markdown envelope parity; invalid FTS syntax returns validation errors; backend failures fall back to generational BM25.
 - **Shadow recursive CTE subtree helper (#253)** — `query_subtree_by_block_uuid` in `src/shadow/subtree.py` reads block subtrees from `shadow.sqlite` with depth-first ordering, visited-rowid cycle guards, SQL-enforced depth/node limits, UTF-8-safe byte truncation, and parity tests against `MarkdownGraphRepository` (no dispatch wiring).
+- **Shadow read-port selector for `read_graph_data(subtree)` (#255)** — `ShadowGraphRepository` routes subtree reads through the CTE helper when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`; `get_graph_read_port` falls back to `MarkdownGraphRepository` when flag is off, health is not `ready`, SQLite fails, or health changes between port selection and query.
 
 ### Changed
 

--- a/src/agent/markdown_graph_repository.py
+++ b/src/agent/markdown_graph_repository.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..graph.path_sandbox import resolved_graph_root
 from ..graph.ports.read import GraphReadPort
 from ..rag.matryca_hooks import get_page_spatial_context
 from .graph_tool_helpers import read_subtree_markdown
+from .shadow_graph_repository import ShadowGraphRepository, shadow_read_port_ready
 
 
 class MarkdownGraphRepository:
@@ -20,8 +22,11 @@ class MarkdownGraphRepository:
 
 
 def get_graph_read_port(graph_root: Path | None = None) -> GraphReadPort:
-    """Return the active read port for ``graph_root`` (Markdown-only until shadow lands)."""
-    _ = graph_root
+    """Return the active read port for ``graph_root`` (shadow when healthy, else Markdown)."""
+    if graph_root is not None and shadow_read_port_ready(graph_root):
+        return ShadowGraphRepository()
+    if graph_root is not None:
+        _ = resolved_graph_root(graph_root)
     return MarkdownGraphRepository()
 
 

--- a/src/agent/shadow_graph_repository.py
+++ b/src/agent/shadow_graph_repository.py
@@ -1,0 +1,170 @@
+"""Shadow-backed ``GraphReadPort`` adapter (v2 PR-C2 / #255)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from ..graph.path_sandbox import resolved_graph_root
+from ..rag.matryca_hooks import get_page_spatial_context
+from ..shadow.config import shadow_db_enabled
+from ..shadow.connection import open_shadow_db
+from ..shadow.health import ShadowHealthState, resolve_shadow_health
+from ..shadow.subtree import SubtreeStatus, query_subtree_by_block_uuid
+from .graph_tool_helpers import parse_optional_json_query
+from .page_input_normalizer import format_resolution_notes_footer, normalize_page_ref_or_raw
+
+_HEADING_BULLET = re.compile(r"^(\s*)-\s+(.*)$")
+
+
+def _parse_subtree_query(
+    graph_path: str,
+    query: str,
+) -> tuple[str, str, str, list[str]]:
+    from .alias_state import resolve_pipe_target
+    from .page_input_normalizer import normalize_pipe_page_target
+
+    normalized_query, page_notes = normalize_pipe_page_target(graph_path, query)
+    resolved_query = resolve_pipe_target(graph_path, normalized_query)
+    opts: dict[str, Any] = {}
+    page_ref = resolved_query
+    block_uuid = ""
+    if resolved_query.strip().startswith("{"):
+        opts = parse_optional_json_query(resolved_query)
+        raw_page = str(opts.get("page", "")).strip()
+        page_norm = normalize_page_ref_or_raw(graph_path, raw_page) if raw_page else None
+        page_ref = page_norm.canonical_title if page_norm else ""
+        if page_norm:
+            page_notes.extend(page_norm.resolution_notes)
+        block_uuid = str(opts.get("block_uuid", opts.get("uuid", ""))).strip()
+    else:
+        parts = [p.strip() for p in resolved_query.split("|", 1)]
+        if len(parts) == 2:
+            page_ref, block_uuid = parts[0], parts[1]
+    heading_filter = str(opts.get("heading", "")).strip() if opts else ""
+    return page_ref, block_uuid, heading_filter, page_notes
+
+
+def _subtree_not_found_message(page_ref: str, block_uuid: str) -> str:
+    return (
+        f"Block `{block_uuid}` not found on page `{page_ref}`. "
+        "Confirm the UUID matches an `id::` line on that page."
+    )
+
+
+def _apply_heading_filter(excerpt: str, heading_filter: str) -> str:
+    if not heading_filter:
+        return excerpt
+    heading_needle = heading_filter.lstrip("#").strip().lower()
+    lines = excerpt.splitlines(keepends=True)
+    filtered: list[str] = []
+    include = False
+    heading_indent: int | None = None
+    for line in lines:
+        stripped_line = line.rstrip("\n")
+        match = _HEADING_BULLET.match(stripped_line)
+        if match:
+            indent = len(match.group(1))
+            text_part = match.group(2).strip()
+            if not include:
+                if text_part.lstrip("#").strip().lower() == heading_needle:
+                    include = True
+                    heading_indent = indent
+                    filtered = [line]
+                continue
+            if heading_indent is not None and indent > heading_indent:
+                filtered.append(line)
+            else:
+                break
+        elif include:
+            filtered.append(line)
+    return "".join(filtered) if filtered else excerpt
+
+
+def _format_subtree_envelope(
+    page_ref: str,
+    block_uuid: str,
+    excerpt: str,
+    page_notes: list[str],
+) -> str:
+    body = (
+        "# Subtree excerpt\n\n"
+        f"- **Page:** [[{page_ref}]]\n"
+        f"- **Block UUID:** `{block_uuid}`\n\n"
+        f"```markdown\n{excerpt.rstrip()}\n```\n"
+    )
+    return body + format_resolution_notes_footer(page_notes)
+
+
+class ShadowGraphRepository:
+    """Read subtree excerpts from shadow CTE; spatial reads stay on Markdown."""
+
+    def __init__(self) -> None:
+        from .markdown_graph_repository import MarkdownGraphRepository
+
+        self._markdown = MarkdownGraphRepository()
+
+    def read_subtree_markdown(self, graph_root: Path, query: str) -> str:
+        root = resolved_graph_root(graph_root)
+        if not shadow_db_enabled() or resolve_shadow_health(root) != ShadowHealthState.READY:
+            return self._markdown.read_subtree_markdown(graph_root, query)
+
+        try:
+            page_ref, block_uuid, heading_filter, page_notes = _parse_subtree_query(
+                str(root),
+                query,
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+
+        if not page_ref or not block_uuid:
+            msg = (
+                "Invalid subtree query. Use `Page Title|block-uuid` or JSON "
+                '`{"page":"...","block_uuid":"...","heading":"optional"}`.'
+            )
+            raise ValueError(msg)
+
+        try:
+            conn = open_shadow_db(root)
+            try:
+                result = query_subtree_by_block_uuid(conn, block_uuid)
+            finally:
+                conn.close()
+        except Exception:  # noqa: BLE001 — shadow backend failure → markdown fallback
+            logger.exception("Shadow subtree read failed; falling back to MarkdownGraphRepository")
+            return self._markdown.read_subtree_markdown(graph_root, query)
+
+        if result.status == SubtreeStatus.NOT_FOUND:
+            msg = _subtree_not_found_message(page_ref, block_uuid)
+            return msg + format_resolution_notes_footer(page_notes)
+
+        if result.status == SubtreeStatus.INCONSISTENT:
+            logger.warning(
+                "Shadow subtree inconsistent for {} on {}; falling back to Markdown",
+                block_uuid,
+                page_ref,
+            )
+            return self._markdown.read_subtree_markdown(graph_root, query)
+
+        excerpt = _apply_heading_filter(result.excerpt_markdown, heading_filter)
+        return _format_subtree_envelope(page_ref, block_uuid, excerpt, page_notes)
+
+    async def read_page_spatial_markdown(self, graph_root: Path, title: str) -> str:
+        return await get_page_spatial_context(title, str(graph_root))
+
+
+def shadow_read_port_ready(graph_root: Path | str) -> bool:
+    """True when shadow subtree reads may use the CTE adapter."""
+    if not shadow_db_enabled():
+        return False
+    root = resolved_graph_root(graph_root)
+    return resolve_shadow_health(root) == ShadowHealthState.READY
+
+
+__all__ = [
+    "ShadowGraphRepository",
+    "shadow_read_port_ready",
+]

--- a/tests/test_shadow_read_port.py
+++ b/tests/test_shadow_read_port.py
@@ -152,6 +152,7 @@ def test_shadow_subtree_truncation_notice_preserved(tmp_path: Path) -> None:
     query = _query(block_id)
 
     original = query_subtree_by_block_uuid
+
     def _limited(
         conn: sqlite3.Connection,
         uuid: str,

--- a/tests/test_shadow_read_port.py
+++ b/tests/test_shadow_read_port.py
@@ -1,0 +1,220 @@
+"""Read-port selector and shadow subtree adapter tests (#255)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.agent.graph_tool_helpers import read_subtree_markdown
+from src.agent.markdown_graph_repository import (
+    MarkdownGraphRepository,
+    get_graph_read_port,
+)
+from src.agent.shadow_graph_repository import ShadowGraphRepository
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.connection import open_shadow_db
+from src.shadow.health import ShadowHealthState
+from src.shadow.meta import META_LAST_SYNC_ERROR
+from src.shadow.subtree import query_subtree_by_block_uuid
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+
+
+def _graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    return graph
+
+
+def _write_page(graph: Path, rel: str, body: str) -> None:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def _seed_ready(graph: Path, block_id: str) -> None:
+    _write_page(
+        graph,
+        "pages/Port.md",
+        f"- Root line\n  id:: {block_id}\n  - child one\n  - child two\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+
+def _query(block_id: str) -> str:
+    return json.dumps({"page": "Port", "block_uuid": block_id})
+
+
+def _extract_excerpt(markdown: str) -> str:
+    marker = "```markdown\n"
+    start = markdown.find(marker)
+    if start == -1:
+        return markdown
+    start += len(marker)
+    end = markdown.find("\n```", start)
+    return markdown[start:end] if end != -1 else markdown[start:]
+
+
+def test_get_graph_read_port_flag_false_returns_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+    port = get_graph_read_port(graph)
+    assert isinstance(port, MarkdownGraphRepository)
+
+
+def test_get_graph_read_port_not_ready_returns_markdown(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _seed_ready(graph, block_id)
+    conn = open_shadow_db(graph)
+    try:
+        conn.execute(
+            "UPDATE shadow_meta SET value = ? WHERE key = ?",
+            ("stale", META_LAST_SYNC_ERROR),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    port = get_graph_read_port(graph)
+    assert isinstance(port, MarkdownGraphRepository)
+
+
+def test_get_graph_read_port_ready_returns_shadow(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _seed_ready(graph, block_id)
+
+    port = get_graph_read_port(graph)
+    assert isinstance(port, ShadowGraphRepository)
+
+
+def test_shadow_subtree_parity_with_markdown_repository(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _seed_ready(graph, block_id)
+    query = _query(block_id)
+
+    markdown = read_subtree_markdown(str(graph), query)
+    shadow = ShadowGraphRepository().read_subtree_markdown(graph, query)
+
+    assert shadow.startswith("# Subtree excerpt")
+    assert _extract_excerpt(shadow).rstrip("\n") == _extract_excerpt(markdown).rstrip("\n")
+
+
+def test_shadow_subtree_not_found_no_markdown_fallback(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    _seed_ready(graph, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    missing = "00000000-0000-4000-8000-000000000099"
+    query = _query(missing)
+
+    with patch.object(MarkdownGraphRepository, "read_subtree_markdown") as markdown_read:
+        out = ShadowGraphRepository().read_subtree_markdown(graph, query)
+        markdown_read.assert_not_called()
+
+    assert f"Block `{missing}` not found on page `Port`" in out
+
+
+def test_shadow_subtree_sqlite_error_falls_back_to_markdown(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _seed_ready(graph, block_id)
+    query = _query(block_id)
+
+    with patch(
+        "src.agent.shadow_graph_repository.query_subtree_by_block_uuid",
+        side_effect=sqlite3.OperationalError("database disk image is malformed"),
+    ):
+        out = ShadowGraphRepository().read_subtree_markdown(graph, query)
+
+    expected = read_subtree_markdown(str(graph), query)
+    assert _extract_excerpt(out).rstrip("\n") == _extract_excerpt(expected).rstrip("\n")
+
+
+def test_shadow_subtree_truncation_notice_preserved(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _write_page(
+        graph,
+        "pages/Port.md",
+        f"- root {'x' * 40}\n  id:: {block_id}\n  - child one padding\n  - child two padding\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    query = _query(block_id)
+
+    original = query_subtree_by_block_uuid
+    def _limited(
+        conn: sqlite3.Connection,
+        uuid: str,
+        *,
+        max_depth: int = 64,
+        max_nodes: int = 500,
+        max_output_bytes: int = 256_000,
+    ) -> object:
+        return original(
+            conn,
+            uuid,
+            max_depth=max_depth,
+            max_nodes=max_nodes,
+            max_output_bytes=80,
+        )
+
+    with patch(
+        "src.agent.shadow_graph_repository.query_subtree_by_block_uuid",
+        side_effect=_limited,
+    ):
+        out = ShadowGraphRepository().read_subtree_markdown(graph, query)
+
+    assert "[truncated: output byte limit exceeded]" in out
+    assert "child two" not in _extract_excerpt(out)
+
+
+def test_shadow_health_change_between_selection_and_query(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    _seed_ready(graph, block_id)
+    query = _query(block_id)
+    calls = 0
+
+    def _health(_root: Path) -> ShadowHealthState:
+        nonlocal calls
+        calls += 1
+        return ShadowHealthState.READY if calls == 1 else ShadowHealthState.ERROR
+
+    with patch(
+        "src.agent.shadow_graph_repository.resolve_shadow_health",
+        side_effect=_health,
+    ):
+        port = get_graph_read_port(graph)
+        assert isinstance(port, ShadowGraphRepository)
+        out = port.read_subtree_markdown(graph, query)
+
+    expected = read_subtree_markdown(str(graph), query)
+    assert _extract_excerpt(out).rstrip("\n") == _extract_excerpt(expected).rstrip("\n")
+
+
+@pytest.mark.asyncio
+async def test_shadow_spatial_read_delegates_to_markdown(tmp_path: Path) -> None:
+    graph = _graph(tmp_path)
+
+    async def fake_spatial(title: str, graph_path: str) -> str:
+        assert title == "Note"
+        assert graph_path == str(graph)
+        return "# spatial"
+
+    with patch(
+        "src.agent.shadow_graph_repository.get_page_spatial_context",
+        fake_spatial,
+    ):
+        body = await ShadowGraphRepository().read_page_spatial_markdown(graph, "Note")
+
+    assert body == "# spatial"


### PR DESCRIPTION
## Summary

- Add `ShadowGraphRepository` implementing `GraphReadPort` for subtree reads via the recursive CTE helper when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`.
- `get_graph_read_port` selects the shadow adapter on healthy shadow; otherwise returns `MarkdownGraphRepository` (no DB creation/rebuild in the selector).
- Controlled Markdown fallback on SQLite errors, inconsistent CTE state, and health changes between port selection and query; missing UUID with healthy shadow returns the existing not-found envelope without fallback.
- `read_page_spatial_markdown` continues to delegate to the Markdown spatial backend.

## Test plan

- [x] `make check` passes locally
- [x] `tests/test_shadow_read_port.py` — selector, parity, not_found, SQLite fallback, truncation notice, health change selection→query, spatial delegation
- [x] User-visible behavior documented in `CHANGELOG.md` under `[Unreleased]`
- [x] `GraphReadPort` protocol unchanged; no CLI/MCP/env surface change

## Issue linking

Closes #255

Made with [Cursor](https://cursor.com)