### PR TITLE
feat(shadow): expose shadow_db health on Sovereign UI state API (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Shadow FTS routing for `search_graph(bm25)` (#250)** — when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`, `handle_search_bm25` queries FTS5 with BM25-markdown envelope parity; invalid FTS syntax returns validation errors; backend failures fall back to generational BM25.
 - **Shadow recursive CTE subtree helper (#253)** — `query_subtree_by_block_uuid` in `src/shadow/subtree.py` reads block subtrees from `shadow.sqlite` with depth-first ordering, visited-rowid cycle guards, SQL-enforced depth/node limits, UTF-8-safe byte truncation, and parity tests against `MarkdownGraphRepository` (no dispatch wiring).
 - **Shadow read-port selector for `read_graph_data(subtree)` (#255)** — `ShadowGraphRepository` routes subtree reads through the CTE helper when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`; `get_graph_read_port` falls back to `MarkdownGraphRepository` when flag is off, health is not `ready`, SQLite fails, or health changes between port selection and query.
+- **Shadow DB health on Sovereign UI `/api/state` (#185)** — backward-compatible `shadow_db` row with persisted-meta fields (`state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`), bounded sanitized errors, and a minimal read-only telemetry row in the control room.
 
 ### Changed
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { FeatureStatusBar } from './components/FeatureStatusBar'
 import { GraphInsightsCard } from './components/GraphInsightsCard'
 import { LiveConsole } from './components/LiveConsole'
 import { MasterHeader } from './components/MasterHeader'
+import { ShadowDbStatusRow } from './components/ShadowDbStatusRow'
 import { TokenCounterCard } from './components/TokenCounterCard'
 import { usePlumberPolling } from './hooks/usePlumberPolling'
 
@@ -151,6 +152,8 @@ export default function App() {
             config={config}
             frozen={frozen}
           />
+
+          <ShadowDbStatusRow shadowDb={state?.shadow_db} />
 
           <div className="flex min-h-[12rem] flex-1 flex-col overflow-hidden lg:min-h-0">
             <LiveConsole

--- a/frontend/src/components/ShadowDbStatusRow.tsx
+++ b/frontend/src/components/ShadowDbStatusRow.tsx
@@ -1,0 +1,68 @@
+import type { ShadowDbState } from '../types/daemon'
+import { DEFAULT_SHADOW_DB_STATE } from '../types/daemon'
+
+const STATE_LABELS: Record<ShadowDbState['state'], string> = {
+  disabled: 'Disabled',
+  bootstrapping: 'Bootstrapping',
+  ready: 'Ready',
+  stale: 'Stale',
+  error: 'Error',
+}
+
+const STATE_CLASSES: Record<ShadowDbState['state'], string> = {
+  disabled: 'border-theme-border/50 bg-theme-base/40 text-theme-muted',
+  bootstrapping: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  ready: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  stale: 'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300',
+  error: 'border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300',
+}
+
+interface ShadowDbStatusRowProps {
+  shadowDb: ShadowDbState | undefined
+}
+
+export function ShadowDbStatusRow({ shadowDb }: ShadowDbStatusRowProps) {
+  const snapshot = shadowDb ?? DEFAULT_SHADOW_DB_STATE
+
+  const detailParts: string[] = []
+  if (snapshot.last_full_sync_at) {
+    detailParts.push(`Last full sync ${snapshot.last_full_sync_at}`)
+  }
+  if (snapshot.source_page_count != null && snapshot.indexed_page_count != null) {
+    detailParts.push(
+      `Indexed ${snapshot.indexed_page_count} / ${snapshot.source_page_count} pages`,
+    )
+  }
+  if (snapshot.lag_pages != null && snapshot.lag_pages > 0) {
+    detailParts.push(`Lag ${snapshot.lag_pages} pages`)
+  }
+  if (snapshot.last_sync_error) {
+    detailParts.push(snapshot.last_sync_error)
+  }
+
+  return (
+    <section
+      className="shrink-0 rounded-2xl bg-theme-surface/45 px-4 py-3 shadow-sm ring-1 ring-theme-border/25 dark:bg-theme-surface/20"
+      aria-label="Shadow DB health"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-[0.25em] text-theme-muted">
+          Shadow DB
+        </span>
+        <span
+          className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider ${STATE_CLASSES[snapshot.state]}`}
+        >
+          {STATE_LABELS[snapshot.state]}
+        </span>
+        {!snapshot.enabled && (
+          <span className="text-[10px] font-medium uppercase tracking-wider text-theme-muted">
+            Flag off
+          </span>
+        )}
+      </div>
+      {detailParts.length > 0 && (
+        <p className="mt-2 text-xs text-theme-muted">{detailParts.join(' · ')}</p>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/types/daemon.shadow.test.ts
+++ b/frontend/src/types/daemon.shadow.test.ts
@@ -1,0 +1,95 @@
+/** Frontend coercion tests for shadow_db on /api/state (#185). */
+
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_SHADOW_DB_STATE, normalizeDaemonState } from '../types/daemon'
+
+const BASE_STATE = {
+  version: 1,
+  files: {},
+  status: 'idle' as const,
+  model: 'test',
+  bootstrap_complete: false,
+  bootstrap_scanned: 0,
+  bootstrap_total: 0,
+  session_prompt_tokens: 0,
+  session_completion_tokens: 0,
+  current_cluster: null,
+  current_cluster_files_total: 0,
+  current_cluster_files_done: 0,
+  phase2_llm_turns: 0,
+  last_scan_at: null,
+  last_file: null,
+}
+
+describe('normalizeDaemonState shadow_db', () => {
+  it('defaults when shadow_db is missing', () => {
+    const normalized = normalizeDaemonState(BASE_STATE)
+    expect(normalized.shadow_db).toEqual(DEFAULT_SHADOW_DB_STATE)
+  })
+
+  it.each([
+    ['disabled', { enabled: false, state: 'disabled' }],
+    ['bootstrapping', { enabled: true, state: 'bootstrapping' }],
+    ['ready', { enabled: true, state: 'ready' }],
+    ['stale', { enabled: true, state: 'stale' }],
+    ['error', { enabled: true, state: 'error', last_sync_error: 'sync failed' }],
+  ] as const)('preserves %s state', (_label, shadowDb) => {
+    const normalized = normalizeDaemonState({
+      ...BASE_STATE,
+      shadow_db: {
+        last_full_sync_at: null,
+        source_page_count: null,
+        indexed_page_count: null,
+        lag_pages: null,
+        last_sync_error: null,
+        ...shadowDb,
+      },
+    })
+    expect(normalized.shadow_db?.state).toBe(shadowDb.state)
+    expect(normalized.shadow_db?.enabled).toBe(shadowDb.enabled)
+    if ('last_sync_error' in shadowDb) {
+      expect(normalized.shadow_db?.last_sync_error).toBe(shadowDb.last_sync_error)
+    }
+  })
+
+  it('coerces camelCase shadowDb payload', () => {
+    const normalized = normalizeDaemonState({
+      ...BASE_STATE,
+      shadowDb: {
+        enabled: true,
+        state: 'ready',
+        lastFullSyncAt: '2026-07-18T10:00:00+00:00',
+        sourcePageCount: 5,
+        indexedPageCount: 3,
+        lagPages: 2,
+        lastSyncError: null,
+      },
+    } as never)
+    expect(normalized.shadow_db).toEqual({
+      enabled: true,
+      state: 'ready',
+      last_full_sync_at: '2026-07-18T10:00:00+00:00',
+      source_page_count: 5,
+      indexed_page_count: 3,
+      lag_pages: 2,
+      last_sync_error: null,
+    })
+  })
+
+  it('forces disabled state when enabled is false', () => {
+    const normalized = normalizeDaemonState({
+      ...BASE_STATE,
+      shadow_db: {
+        enabled: false,
+        state: 'ready',
+        last_full_sync_at: null,
+        source_page_count: null,
+        indexed_page_count: null,
+        lag_pages: null,
+        last_sync_error: null,
+      },
+    })
+    expect(normalized.shadow_db?.state).toBe('disabled')
+  })
+})

--- a/frontend/src/types/daemon.ts
+++ b/frontend/src/types/daemon.ts
@@ -1,3 +1,26 @@
+/** Shadow DB health row from ``GET /api/state`` (v2 PR-D). */
+export type ShadowDbStateValue = 'disabled' | 'bootstrapping' | 'ready' | 'stale' | 'error'
+
+export interface ShadowDbState {
+  enabled: boolean
+  state: ShadowDbStateValue
+  last_full_sync_at: string | null
+  source_page_count: number | null
+  indexed_page_count: number | null
+  lag_pages: number | null
+  last_sync_error: string | null
+}
+
+export const DEFAULT_SHADOW_DB_STATE: ShadowDbState = {
+  enabled: false,
+  state: 'disabled',
+  last_full_sync_at: null,
+  source_page_count: null,
+  indexed_page_count: null,
+  lag_pages: null,
+  last_sync_error: null,
+}
+
 /** Mirrors ``FileStateResponse`` from ``src/cli/ui_server.py``. */
 export type FileStatus = 'processed' | 'skipped' | 'error' | 'pending'
 
@@ -226,6 +249,44 @@ function normalizeImpactCounters(raw: DaemonStateResponse): DaemonImpactCounters
   }
 }
 
+function readNullableCount(source: Record<string, unknown>, snakeKey: string, camelKey: string): number | null {
+  if (!hasExplicitField(source, snakeKey, camelKey)) {
+    return null
+  }
+  const value = readNumber(source, snakeKey, camelKey)
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : null
+}
+
+function normalizeShadowDb(raw: unknown): ShadowDbState {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_SHADOW_DB_STATE }
+  }
+  const source = raw as Record<string, unknown>
+  const stateRaw = source.state ?? source.status ?? source.State ?? source.Status
+  const state =
+    stateRaw === 'disabled'
+    || stateRaw === 'bootstrapping'
+    || stateRaw === 'ready'
+    || stateRaw === 'stale'
+    || stateRaw === 'error'
+      ? stateRaw
+      : 'disabled'
+  const enabled = Boolean(source.enabled ?? source.Enabled ?? false)
+  const lastFullSyncRaw =
+    source.last_full_sync_at ?? source.lastFullSyncAt ?? source.last_sync ?? source.lastSync
+  const errorRaw = source.last_sync_error ?? source.lastSyncError ?? source.error ?? source.Error
+  return {
+    enabled,
+    state: enabled ? state : 'disabled',
+    last_full_sync_at:
+      typeof lastFullSyncRaw === 'string' && lastFullSyncRaw.trim() ? lastFullSyncRaw : null,
+    source_page_count: readNullableCount(source, 'source_page_count', 'sourcePageCount'),
+    indexed_page_count: readNullableCount(source, 'indexed_page_count', 'indexedPageCount'),
+    lag_pages: readNullableCount(source, 'lag_pages', 'lagPages'),
+    last_sync_error: typeof errorRaw === 'string' && errorRaw.trim() ? errorRaw : null,
+  }
+}
+
 /** Coerce legacy `/api/state` payloads that omit ``graph_analytics`` or use camelCase keys. */
 export function normalizeDaemonState(raw: DaemonStateResponse): DaemonStateResponse {
   const files =
@@ -265,6 +326,10 @@ export function normalizeDaemonState(raw: DaemonStateResponse): DaemonStateRespo
     ),
     daemon_pid: readNumber(source, 'daemon_pid', 'daemonPid') || undefined,
     graph_analytics: graphAnalytics,
+    shadow_db: normalizeShadowDb(
+      (raw as unknown as Record<string, unknown>).shadow_db
+        ?? (raw as unknown as Record<string, unknown>).shadowDb,
+    ),
   }
 }
 
@@ -302,6 +367,7 @@ export interface DaemonStateResponse {
   bootstrap_recent?: Record<string, BootstrapRecentEntry>
   daemon_pid?: number | null
   graph_analytics?: GraphAnalytics
+  shadow_db?: ShadowDbState
 }
 
 /** Mirrors ``PlumberConfigResponse`` from ``src/cli/ui_server.py``. */

--- a/src/cli/ui_server.py
+++ b/src/cli/ui_server.py
@@ -56,6 +56,7 @@ from ..agent.plumber_config import (
 from ..config import load_matryca_wiki_config
 from ..graph.graph_analytics import compute_graph_analytics
 from ..graph.graph_path_validate import validate_logseq_graph_path_for_config
+from ..shadow.state_api import ShadowDbStateResponse, resolve_shadow_db_state_for_api
 from ..utils.console_sanitize import sanitize_for_console
 from ..utils.env_placeholders import is_template_env_path
 from ..utils.llm_url_policy import UnsafeLlmProxyUrlError, validate_llm_proxy_url
@@ -160,6 +161,7 @@ class DaemonStateResponse(BaseModel):
     progress_total: int = 0
     progress_percent: float = 0.0
     daemon_pid: int | None = None
+    shadow_db: ShadowDbStateResponse = Field(default_factory=ShadowDbStateResponse)
 
     @classmethod
     def from_daemon_state(cls, state: DaemonState) -> DaemonStateResponse:
@@ -809,6 +811,7 @@ def _build_daemon_state_response(graph_root: Path) -> DaemonStateResponse:
             "session_prompt_tokens": session_prompt_tokens,
             "session_completion_tokens": session_completion_tokens,
             "daemon_pid": daemon_pid,
+            "shadow_db": resolve_shadow_db_state_for_api(graph_root),
             **progress.to_api_fields(),
         }
     )

--- a/src/shadow/state_api.py
+++ b/src/shadow/state_api.py
@@ -1,0 +1,168 @@
+"""Shadow DB health snapshot for Sovereign UI ``GET /api/state`` (v2 PR-D / #185)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
+
+from ..graph.path_sandbox import resolved_graph_root
+from ..utils.console_sanitize import sanitize_for_console
+from .config import shadow_db_enabled
+from .connection import shadow_db_path
+from .meta import (
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_AT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    META_SCHEMA_VERSION,
+    META_SOURCE_PAGE_COUNT,
+    get_meta,
+)
+from .runtime_state import is_shadow_bootstrapping
+from .schema import SHADOW_SCHEMA_VERSION
+
+ShadowDbStateValue = Literal["disabled", "bootstrapping", "ready", "stale", "error"]
+_SHADOW_ERROR_MAX_LEN = 200
+
+
+class ShadowDbStateResponse(BaseModel):
+    """Stable ``shadow_db`` contract for ``DaemonStateResponse`` (Phase 3)."""
+
+    enabled: bool = False
+    state: ShadowDbStateValue = "disabled"
+    last_full_sync_at: str | None = None
+    source_page_count: int | None = None
+    indexed_page_count: int | None = None
+    lag_pages: int | None = None
+    last_sync_error: str | None = None
+
+
+def _disabled_snapshot() -> ShadowDbStateResponse:
+    return ShadowDbStateResponse()
+
+
+def _bounded_error_message(raw: str | None) -> str | None:
+    cleaned = sanitize_for_console((raw or "").strip())
+    if not cleaned:
+        return None
+    if len(cleaned) <= _SHADOW_ERROR_MAX_LEN:
+        return cleaned
+    return cleaned[: _SHADOW_ERROR_MAX_LEN - 1] + "…"
+
+
+def _parse_non_negative_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return max(0, int(text))
+    except ValueError:
+        return None
+
+
+def _resolve_lag_pages(source: int | None, indexed: int | None) -> int | None:
+    if source is None or indexed is None:
+        return None
+    return max(0, source - indexed)
+
+
+def _counts_from_meta(meta: dict[str, str | None]) -> tuple[int | None, int | None, int | None]:
+    source = _parse_non_negative_int(meta.get(META_SOURCE_PAGE_COUNT))
+    indexed = _parse_non_negative_int(meta.get(META_INDEXED_PAGE_COUNT))
+    return source, indexed, _resolve_lag_pages(source, indexed)
+
+
+def _last_full_sync_at(meta: dict[str, str | None]) -> str | None:
+    value = (meta.get(META_LAST_FULL_SYNC_AT) or "").strip()
+    return value or None
+
+
+def _read_meta_readonly(db_path: Path) -> dict[str, str | None]:
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return {
+            META_SCHEMA_VERSION: get_meta(connection, META_SCHEMA_VERSION),
+            META_LAST_SYNC_ERROR: get_meta(connection, META_LAST_SYNC_ERROR),
+            META_LAST_FULL_SYNC_AT: get_meta(connection, META_LAST_FULL_SYNC_AT),
+            META_LAST_FULL_SYNC_COMPLETED: get_meta(connection, META_LAST_FULL_SYNC_COMPLETED),
+            META_SOURCE_PAGE_COUNT: get_meta(connection, META_SOURCE_PAGE_COUNT),
+            META_INDEXED_PAGE_COUNT: get_meta(connection, META_INDEXED_PAGE_COUNT),
+        }
+    finally:
+        connection.close()
+
+
+def _state_from_meta(meta: dict[str, str | None]) -> ShadowDbStateValue:
+    sync_error = (meta.get(META_LAST_SYNC_ERROR) or "").strip()
+    if sync_error:
+        return "error"
+    completed = (meta.get(META_LAST_FULL_SYNC_COMPLETED) or "").strip().lower()
+    if completed == "true":
+        return "ready"
+    return "stale"
+
+
+def _snapshot_from_meta(
+    *,
+    state: ShadowDbStateValue,
+    meta: dict[str, str | None],
+    last_sync_error: str | None = None,
+) -> ShadowDbStateResponse:
+    source, indexed, lag = _counts_from_meta(meta)
+    return ShadowDbStateResponse(
+        enabled=True,
+        state=state,
+        last_full_sync_at=_last_full_sync_at(meta),
+        source_page_count=source,
+        indexed_page_count=indexed,
+        lag_pages=lag,
+        last_sync_error=last_sync_error,
+    )
+
+
+def resolve_shadow_db_state_for_api(graph_root: Path | str) -> ShadowDbStateResponse:
+    """Build a stable ``shadow_db`` payload without creating a DB when disabled."""
+    if not shadow_db_enabled():
+        return _disabled_snapshot()
+
+    root = resolved_graph_root(graph_root)
+    if is_shadow_bootstrapping(root):
+        return ShadowDbStateResponse(enabled=True, state="bootstrapping")
+
+    db_path = shadow_db_path(root)
+    if not db_path.is_file():
+        return ShadowDbStateResponse(enabled=True, state="stale")
+
+    try:
+        meta = _read_meta_readonly(db_path)
+    except sqlite3.Error as exc:
+        return ShadowDbStateResponse(
+            enabled=True,
+            state="error",
+            last_sync_error=_bounded_error_message(str(exc)),
+        )
+
+    schema_raw = (meta.get(META_SCHEMA_VERSION) or "").strip()
+    if schema_raw != str(SHADOW_SCHEMA_VERSION):
+        return _snapshot_from_meta(
+            state="error",
+            meta=meta,
+            last_sync_error="Shadow schema version mismatch",
+        )
+
+    state = _state_from_meta(meta)
+    sync_error = (meta.get(META_LAST_SYNC_ERROR) or "").strip()
+    error = _bounded_error_message(sync_error) if state == "error" else None
+    return _snapshot_from_meta(state=state, meta=meta, last_sync_error=error)
+
+
+__all__ = [
+    "ShadowDbStateResponse",
+    "ShadowDbStateValue",
+    "resolve_shadow_db_state_for_api",
+]

--- a/tests/test_shadow_state_api.py
+++ b/tests/test_shadow_state_api.py
@@ -1,0 +1,217 @@
+"""Unit tests for Shadow DB ``/api/state`` snapshot builder (#185)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.connection import open_shadow_db, shadow_db_path
+from src.shadow.meta import (
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_AT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    META_SCHEMA_VERSION,
+    META_SOURCE_PAGE_COUNT,
+    set_meta,
+)
+from src.shadow.runtime_state import mark_bootstrapping, reset_shadow_runtime_state_for_tests
+from src.shadow.schema import SHADOW_SCHEMA_VERSION
+from src.shadow.state_api import ShadowDbStateResponse, resolve_shadow_db_state_for_api
+
+DISABLED_SHADOW_DB = {
+    "enabled": False,
+    "state": "disabled",
+    "last_full_sync_at": None,
+    "source_page_count": None,
+    "indexed_page_count": None,
+    "lag_pages": None,
+    "last_sync_error": None,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime() -> None:
+    reset_shadow_runtime_state_for_tests()
+
+
+def _graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    return graph
+
+
+def _write_page(graph: Path, rel: str, body: str) -> None:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def test_resolve_shadow_db_state_disabled_when_flag_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.model_dump() == DISABLED_SHADOW_DB
+    assert not shadow_db_path(graph).exists()
+
+
+def test_resolve_shadow_db_state_bootstrapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    mark_bootstrapping(graph)
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.enabled is True
+    assert snapshot.state == "bootstrapping"
+    assert snapshot.last_full_sync_at is None
+    assert snapshot.source_page_count is None
+    assert snapshot.indexed_page_count is None
+    assert snapshot.lag_pages is None
+    assert snapshot.last_sync_error is None
+
+
+def test_resolve_shadow_db_state_stale_without_db_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.enabled is True
+    assert snapshot.state == "stale"
+    assert not shadow_db_path(graph).exists()
+
+
+def test_resolve_shadow_db_state_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "ready"
+    assert snapshot.enabled is True
+    assert snapshot.last_sync_error is None
+    assert snapshot.source_page_count == 1
+    assert snapshot.indexed_page_count == 1
+    assert snapshot.lag_pages == 0
+
+
+def test_resolve_shadow_db_state_error_with_bounded_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        set_meta(conn, META_LAST_SYNC_ERROR, "sync failed on pages/Alpha.md")
+        conn.commit()
+    finally:
+        conn.close()
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "error"
+    assert snapshot.last_sync_error == "sync failed on pages/Alpha.md"
+
+
+def test_resolve_shadow_db_state_schema_mismatch_is_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        set_meta(conn, META_SCHEMA_VERSION, str(SHADOW_SCHEMA_VERSION + 1))
+        conn.commit()
+    finally:
+        conn.close()
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "error"
+    assert snapshot.last_sync_error == "Shadow schema version mismatch"
+
+
+def test_resolve_shadow_db_state_reports_lag_and_last_full_sync_at(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        set_meta(conn, META_SOURCE_PAGE_COUNT, "5")
+        set_meta(conn, META_INDEXED_PAGE_COUNT, "2")
+        set_meta(conn, META_LAST_FULL_SYNC_AT, "2026-07-18T10:00:00+00:00")
+        set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "false")
+        conn.commit()
+    finally:
+        conn.close()
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "stale"
+    assert snapshot.lag_pages == 3
+    assert snapshot.source_page_count == 5
+    assert snapshot.indexed_page_count == 2
+    assert snapshot.last_full_sync_at == "2026-07-18T10:00:00+00:00"
+
+
+def test_resolve_shadow_db_state_sqlite_read_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    db_path = shadow_db_path(graph)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_bytes(b"not-a-sqlite-db")
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "error"
+    assert snapshot.last_sync_error is not None
+    assert len(snapshot.last_sync_error) <= 200
+
+
+def test_shadow_db_response_model_has_stable_keys() -> None:
+    payload = ShadowDbStateResponse().model_dump()
+    assert set(payload.keys()) == set(DISABLED_SHADOW_DB.keys())

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -75,6 +75,15 @@ def test_get_state_returns_daemon_checkpoint(
     assert payload["ai_links_injected"] == 0
     assert payload["ai_blocks_healed"] == 0
     assert "graph_analytics" not in payload
+    assert payload["shadow_db"] == {
+        "enabled": False,
+        "state": "disabled",
+        "last_full_sync_at": None,
+        "source_page_count": None,
+        "indexed_page_count": None,
+        "lag_pages": None,
+        "last_sync_error": None,
+    }
 
 
 def test_get_graph_analytics_returns_topology(
@@ -959,3 +968,127 @@ def test_post_graph_path_endpoint(
     env_text = (tmp_path / ".env").read_text(encoding="utf-8")
     assert str(graph.resolve()) in env_text
     assert "LOGSEQ_GRAPH_PATH=" in env_text
+
+
+def test_get_state_shadow_db_disabled_by_default(
+    graph_root: Path,
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MATRYCA_SHADOW_DB_ENABLED", raising=False)
+    save_daemon_state(graph_root, DaemonState(status="idle"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/state", headers=auth_headers)
+
+    assert response.status_code == 200
+    shadow_db = response.json()["shadow_db"]
+    assert shadow_db == {
+        "enabled": False,
+        "state": "disabled",
+        "last_full_sync_at": None,
+        "source_page_count": None,
+        "indexed_page_count": None,
+        "lag_pages": None,
+        "last_sync_error": None,
+    }
+    from src.shadow.connection import shadow_db_path
+
+    assert not shadow_db_path(graph_root).exists()
+
+
+def test_get_state_shadow_db_ready_when_rebuilt(
+    graph_root: Path,
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.shadow.bootstrap import rebuild_shadow_from_graph
+
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    page = graph_root / "pages" / "Alpha.md"
+    page.write_text("- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n", encoding="utf-8")
+    rebuild_shadow_from_graph(graph_root)
+    save_daemon_state(graph_root, DaemonState(status="idle"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/state", headers=auth_headers)
+
+    shadow_db = response.json()["shadow_db"]
+    assert shadow_db["enabled"] is True
+    assert shadow_db["state"] == "ready"
+    assert shadow_db["last_sync_error"] is None
+    assert shadow_db["lag_pages"] == 0
+    assert shadow_db["source_page_count"] == 1
+    assert shadow_db["indexed_page_count"] == 1
+
+
+def test_get_state_shadow_db_bootstrapping(
+    graph_root: Path,
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.shadow.runtime_state import mark_bootstrapping
+
+    monkeypatch.setattr(
+        "src.cli.ui_server.try_prepare_matryca_runtime_from_env",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    mark_bootstrapping(graph_root)
+    save_daemon_state(graph_root, DaemonState(status="idle"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/state", headers=auth_headers)
+
+    shadow_db = response.json()["shadow_db"]
+    assert shadow_db["enabled"] is True
+    assert shadow_db["state"] == "bootstrapping"
+
+
+def test_get_state_shadow_db_stale_without_db_file(
+    graph_root: Path,
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.cli.ui_server.try_prepare_matryca_runtime_from_env",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    save_daemon_state(graph_root, DaemonState(status="idle"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/state", headers=auth_headers)
+
+    shadow_db = response.json()["shadow_db"]
+    assert shadow_db["enabled"] is True
+    assert shadow_db["state"] == "stale"
+
+
+def test_get_state_shadow_db_error_from_meta(
+    graph_root: Path,
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.shadow.bootstrap import rebuild_shadow_from_graph
+    from src.shadow.connection import open_shadow_db
+    from src.shadow.meta import META_LAST_SYNC_ERROR, set_meta
+
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    page = graph_root / "pages" / "Alpha.md"
+    page.write_text("- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n", encoding="utf-8")
+    rebuild_shadow_from_graph(graph_root)
+    conn = open_shadow_db(graph_root)
+    try:
+        set_meta(conn, META_LAST_SYNC_ERROR, "sync failed")
+        conn.commit()
+    finally:
+        conn.close()
+    save_daemon_state(graph_root, DaemonState(status="idle"))
+
+    with TestClient(app) as client:
+        response = client.get("/api/state", headers=auth_headers)
+
+    shadow_db = response.json()["shadow_db"]
+    assert shadow_db["state"] == "error"
+    assert shadow_db["last_sync_error"] == "sync failed"


### PR DESCRIPTION
## Summary

- Add `shadow_db` to `GET /api/state` with the Phase 3 persisted-meta contract: `enabled`, `state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`.
- `resolve_shadow_db_state_for_api()` reads `shadow_meta` read-only when enabled; flag off never opens or creates `shadow.sqlite`.
- Sovereign UI shows a minimal read-only `ShadowDbStatusRow` in the sidebar telemetry stack.

## HIGH impact reviewed

`detect_changes(compare main)` reports **HIGH** because the additive `shadow_db` field flows through existing polling normalization (`normalizeDaemonState` → `usePlumberPolling` → `App`). Reviewed blast radius:

- **Changed:** `DaemonStateResponse`, `_build_daemon_state_response`, `normalizeDaemonState`, `App`, `ShadowDbStatusRow`
- **Affected processes:** polling/UI only (`UsePlumberPolling`, `StartEngine`, `StopEngine`, `RunTelemetryCycle`)
- **Not touched:** FTS/subtree routing, `GraphReadPort`, MCP dispatch
- **Backward compatibility:** new `shadow_db` object always present with stable nullable keys; existing daemon `status` unchanged

## Test plan

- [x] `make check` (1115 tests)
- [x] `npm run build` + `npm test` (frontend coercion for all `state` values)
- [x] `tests/test_shadow_state_api.py` — disabled, bootstrapping, ready, stale, error, schema mismatch, corrupt DB
- [x] `tests/test_ui_server.py` — `/api/state` integration for all states
- [x] Pydantic shape validation for stable `shadow_db` keys

## Issue linking

Closes #185

Made with [Cursor](https://cursor.com)