### PR TITLE
fix(shadow): bounded duplicate block_uuid diagnostics (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **Shadow DB health on Sovereign UI `/api/state` (#185)** — backward-compatible `shadow_db` row with persisted-meta fields (`state`, `last_full_sync_at`, `source_page_count`, `indexed_page_count`, `lag_pages`, `last_sync_error`), bounded sanitized errors, and a minimal read-only telemetry row in the control room.
 - **Phase 3 alpha operator docs** — `llms.txt` §2.6 documents `MATRYCA_SHADOW_DB_ENABLED`; v2 roadmaps updated for shipped read routing ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)).
 
+### Fixed
+
+- **Shadow duplicate block UUID diagnostics (#251)** — pre-insert guard during bootstrap/incremental sync raises bounded `ShadowSyncError` with sanitized UUID and `file_path` values (no auto-dedup); bootstrap persists the message in `last_sync_error` and reports `error` health while read paths keep Markdown/BM25 fallback.
+
 ### Changed
 
 - **`env_str` migration for `MATRYCA_BM25_MODE` ([#169](https://github.com/MarcoPorcellato/matryca-plumber/issues/169) / [#194](https://github.com/MarcoPorcellato/matryca-plumber/pull/194))** — `_bm25_mode()` in `generational_cache.py` now reads `MATRYCA_BM25_MODE` via `env_str()` (strips + lowercases; empty → default) instead of a raw `os.environ.get`; `env_str` added to `src/utils/env_parse.py` and exported in `__all__`; `env_str` import hoisted to module level in `generational_cache.py`; loguru warning on unknown mode value. Tests added for unset/empty → default and value → stripped+lowercased. Thanks to @Maqbool61.

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -12,6 +12,7 @@ from ..graph.alias_index import iter_alias_source_paths
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
+from .errors import ShadowSyncError
 from .meta import (
     META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_AT,
@@ -90,9 +91,10 @@ def rebuild_shadow_from_graph(graph_root: Path | str) -> None:
                 set_meta(conn, META_INDEXED_PAGE_COUNT, str(indexed))
                 set_meta(conn, META_LAST_SYNC_ERROR, "")
                 conn.commit()
-            except Exception:
+            except Exception as exc:
                 conn.rollback()
-                _record_rebuild_error(root, "full rebuild failed")
+                message = str(exc) if isinstance(exc, ShadowSyncError) else "full rebuild failed"
+                _record_rebuild_error(root, message)
                 raise
         finally:
             conn.close()

--- a/src/shadow/errors.py
+++ b/src/shadow/errors.py
@@ -1,0 +1,51 @@
+"""Shadow DB sync errors with bounded operator diagnostics."""
+
+from __future__ import annotations
+
+from ..utils.console_sanitize import sanitize_for_console
+
+_SHADOW_ERROR_MAX_LEN = 200
+_MAX_PATHS_IN_MESSAGE = 5
+
+
+class ShadowSyncError(RuntimeError):
+    """Raised when shadow ingestion cannot proceed without ambiguous block identity."""
+
+
+def _display_uuid(block_uuid: str) -> str:
+    cleaned = sanitize_for_console(block_uuid.strip())
+    if len(cleaned) > 12:
+        return f"{cleaned[:8]}…"
+    return cleaned
+
+
+def format_duplicate_block_uuid_error(
+    block_uuid: str,
+    file_paths: list[str],
+    *,
+    max_paths: int = _MAX_PATHS_IN_MESSAGE,
+    max_len: int = _SHADOW_ERROR_MAX_LEN,
+) -> str:
+    """Build a bounded diagnostic for duplicate ``block_uuid`` conflicts."""
+    uid = _display_uuid(block_uuid)
+    unique_paths: list[str] = []
+    for raw in file_paths:
+        path = sanitize_for_console(raw.strip())
+        if path and path not in unique_paths:
+            unique_paths.append(path)
+    unique_paths = unique_paths[:max_paths]
+
+    if len(unique_paths) == 1:
+        body = f"duplicate block_uuid {uid} within page: {unique_paths[0]}"
+    else:
+        body = f"duplicate block_uuid {uid} across pages: {', '.join(unique_paths)}"
+
+    if len(body) <= max_len:
+        return body
+    return body[: max_len - 1] + "…"
+
+
+__all__ = [
+    "ShadowSyncError",
+    "format_duplicate_block_uuid_error",
+]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -22,6 +22,7 @@ from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
 from ..graph.post_write import PageWrittenEvent, register_page_written_handler
 from .config import shadow_db_enabled
 from .connection import open_shadow_db
+from .errors import ShadowSyncError, format_duplicate_block_uuid_error
 from .meta import META_LAST_INCREMENTAL_SYNC_AT, set_meta
 from .runtime_state import defer_sync_path, is_shadow_bootstrapping
 
@@ -79,6 +80,37 @@ def _walk_blocks(
             )
         )
     return rows
+
+
+def _preflight_block_uuids(
+    connection: sqlite3.Connection,
+    flat: list[tuple[str, str | None, int, int, str, dict[str, Any]]],
+    current_rel: str,
+) -> None:
+    """Reject duplicate ``block_uuid`` values before insert (no silent dedup)."""
+    if not flat:
+        return
+
+    seen_on_page: set[str] = set()
+    for block_uuid, *_rest in flat:
+        if block_uuid in seen_on_page:
+            raise ShadowSyncError(format_duplicate_block_uuid_error(block_uuid, [current_rel]))
+        seen_on_page.add(block_uuid)
+
+    placeholders = ",".join("?" * len(seen_on_page))
+    rows = connection.execute(
+        f"""
+        SELECT b.block_uuid, p.file_path
+        FROM blocks b
+        JOIN pages p ON b.page_id = p.page_id
+        WHERE b.block_uuid IN ({placeholders})
+        """,
+        tuple(seen_on_page),
+    ).fetchall()
+    for block_uuid, other_path in rows:
+        if other_path != current_rel:
+            paths = sorted({current_rel, str(other_path)})
+            raise ShadowSyncError(format_duplicate_block_uuid_error(block_uuid, paths))
 
 
 def delete_shadow_page_by_file_path(graph_root: Path | str, rel_path: str) -> None:
@@ -147,6 +179,7 @@ def sync_page_into_connection(
     if page_id <= 0:
         raise RuntimeError("shadow pages insert returned no page_id")
     flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
+    _preflight_block_uuids(connection, flat, rel)
     uuid_to_rowid: dict[str, int] = {}
     for block_uuid, parent_uuid, sort_order, indent, content, props in flat:
         parent_rowid = uuid_to_rowid.get(parent_uuid) if parent_uuid else None

--- a/tests/test_shadow_bootstrap.py
+++ b/tests/test_shadow_bootstrap.py
@@ -17,6 +17,7 @@ from src.shadow.bootstrap import (
 )
 from src.shadow.config import shadow_db_enabled
 from src.shadow.connection import open_shadow_db, shadow_db_path
+from src.shadow.errors import ShadowSyncError
 from src.shadow.health import ShadowHealthState, resolve_shadow_health
 from src.shadow.meta import (
     META_GENERATION,
@@ -370,3 +371,71 @@ def test_startup_bootstrap_via_prepare_matryca_runtime(tmp_path: Path) -> None:
         assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
     finally:
         conn.close()
+
+
+def test_rebuild_duplicate_block_uuid_cross_page_bounded_diagnostic(
+    tmp_path: Path,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    shared_uuid = "67684dfc-dddd-4ddd-8ddd-dddddddddddd"
+    secret_a = "super-secret-alpha-content"
+    secret_b = "super-secret-beta-content"
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        f"- alpha block\n  id:: {shared_uuid}\n  {secret_a}\n",
+    )
+    _write_page(
+        graph,
+        "pages/Beta.md",
+        f"- beta block\n  id:: {shared_uuid}\n  {secret_b}\n",
+    )
+
+    with pytest.raises(ShadowSyncError, match="duplicate block_uuid") as exc_info:
+        rebuild_shadow_from_graph(graph)
+
+    message = str(exc_info.value)
+    assert shared_uuid[:8] in message
+    assert "pages/Alpha.md" in message
+    assert "pages/Beta.md" in message
+    assert secret_a not in message
+    assert secret_b not in message
+    assert len(message) <= 200
+
+    conn = open_shadow_db(graph)
+    try:
+        sync_error = get_meta(conn, META_LAST_SYNC_ERROR) or ""
+        assert "duplicate block_uuid" in sync_error
+        assert secret_a not in sync_error
+        assert secret_b not in sync_error
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) != "true"
+    finally:
+        conn.close()
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+
+
+def test_incremental_sync_duplicate_block_uuid_raises_without_content_leak(
+    tmp_path: Path,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    shared_uuid = "abababab-abab-4aba-8aba-abababababab"
+    secret = "vault-secret-should-not-appear"
+    _write_page(
+        graph,
+        "pages/First.md",
+        f"- first\n  id:: {shared_uuid}\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    second = _write_page(
+        graph,
+        "pages/Second.md",
+        f"- second\n  id:: {shared_uuid}\n  {secret}\n",
+    )
+    with pytest.raises(ShadowSyncError, match="duplicate block_uuid") as exc_info:
+        sync_page_to_shadow(graph, second)
+
+    message = str(exc_info.value)
+    assert "pages/First.md" in message
+    assert "pages/Second.md" in message
+    assert secret not in message


### PR DESCRIPTION
## Summary
- Pre-insert guard in `sync_page_into_connection` detects duplicate `block_uuid` within a page or across pages before SQLite insert.
- Raises bounded `ShadowSyncError` with sanitized UUID prefix and sandboxed `file_path` values (max 5 paths, 200 chars); no auto-dedup, no block content in the message.
- Bootstrap persists the diagnostic in `last_sync_error` and leaves shadow health in `error`; Markdown/BM25 fallback unchanged.

## Test plan
- [x] Cross-page duplicate during `rebuild_shadow_from_graph` — diagnostic + `ERROR` health, no content leak
- [x] Incremental sync duplicate — same guarantees
- [x] `make ci` — 1117 passed, 2 skipped

Closes #251.


Made with [Cursor](https://cursor.com)