### PR TITLE
test(shadow): v2.0-alpha hardening axis-1 audit probes

### DIFF
--- a/docs/quality/issue-bodies/v2-alpha-hardening-a1-meta-01.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening-a1-meta-01.md
@@ -1,0 +1,40 @@
+## Problem Description
+
+`resolve_shadow_health` returns **`ready`** when `last_full_sync_completed=true` and `last_sync_error` is empty, **without validating** that `shadow_meta` row counts match the actual `pages` table.
+
+Reproducer (Axis 1 audit, tracking [#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)):
+
+| Signal | Value |
+|--------|-------|
+| `last_full_sync_completed` | `true` |
+| `source_page_count` | `> 0` |
+| `indexed_page_count` | `> 0` |
+| `pages` row count | **0** (or diverges from meta) |
+| **Current health** | **`ready`** (incorrect) |
+| **Expected health** | **`stale`** or **`error`** — never `ready` |
+
+FTS/CTE routing then serves empty or partial results instead of falling back to `MarkdownGraphRepository` / generational BM25.
+
+**Minimal test (already in tree):** `tests/test_shadow_hardening_axis1_concurrency.py::test_a1_health_not_ready_when_meta_completed_but_pages_empty` (`pytest.mark.xfail(strict=True)` until fixed).
+
+## Proposed Architectural Solution
+
+Add a **lightweight consistency check** in `resolve_shadow_health` / `resolve_shadow_db_state_for_api` before reporting `ready` — e.g. compare `indexed_page_count` (and optionally `source_page_count`) to `SELECT COUNT(*) FROM pages`. On mismatch, return `stale` or `error` and route reads through Markdown fallback.
+
+**Scope:** health validation only — **no automatic rebuild** in this fix.
+
+## Estimated Impact
+
+**P2** — unlikely without manual DB corruption or partial crash, but breaks the operator contract that `ready` implies a usable shadow index.
+
+## Files Involved
+
+- `src/shadow/health.py`
+- `src/shadow/state_api.py`
+- `tests/test_shadow_hardening_axis1_concurrency.py` (remove `xfail` when fixed)
+- `tests/test_shadow_state_api.py` (regression)
+
+---
+**Parent tracker:** [#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261) · **Epic:** [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
+
+_Closes when merged with tests green (`make ci`) and CHANGELOG updated._

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -1,0 +1,125 @@
+# v2.0-alpha hardening — tracking issue
+
+## Problem Description
+
+`v2.0.0-alpha` ships an opt-in Shadow DB read cache behind `MATRYCA_SHADOW_DB_ENABLED`. Before `v2.0.0-rc`, we need a structured hardening campaign: reproduce real failures and edge cases with minimal tests, then land **surgical PRs** per confirmed finding — no monolithic audit-fix PR.
+
+**Baseline:** tag [`v2.0.0-alpha`](https://github.com/MarcoPorcellato/matryca-plumber/releases/tag/v2.0.0-alpha) · maintainer docs on [`main` @ `2f97375`](https://github.com/MarcoPorcellato/matryca-plumber/commit/2f97375915161f867d667a30efc80e2398631a7e).
+
+**Parent epic:** [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
+
+## Proposed Architectural Solution
+
+Seven-axis audit with severity classification **P0–P3**. Each **confirmed** finding gets:
+
+1. A **minimal reproducer test** (fixture vault, failure injection, read-only where possible).
+2. A **child issue** linked below.
+3. A **surgical PR** — one concern per PR.
+
+### Severity
+
+| Level | Meaning |
+|-------|---------|
+| **P0** | Data loss/corruption, sandbox bypass, broken fallback to Markdown/BM25 |
+| **P1** | Wrong query results, bootstrap stuck, reproducible race |
+| **P2** | Diagnostics, performance regression, edge-case contract gap |
+| **P3** | Ergonomics, docs-only |
+
+### RC exit criteria
+
+- **No open P0 or P1** findings.
+- Every **P2** either fixed or explicitly accepted with rationale in this table.
+
+### Baseline verification commands
+
+```bash
+make ci
+uvx matryca-plumber@2.0.0-alpha --version
+# vault soak (flag off + flag on) — see Epic #20 distribution comment
+```
+
+---
+
+## Seven axes (checklist)
+
+### Axis 1 — Concurrency & recovery
+
+- [x] Bootstrap vs `post_write` / file watcher (defer + replay) — **A1-DEFER-01/02 pass**
+- [x] Two processes on the same vault (daemon + CLI / twin `uvx`) — **A1-PROC-01/02 P1 open**
+- [x] SQLite `locked` / writer contention / crash mid-transaction — **A1-SQLITE-01 pass; A1-BOOT-02 accepted**
+- [x] `shadow_meta` `ready` coherent with committed page/block generation — **A1-META-01 P2 gap**
+
+### Axis 2 — Shadow ↔ Markdown correctness
+
+- [ ] Rename/delete during bootstrap
+- [ ] Duplicate Logseq titles / encoded filenames
+- [ ] Missing, intra-page, and cross-page duplicate `block_uuid`
+- [ ] Multiline properties, deep blocks, journals, namespaces
+
+### Axis 3 — Routing & fallback
+
+- [ ] Health changes between port selection and query
+- [ ] DB removed/corrupted after `ready`
+- [ ] Flag toggled across processes
+- [ ] Zero-hit and not-found must **not** trigger Markdown fallback
+
+### Axis 4 — FTS5
+
+- [ ] Special chars, quotes, operators, Unicode
+- [ ] Very long queries
+- [ ] Limits and deterministic ordering
+- [ ] MCP/CLI envelope parity
+
+### Axis 5 — CTE subtree
+
+- [ ] Extreme depth / large sibling sets
+- [ ] Artificial cycles and cross-page parents
+- [ ] UTF-8 byte truncation
+- [ ] Property-based parity vs parser Markdown reads
+
+### Axis 6 — Security & isolation
+
+- [ ] Path traversal and symlink escape
+- [ ] Sanitized errors (no vault content leak)
+- [ ] Flag `false` must not create/open/mutate SQLite
+- [ ] Shadow DB must never write Markdown
+
+### Axis 7 — Performance
+
+- [ ] Bootstrap at 1k / 10k / 50k blocks
+- [ ] FTS/CTE latency p50/p95
+- [ ] Memory and lock hold duration
+- [ ] Watcher cost on file bursts
+
+---
+
+## Findings table
+
+| ID | Axis | Repro | Sev | Minimal test | Child issue | Status |
+|----|------|-------|-----|--------------|-------------|--------|
+| A1-PROC-01 | 1 | Cross-process rebuild while another writer holds `BEGIN IMMEDIATE` | **P1** | `test_a1_cross_process_rebuild_while_write_lock_held_raises_database_locked` | [#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262) | **open** |
+| A1-PROC-02 | 1 | Design review | **P1** | `test_a1_rebuild_lock_is_in_process_only_documented_gap` | [#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262) | **open** |
+| A1-META-01 | 1 | Manual meta corruption on fixture DB | **P2** | `test_a1_health_ready_does_not_validate_page_rows` | *(pending)* | **open** |
+| A1-BOOT-02 | 1 | Injected page failure mid-rebuild | **P2** | `test_a1_rebuild_injected_failure_preserves_committed_generation` | — | **accepted** — rollback preserves generation; `last_sync_error` forces `error` health (fallback) |
+| A1-DEFER-01 | 1 | Watchdog delete deferred + file removed | — | `test_a1_watchdog_delete_during_bootstrap_replays_removal_when_file_gone` | — | **pass** |
+| A1-DEFER-02 | 1 | `post_write` during bootstrap | — | `test_a1_post_write_during_bootstrap_replays_after_rebuild` | — | **pass** |
+| A1-SQLITE-01 | 1 | Holder keeps `BEGIN IMMEDIATE` | — | `test_a1_sqlite_writer_lock_blocks_incremental_without_meta_corruption` | — | **pass** |
+
+---
+
+## Estimated Impact
+
+**Alto** — gates `v2.0.0-rc` confidence for operators enabling `MATRYCA_SHADOW_DB_ENABLED`.
+
+## Files Involved
+
+- `src/shadow/` (bootstrap, sync, meta, health, connection)
+- `src/agent/shadow_graph_repository.py`, `src/agent/graph_read_port.py`
+- `tests/test_shadow_hardening_axis*.py` (audit reproducers)
+- `docs/quality/issue-bodies/v2-alpha-hardening.md` (this body, SSOT for edits)
+
+---
+**Epic:** [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
+**Milestone:** `v2.0.0 — Shadow DB & Safe-Sync Architecture`
+
+_Closes when RC exit criteria are met and findings table is empty or P2-only with explicit acceptance._

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -97,9 +97,9 @@ uvx matryca-plumber@2.0.0-alpha --version
 
 | ID | Axis | Repro | Sev | Minimal test | Child issue | Status |
 |----|------|-------|-----|--------------|-------------|--------|
-| A1-PROC-01 | 1 | Cross-process rebuild while another writer holds `BEGIN IMMEDIATE` | **P1** | `test_a1_cross_process_rebuild_while_write_lock_held_raises_database_locked` | [#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262) | **open** |
+| A1-PROC-01 | 1 | Cross-process rebuild while SQLite writer active | **P1** | `test_a1_cross_process_rebuild_completes_while_sqlite_writer_active` | [#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262) | **open** |
 | A1-PROC-02 | 1 | Design review | **P1** | `test_a1_rebuild_lock_is_in_process_only_documented_gap` | [#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262) | **open** |
-| A1-META-01 | 1 | Manual meta corruption on fixture DB | **P2** | `test_a1_health_ready_does_not_validate_page_rows` | *(pending)* | **open** |
+| A1-META-01 | 1 | Manual meta corruption on fixture DB | **P2** | `test_a1_health_not_ready_when_meta_completed_but_pages_empty` | [#264](https://github.com/MarcoPorcellato/matryca-plumber/issues/264) | **open** |
 | A1-BOOT-02 | 1 | Injected page failure mid-rebuild | **P2** | `test_a1_rebuild_injected_failure_preserves_committed_generation` | — | **accepted** — rollback preserves generation; `last_sync_error` forces `error` health (fallback) |
 | A1-DEFER-01 | 1 | Watchdog delete deferred + file removed | — | `test_a1_watchdog_delete_during_bootstrap_replays_removal_when_file_gone` | — | **pass** |
 | A1-DEFER-02 | 1 | `post_write` during bootstrap | — | `test_a1_post_write_during_bootstrap_replays_after_rebuild` | — | **pass** |

--- a/tests/test_shadow_hardening_axis1_concurrency.py
+++ b/tests/test_shadow_hardening_axis1_concurrency.py
@@ -26,6 +26,7 @@ from src.shadow.meta import (
     META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_COMPLETED,
     META_LAST_SYNC_ERROR,
+    META_SOURCE_PAGE_COUNT,
     get_meta,
     set_meta,
 )
@@ -116,22 +117,38 @@ def test_a1_rebuild_injected_failure_preserves_committed_generation(tmp_path: Pa
         conn.close()
 
 
-def test_a1_health_ready_does_not_validate_page_rows(tmp_path: Path) -> None:
-    """A1-META-01 (P2 gap): ``ready`` trusts meta only; empty ``pages`` still reports ready."""
+@pytest.mark.xfail(
+    strict=True,
+    reason="A1-META-01: health ready ignores meta/row mismatch (#264)",
+)
+def test_a1_health_not_ready_when_meta_completed_but_pages_empty(tmp_path: Path) -> None:
+    """A1-META-01: meta/pages mismatch must report ``stale`` or ``error``, never ``ready``."""
     graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
     rebuild_shadow_from_graph(graph)
 
     conn = open_shadow_db(graph)
     try:
         set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "true")
         set_meta(conn, META_LAST_SYNC_ERROR, "")
-        set_meta(conn, META_INDEXED_PAGE_COUNT, "99")
+        set_meta(conn, META_SOURCE_PAGE_COUNT, "1")
+        set_meta(conn, META_INDEXED_PAGE_COUNT, "1")
         conn.execute("DELETE FROM pages")
         conn.commit()
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert int(get_meta(conn, META_SOURCE_PAGE_COUNT) or "0") > 0
+        assert int(get_meta(conn, META_INDEXED_PAGE_COUNT) or "0") > 0
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 0
     finally:
         conn.close()
 
-    assert resolve_shadow_health(graph) == ShadowHealthState.READY
+    health = resolve_shadow_health(graph)
+    assert health != ShadowHealthState.READY
+    assert health in (ShadowHealthState.STALE, ShadowHealthState.ERROR)
 
 
 def test_a1_watchdog_delete_during_bootstrap_replays_removal_when_file_gone(
@@ -241,11 +258,12 @@ def _multiprocess_rebuild_worker(graph_str: str) -> None:
     rebuild_shadow_from_graph(graph_str)
 
 
+@pytest.mark.xfail(strict=True, reason="A1-PROC-01/02: no cross-process rebuild lock (#262)")
 @pytest.mark.slow
-def test_a1_cross_process_rebuild_while_write_lock_held_raises_database_locked(
+def test_a1_cross_process_rebuild_completes_while_sqlite_writer_active(
     tmp_path: Path,
 ) -> None:
-    """A1-PROC-01 (P1): cross-process rebuild contends when another writer holds the DB."""
+    """A1-PROC-01: rebuild must finish under cross-process contention without SQLite lock errors."""
     graph = _minimal_graph(tmp_path)
     for index in range(4):
         _write_page(
@@ -259,27 +277,24 @@ def test_a1_cross_process_rebuild_while_write_lock_held_raises_database_locked(
     holder.execute("BEGIN IMMEDIATE")
     try:
         ctx = mp.get_context("spawn")
-        with (
-            ctx.Pool(processes=1) as pool,
-            pytest.raises(Exception, match="database is locked"),
-        ):
+        with ctx.Pool(processes=1) as pool:
             pool.apply(_multiprocess_rebuild_worker, (str(graph),))
     finally:
         holder.rollback()
         holder.close()
 
-    rebuild_shadow_from_graph(graph)
     conn = open_shadow_db(graph)
     try:
         assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip() == ""
         assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 4
         assert resolve_shadow_health(graph) == ShadowHealthState.READY
     finally:
         conn.close()
 
 
-def test_a1_rebuild_lock_is_in_process_only_documented_gap() -> None:
-    """A1-PROC-02 (P1 gap): ``rebuild_lock_for`` is a threading.Lock, not cross-process."""
+def test_a1_rebuild_lock_is_in_process_only_probe() -> None:
+    """A1-PROC-02 probe (non-gating): documents in-process ``threading.Lock`` scope."""
     from src.shadow.runtime_state import rebuild_lock_for
 
     lock_a = rebuild_lock_for("/tmp/vault-a")

--- a/tests/test_shadow_hardening_axis1_concurrency.py
+++ b/tests/test_shadow_hardening_axis1_concurrency.py
@@ -1,0 +1,288 @@
+"""v2.0-alpha hardening — Axis 1: concurrency & recovery (audit probes).
+
+Read-only failure injection on temporary vault fixtures. Findings feed
+tracking issue #261; production code changes only after a minimal reproducer
+exists and a child issue is opened.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.graph.post_write import register_page_written_handler
+from src.shadow.bootstrap import (
+    handle_shadow_watchdog_change,
+    rebuild_shadow_from_graph,
+    reset_shadow_bootstrap_checked_for_tests,
+)
+from src.shadow.connection import open_shadow_db
+from src.shadow.health import ShadowHealthState, resolve_shadow_health
+from src.shadow.meta import (
+    META_GENERATION,
+    META_INDEXED_PAGE_COUNT,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    get_meta,
+    set_meta,
+)
+from src.shadow.runtime_state import (
+    mark_bootstrapping,
+    reset_shadow_runtime_state_for_tests,
+)
+from src.shadow.sync import (
+    reset_shadow_sync_bridge_for_tests,
+    sync_page_into_connection,
+    sync_page_to_shadow,
+)
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    reset_shadow_runtime_state_for_tests()
+    reset_shadow_bootstrap_checked_for_tests()
+    reset_shadow_sync_bridge_for_tests()
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _minimal_graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    (graph / "journals").mkdir(parents=True)
+    return graph
+
+
+def test_a1_rebuild_injected_failure_preserves_committed_generation(tmp_path: Path) -> None:
+    """A1-BOOT-01: failed rebuild must not destroy the last committed generation."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Stable.md",
+        "- stable\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        generation_before = get_meta(conn, META_GENERATION)
+        page_count_before = conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+    finally:
+        conn.close()
+
+    _write_page(
+        graph,
+        "pages/Trigger.md",
+        "- trigger\n  id:: 22222222-2222-4222-8222-222222222222\n",
+    )
+
+    calls = 0
+    original = sync_page_into_connection
+
+    def _fail_on_second_page(
+        connection: sqlite3.Connection,
+        graph_root: Path,
+        page_path: Path,
+    ) -> None:
+        nonlocal calls
+        calls += 1
+        if calls >= 2:
+            raise RuntimeError("injected axis-1 rebuild failure")
+        original(connection, graph_root, page_path)
+
+    with (
+        patch("src.shadow.sync.sync_page_into_connection", side_effect=_fail_on_second_page),
+        pytest.raises(RuntimeError, match="injected axis-1"),
+    ):
+        rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert get_meta(conn, META_GENERATION) == generation_before
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == page_count_before
+        assert (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip() != ""
+        assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    finally:
+        conn.close()
+
+
+def test_a1_health_ready_does_not_validate_page_rows(tmp_path: Path) -> None:
+    """A1-META-01 (P2 gap): ``ready`` trusts meta only; empty ``pages`` still reports ready."""
+    graph = _minimal_graph(tmp_path)
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "true")
+        set_meta(conn, META_LAST_SYNC_ERROR, "")
+        set_meta(conn, META_INDEXED_PAGE_COUNT, "99")
+        conn.execute("DELETE FROM pages")
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert resolve_shadow_health(graph) == ShadowHealthState.READY
+
+
+def test_a1_watchdog_delete_during_bootstrap_replays_removal_when_file_gone(
+    tmp_path: Path,
+) -> None:
+    """A1-DEFER-01: deferred delete replays after rebuild when the Markdown file is gone."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Seed.md",
+        "- seed\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    victim = _write_page(
+        graph,
+        "pages/Victim.md",
+        "- victim\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n",
+    )
+    sync_page_to_shadow(graph, victim)
+    victim_rel = victim.relative_to(graph).as_posix()
+    victim.unlink()
+
+    mark_bootstrapping(graph)
+    handle_shadow_watchdog_change(graph, graph / victim_rel, "deleted")
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
+        assert "Seed" in titles
+        assert "Victim" not in titles
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+    finally:
+        conn.close()
+
+
+def test_a1_post_write_during_bootstrap_replays_after_rebuild(tmp_path: Path) -> None:
+    """A1-DEFER-02: post_write hook defers until bootstrap completes."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Base.md",
+        "- base\n  id:: cccccccc-cccc-4ccc-8ccc-cccccccccccc\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    mark_bootstrapping(graph)
+    late = _write_page(
+        graph,
+        "pages/Late.md",
+        "- late\n  id:: dddddddd-dddd-4ddd-8ddd-dddddddddddd\n",
+    )
+    register_page_written_handler(
+        lambda event: sync_page_to_shadow(event.graph_root, event.path),
+    )
+    sync_page_to_shadow(
+        graph,
+        late,
+    )
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
+        assert {"Base", "Late"} <= titles
+    finally:
+        conn.close()
+
+
+def test_a1_sqlite_writer_lock_blocks_incremental_without_meta_corruption(
+    tmp_path: Path,
+) -> None:
+    """A1-SQLITE-01: writer contention surfaces as SQLite error, not torn meta."""
+    graph = _minimal_graph(tmp_path)
+    page = _write_page(
+        graph,
+        "pages/Lock.md",
+        "- lock\n  id:: eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    holder = open_shadow_db(graph)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            sync_page_to_shadow(graph, page)
+    finally:
+        holder.rollback()
+        holder.close()
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip() == ""
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def _multiprocess_rebuild_worker(graph_str: str) -> None:
+    import os
+
+    os.environ["MATRYCA_SHADOW_DB_ENABLED"] = "true"
+    from src.shadow.bootstrap import rebuild_shadow_from_graph
+
+    rebuild_shadow_from_graph(graph_str)
+
+
+@pytest.mark.slow
+def test_a1_cross_process_rebuild_while_write_lock_held_raises_database_locked(
+    tmp_path: Path,
+) -> None:
+    """A1-PROC-01 (P1): cross-process rebuild contends when another writer holds the DB."""
+    graph = _minimal_graph(tmp_path)
+    for index in range(4):
+        _write_page(
+            graph,
+            f"pages/P{index}.md",
+            f"- p{index}\n  id:: {index:08d}-1111-4111-8111-111111111111\n",
+        )
+    rebuild_shadow_from_graph(graph)
+
+    holder = open_shadow_db(graph)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        ctx = mp.get_context("spawn")
+        with (
+            ctx.Pool(processes=1) as pool,
+            pytest.raises(Exception, match="database is locked"),
+        ):
+            pool.apply(_multiprocess_rebuild_worker, (str(graph),))
+    finally:
+        holder.rollback()
+        holder.close()
+
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 4
+        assert resolve_shadow_health(graph) == ShadowHealthState.READY
+    finally:
+        conn.close()
+
+
+def test_a1_rebuild_lock_is_in_process_only_documented_gap() -> None:
+    """A1-PROC-02 (P1 gap): ``rebuild_lock_for`` is a threading.Lock, not cross-process."""
+    from src.shadow.runtime_state import rebuild_lock_for
+
+    lock_a = rebuild_lock_for("/tmp/vault-a")
+    lock_b = rebuild_lock_for("/tmp/vault-a")
+    assert lock_a is lock_b
+    assert type(lock_a).__name__ == "lock"


### PR DESCRIPTION
## Summary

- Adds **Axis 1** failure-injection reproducers for Shadow DB concurrency/recovery ([#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)).
- **No production code changes** — audit-only tests on temporary fixture vaults.
- Documents open findings: **P1** cross-process SQLite contention ([#262](https://github.com/MarcoPorcellato/matryca-plumber/issues/262)), **P2** `ready` health without row validation (child issue pending).

## Findings (Axis 1)

| ID | Sev | Result |
|----|-----|--------|
| A1-PROC-01/02 | P1 | `rebuild_lock_for` is in-process; cross-process rebuild → `database is locked` |
| A1-META-01 | P2 | `ready` trusts meta only; empty `pages` still reports ready |
| A1-BOOT-02 | P2 accepted | Rollback preserves generation; `last_sync_error` forces fallback |
| A1-DEFER/SQLITE | — | defer/replay and writer lock probes pass |

## Test plan

- [x] `make ci` (1124 passed)
- [ ] CI green on PR

**Next:** surgical fix PR for #262 after this lands.

Made with [Cursor](https://cursor.com)