### PR TITLE
docs(v2): Phase 3 alpha readiness — roadmaps, llms.txt, env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -486,6 +486,6 @@ MATRYCA_MEMORY_GRAPH_ENABLED=false
 # Daemon-owned shadow.sqlite read cache (FTS5 + subtree CTE). src/shadow/config.py
 # Default (code): false
 # Template: false
-# Range / notes: opt-in v2.0.0-alpha; config parse only until bootstrap slice ships
+# Range / notes: opt-in v2.0.0-alpha; FTS5 BM25 + subtree CTE when healthy; Markdown/BM25 fallback otherwise
 MATRYCA_SHADOW_DB_ENABLED=false
 

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -217,6 +217,20 @@ export LOGSEQ_GRAPH_PATH="/absolute/path/to/your/logseq/graph"
 uvx matryca-plumber --json plumber audit
 ```
 
+### 2.6 Shadow DB (v2.0.0-alpha — experimental, opt-in)
+
+Shadow DB is a **daemon-owned read cache** at `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite`. It does **not** replace Markdown on disk. **Default: off.**
+
+| Env var | Default | When `true` |
+|---------|---------|-------------|
+| `MATRYCA_SHADOW_DB_ENABLED` | `false` | `search_graph(bm25)` prefers FTS5 on shadow; `read_graph_data(subtree)` prefers recursive CTE; **always falls back** to generational BM25 / parser+AST when flag is off, shadow is bootstrapping, stale, or errors |
+
+**Operator health (no `doctor`):** Sovereign UI `status` → sidebar **Shadow DB** row (sourced from `GET /api/state.shadow_db`: `state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`).
+
+**Agent default unchanged:** With flag unset/false, MCP/CLI behavior matches v1.14.x (BM25 + parser subtree). Enable only when explicitly testing v2 alpha on a vault backup.
+
+Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md` · Epic [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20).
+
 ---
 
 ## 3. Zero-shot examples (small LLMs — copy exactly)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Shadow recursive CTE subtree helper (#253)** — `query_subtree_by_block_uuid` in `src/shadow/subtree.py` reads block subtrees from `shadow.sqlite` with depth-first ordering, visited-rowid cycle guards, SQL-enforced depth/node limits, UTF-8-safe byte truncation, and parity tests against `MarkdownGraphRepository` (no dispatch wiring).
 - **Shadow read-port selector for `read_graph_data(subtree)` (#255)** — `ShadowGraphRepository` routes subtree reads through the CTE helper when `MATRYCA_SHADOW_DB_ENABLED=true` and shadow health is `ready`; `get_graph_read_port` falls back to `MarkdownGraphRepository` when flag is off, health is not `ready`, SQLite fails, or health changes between port selection and query.
 - **Shadow DB health on Sovereign UI `/api/state` (#185)** — backward-compatible `shadow_db` row with persisted-meta fields (`state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`), bounded sanitized errors, and a minimal read-only telemetry row in the control room.
+- **Phase 3 alpha operator docs** — `llms.txt` §2.6 documents `MATRYCA_SHADOW_DB_ENABLED`; v2 roadmaps updated for shipped read routing ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)).
 
 ### Changed
 

--- a/docs/roadmaps/ROADMAP_V2_PREPARATION.md
+++ b/docs/roadmaps/ROADMAP_V2_PREPARATION.md
@@ -15,13 +15,14 @@ Matryca Plumber **v2.0.0** adds a daemon-owned **Shadow DB** (`shadow.sqlite`) f
 | Layer | Shipped | In tree (not fully operational) | Not wired yet |
 |-------|---------|----------------------------------|---------------|
 | **DDL** | [`src/shadow/schema.py`](../../src/shadow/schema.py) + tests | — | — |
-| **Shadow sync** | `open_shadow_db`, per-page `sync_page_to_shadow`, post-write bridge ([#181](https://github.com/MarcoPorcellato/matryca-plumber/issues/181)–[#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182)) | Full bootstrap/reconciliation ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176)) | — |
-| **Shadow query** | `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183)) | — | dispatch routing ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) |
+| **Shadow sync** | `open_shadow_db`, per-page `sync_page_to_shadow`, post-write bridge, bootstrap/reconciliation ([#181](https://github.com/MarcoPorcellato/matryca-plumber/issues/181)–[#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182), [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248)) | — | — |
+| **Shadow query** | `search_blocks_fts` + FTS5 dispatch ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183), [#250](https://github.com/MarcoPorcellato/matryca-plumber/issues/250)) | — | — |
 | **Memory algorithms** | — | [`src/memory/decay.py`](../../src/memory/decay.py) | recall, consolidate, MCP `recall` |
-| **Repository port** | `GraphReadPort` + `MarkdownGraphRepository` (subtree) | — | shadow adapter + routing |
-| **Read path** | `master_catalog.json` + in-memory BM25; subtree via port | — | shadow routing |
+| **Repository port** | `GraphReadPort`, `MarkdownGraphRepository`, `ShadowGraphRepository`, subtree CTE routing ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17), [#253](https://github.com/MarcoPorcellato/matryca-plumber/issues/253), [#255](https://github.com/MarcoPorcellato/matryca-plumber/issues/255)) | — | — |
+| **Read path** | Default: `master_catalog.json` + in-memory BM25; opt-in shadow FTS5/CTE when `MATRYCA_SHADOW_DB_ENABLED=true` ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) | — | shadow default-on (rc) |
 | **Write path (OG)** | OCC + `.md` + `page_rmw_lock` | — | — |
 | **Write path (Logseq DB)** | — | — | official CLI/API bridge ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)) |
+| **Operator health** | Sovereign UI `/api/state.shadow_db` ([#185](https://github.com/MarcoPorcellato/matryca-plumber/issues/185)) | — | — |
 
 Child roadmaps: [`ROADMAP_V2_SHADOW_DB.md`](ROADMAP_V2_SHADOW_DB.md) · [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](ROADMAP_V2_BIOLOGICAL_MEMORY.md) · [`../openspec/biological-memory.md`](../openspec/biological-memory.md).
 
@@ -44,8 +45,8 @@ flowchart LR
 |-------|------|-------------------|--------|
 | **0** | v1.9.12 prerequisites | Daemon/dispatch modular enough for shadow duty cycle; env_parse DRY; documented blockers closed or explicitly tracked | Phase 0 ([#174](https://github.com/MarcoPorcellato/matryca-plumber/issues/174)) **done** · [#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58) **done** · [#59](https://github.com/MarcoPorcellato/matryca-plumber/issues/59) **done** |
 | **1** | GraphRepository ports | `GraphReadPort` + `MarkdownGraphRepository`; `graph_dispatch` delegates at least one read method; parity tests; **default behavior unchanged** | [#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) · Phase 1 ([#175](https://github.com/MarcoPorcellato/matryca-plumber/issues/175)) **done** (subtree + port) |
-| **2** | Shadow incremental sync | **Core shipped:** `open_shadow_db`, post-write upsert, FTS5 helper. **Operational completion pending:** bootstrap/reconciliation/freshness ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176)) | [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) · [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176) **open** |
-| **3** | Read routing (alpha) | `MATRYCA_SHADOW_DB_ENABLED=false` default; FTS5/CTE behind flag; BM25/AST fallback when lag or disabled | Phase 3 issue · slices under #24 |
+| **2** | Shadow incremental sync | Bootstrap, reconciliation, runtime gating ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248)) | [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) · **done** |
+| **3** | Read routing (alpha) | `MATRYCA_SHADOW_DB_ENABLED=false` default; FTS5/CTE behind flag; BM25/AST fallback when lag or disabled; Sovereign UI health row | [#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177) · **done** |
 | **4** | Memory + Logseq DB Safe-Sync | `MATRYCA_MEMORY_GRAPH_ENABLED`; `search_graph(method=recall)`; Logseq DB write via official CLI only | [#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25) · [#139](https://github.com/MarcoPorcellato/matryca-plumber/issues/139) · Phase 4 issue |
 
 ### Phase 0 — v1 prerequisites (blockers)
@@ -75,7 +76,7 @@ flowchart LR
 
 ### Phase 2 — Shadow sync (read-only on source)
 
-**Status:** core shipped (#181–#183); operational completion (bootstrap, reconciliation, runtime gating) tracked in [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176).
+**Status:** shipped ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248), #181–#183).
 
 - Sync listens on [`post_write`](../../src/graph/post_write.py) / file watcher — **never** writes to `pages/*.md` from shadow.
 - Path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite` (see schema).
@@ -84,13 +85,19 @@ flowchart LR
 
 ### Phase 3 — Alpha read routing
 
+**Status:** shipped ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177) — PR-A/B/C1/C2/D on `main`).
+
 | Surface | v1 default | v2-alpha (`MATRYCA_SHADOW_DB_ENABLED=true`) |
 |---------|------------|---------------------------------------------|
 | `search_graph(bm25)` | generational BM25 | FTS5 shadow; fallback if stale |
 | `read_graph_data(subtree)` | parser + AST | recursive CTE on `blocks` |
 | `read_graph_data(page)` | `read_graph_file_text` | unchanged (source of truth) |
 
-Sovereign UI: shadow sync lag / last full sync (no `matryca doctor` — see `llms.txt` §2.3).
+Sovereign UI: `GET /api/state` → `shadow_db` row (`state`, `last_full_sync_at`, page counts, `lag_pages`, `last_sync_error`). No `matryca doctor` — see `llms.txt` §2.5–§2.6.
+
+**Known alpha hardening (non-blocking):** [#251](https://github.com/MarcoPorcellato/matryca-plumber/issues/251) duplicate block UUID pre-insert diagnostics — bootstrap fails safe; read paths fall back to Markdown/BM25.
+
+**Verify:** `uv run pytest tests/test_shadow_fts_routing.py tests/test_shadow_read_port.py tests/test_shadow_state_api.py tests/test_ui_server.py -q`
 
 ### Phase 4 — Biological memory + Safe-Sync DB
 

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -1,7 +1,7 @@
 # v2.0 — Shadow DB read path (checklist)
 
 **Detailed index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) — visitor SSOT for all five v2 phases  
-**Status:** Phase 2 **core shipped** (connection, post-write upsert, FTS5 query helper); **operational completion pending** (bootstrap/reconciliation, freshness contract, runtime gating). Read routing **not wired**.  
+**Status:** Phase 2 **operational** (bootstrap, reconciliation, runtime gating — [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248)). Phase 3 **read routing shipped** (opt-in flag, FTS5/BM25 + subtree CTE + Sovereign UI health — [#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)).  
 **Parent epic:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
 **Trackable issue:** [#24 — Shadow DB read path](https://github.com/MarcoPorcellato/matryca-plumber/issues/24)  
 **Prerequisite:** [#17 — GraphRepository abstraction](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) · Phase 2–3 tracking in [`v2_preparation_blueprints.md`](../../v2_preparation_blueprints.md)  
@@ -44,20 +44,20 @@ Default path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite` (exact
 - [x] Scaffold `shadow.sqlite` DDL (`pages`, `blocks`, `block_refs`, FTS5) — `src/shadow/schema.py`
 - [x] Connection helper — `open_shadow_db` / `shadow_db_path` ([#181](https://github.com/MarcoPorcellato/matryca-plumber/issues/181))
 - [x] Incremental post-write upsert — `sync_page_to_shadow` ([#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182))
-- [x] FTS5 query helper — `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183); dispatch wiring Phase 3)
-- [ ] Full bootstrap / reconciliation / freshness contract (Phase 2 operational — [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176))
-- [ ] `GraphRepository` read routing ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17))
-- [ ] Recursive CTEs (`WITH RECURSIVE`) for sub-tree / thought-chain extraction
-- [ ] Opt-in env flag `MATRYCA_SHADOW_DB_ENABLED` ([#184](https://github.com/MarcoPorcellato/matryca-plumber/issues/184); config slice in flight)
-- [ ] Preflight / Sovereign UI health surface (no `matryca doctor` — see `llms.txt` §2.3)
+- [x] FTS5 query helper — `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183); dispatch wiring [#250](https://github.com/MarcoPorcellato/matryca-plumber/issues/250))
+- [x] Full bootstrap / reconciliation / freshness contract ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248))
+- [x] `GraphRepository` read routing — `ShadowGraphRepository` + `get_graph_read_port` ([#255](https://github.com/MarcoPorcellato/matryca-plumber/issues/255))
+- [x] Recursive CTEs (`query_subtree_by_block_uuid`) ([#253](https://github.com/MarcoPorcellato/matryca-plumber/issues/253))
+- [x] Opt-in env flag `MATRYCA_SHADOW_DB_ENABLED` ([#184](https://github.com/MarcoPorcellato/matryca-plumber/issues/184))
+- [x] Sovereign UI shadow health (`/api/state.shadow_db`) ([#185](https://github.com/MarcoPorcellato/matryca-plumber/issues/185))
 
 ### Rollout (Epic #20)
 
-| Track | Target |
-|-------|--------|
-| v2.0.0-alpha | Experimental `shadow.sqlite` behind opt-in env flag |
-| v2.0.0-rc | MCP read traffic routed to Shadow DB by default |
-| v2.0.0-stable | Deprecate pure in-memory BM25 as default discovery path |
+| Track | Target | Status |
+|-------|--------|--------|
+| v2.0.0-alpha | Experimental `shadow.sqlite` behind opt-in env flag | **ready for tag** (Phase 3 complete; see [#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) |
+| v2.0.0-rc | MCP read traffic routed to Shadow DB by default | planned |
+| v2.0.0-stable | Deprecate pure in-memory BM25 as default discovery path | planned |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -217,6 +217,20 @@ export LOGSEQ_GRAPH_PATH="/absolute/path/to/your/logseq/graph"
 uvx matryca-plumber --json plumber audit
 ```
 
+### 2.6 Shadow DB (v2.0.0-alpha — experimental, opt-in)
+
+Shadow DB is a **daemon-owned read cache** at `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite`. It does **not** replace Markdown on disk. **Default: off.**
+
+| Env var | Default | When `true` |
+|---------|---------|-------------|
+| `MATRYCA_SHADOW_DB_ENABLED` | `false` | `search_graph(bm25)` prefers FTS5 on shadow; `read_graph_data(subtree)` prefers recursive CTE; **always falls back** to generational BM25 / parser+AST when flag is off, shadow is bootstrapping, stale, or errors |
+
+**Operator health (no `doctor`):** Sovereign UI `status` → sidebar **Shadow DB** row (sourced from `GET /api/state.shadow_db`: `state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`).
+
+**Agent default unchanged:** With flag unset/false, MCP/CLI behavior matches v1.14.x (BM25 + parser subtree). Enable only when explicitly testing v2 alpha on a vault backup.
+
+Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md` · Epic [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20).
+
 ---
 
 ## 3. Zero-shot examples (small LLMs — copy exactly)


### PR DESCRIPTION
## Summary
- Mark Phase 3 read routing as shipped in `ROADMAP_V2_SHADOW_DB.md` and `ROADMAP_V2_PREPARATION.md` (closes documentation gates for #177).
- Document `MATRYCA_SHADOW_DB_ENABLED` in `llms.txt` §2.6; keep `.well-known/llms.txt` byte-identical.
- Refresh `.env.example` comment (FTS5/CTE routing, not config-parse-only).
- Rule 11: no Tier-2 fragment changes → `SYSTEM_PROMPT.md` unchanged.

## Test plan
- [x] `make agents-check`
- [x] `make check-system-prompt` (no rebuild)
- [x] `make ci` — 1115 passed, 2 skipped

Closes #177 (after merge + issue comment with gate results).


Made with [Cursor](https://cursor.com)