### PR TITLE
fix(shadow): cross-process writer coordination (#262)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -489,3 +489,21 @@ MATRYCA_MEMORY_GRAPH_ENABLED=false
 # Range / notes: opt-in v2.0.0-alpha; FTS5 BM25 + subtree CTE when healthy; Markdown/BM25 fallback otherwise
 MATRYCA_SHADOW_DB_ENABLED=false
 
+# SQLite busy_timeout (ms) for shadow.sqlite connections. src/shadow/config.py
+# Default (code): 5000
+# Template: 5000
+# Range / notes: clamped [0, 60000]; 0 disables waiting
+MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS=5000
+
+# Cross-process shadow writer flock timeout (seconds) for incremental sync/delete. src/shadow/config.py
+# Default (code): 10
+# Template: 10
+# Range / notes: clamped [1, 300]; post-write and watchdog paths — keep short for interactive CLI
+MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S=10
+
+# Cross-process shadow rebuild flock timeout (seconds). src/shadow/config.py
+# Default (code): 120
+# Template: 120
+# Range / notes: clamped [1, 600]; full rebuild may scan large vaults at daemon bootstrap
+MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S=120
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- **Shadow cross-process writer coordination (#262)** — advisory `shadow.writer.flock` per graph root serializes rebuild, incremental sync, and delete writers; split flock timeouts (`MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` default 10s for post-write/watchdog, `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` default 120s for full rebuild) and `PRAGMA busy_timeout` via `MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS` (clamped) prevent infinite SQLite waits without masking corruption errors.
+
 - **UI server test isolation** — `test_get_state_returns_daemon_checkpoint` clears `MATRYCA_SHADOW_DB_ENABLED` so local env cannot flip `shadow_db` expectations.
 
 ## [2.0.0-alpha] - 2026-07-18

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -32,6 +32,7 @@ from .runtime_state import (
 )
 from .schema import SHADOW_SCHEMA_VERSION
 from .sync import delete_shadow_page_by_file_path, sync_page_to_shadow
+from .writer_lock import shadow_rebuild_lock
 
 _BOOTSTRAP_CHECKED: set[str] = set()
 
@@ -63,7 +64,7 @@ def rebuild_shadow_from_graph(graph_root: Path | str) -> None:
     if not shadow_db_enabled():
         return
     root = resolved_graph_root(graph_root)
-    with rebuild_lock_for(root):
+    with shadow_rebuild_lock(root), rebuild_lock_for(root):
         mark_bootstrapping(root)
         conn = open_shadow_db(root)
         try:

--- a/src/shadow/config.py
+++ b/src/shadow/config.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
-from ..utils.env_parse import env_bool
+from ..utils.env_parse import env_bool, env_int_clamped
+
+_SHADOW_BUSY_TIMEOUT_MS_MIN = 0
+_SHADOW_BUSY_TIMEOUT_MS_MAX = 60_000
+_SHADOW_BUSY_TIMEOUT_MS_DEFAULT = 5_000
+
+_SHADOW_WRITER_LOCK_TIMEOUT_S_MIN = 1
+_SHADOW_WRITER_LOCK_TIMEOUT_S_MAX = 300
+_SHADOW_WRITER_LOCK_TIMEOUT_S_DEFAULT = 10
+
+_SHADOW_REBUILD_LOCK_TIMEOUT_S_MIN = 1
+_SHADOW_REBUILD_LOCK_TIMEOUT_S_MAX = 600
+_SHADOW_REBUILD_LOCK_TIMEOUT_S_DEFAULT = 120
 
 
 def shadow_db_enabled() -> bool:
@@ -13,4 +25,43 @@ def shadow_db_enabled() -> bool:
     return env_bool("MATRYCA_SHADOW_DB_ENABLED", default=False)
 
 
-__all__ = ["shadow_db_enabled"]
+def shadow_db_busy_timeout_ms() -> int:
+    """SQLite ``busy_timeout`` for shadow connections (0 disables waiting)."""
+    return env_int_clamped(
+        "MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS",
+        _SHADOW_BUSY_TIMEOUT_MS_DEFAULT,
+        minimum=_SHADOW_BUSY_TIMEOUT_MS_MIN,
+        maximum=_SHADOW_BUSY_TIMEOUT_MS_MAX,
+    )
+
+
+def shadow_writer_lock_timeout_s() -> float:
+    """Maximum wait for incremental shadow writer flock (post-write / watchdog)."""
+    return float(
+        env_int_clamped(
+            "MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S",
+            _SHADOW_WRITER_LOCK_TIMEOUT_S_DEFAULT,
+            minimum=_SHADOW_WRITER_LOCK_TIMEOUT_S_MIN,
+            maximum=_SHADOW_WRITER_LOCK_TIMEOUT_S_MAX,
+        )
+    )
+
+
+def shadow_rebuild_lock_timeout_s() -> float:
+    """Maximum wait for full rebuild flock (daemon bootstrap; may scan large vaults)."""
+    return float(
+        env_int_clamped(
+            "MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S",
+            _SHADOW_REBUILD_LOCK_TIMEOUT_S_DEFAULT,
+            minimum=_SHADOW_REBUILD_LOCK_TIMEOUT_S_MIN,
+            maximum=_SHADOW_REBUILD_LOCK_TIMEOUT_S_MAX,
+        )
+    )
+
+
+__all__ = [
+    "shadow_db_busy_timeout_ms",
+    "shadow_db_enabled",
+    "shadow_rebuild_lock_timeout_s",
+    "shadow_writer_lock_timeout_s",
+]

--- a/src/shadow/connection.py
+++ b/src/shadow/connection.py
@@ -6,6 +6,7 @@ import sqlite3
 from pathlib import Path
 
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from .config import shadow_db_busy_timeout_ms
 from .schema import apply_shadow_schema
 
 _SHADOW_CACHE_DIRNAME = ".matryca_semantic_cache"
@@ -28,6 +29,9 @@ def open_shadow_db(graph_root: Path | str) -> sqlite3.Connection:
     db_path = shadow_db_path(graph_root)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(str(db_path))
+    busy_timeout_ms = shadow_db_busy_timeout_ms()
+    if busy_timeout_ms > 0:
+        connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
     try:
         apply_shadow_schema(connection)
         connection.commit()

--- a/src/shadow/sqlite_busy.py
+++ b/src/shadow/sqlite_busy.py
@@ -1,0 +1,46 @@
+"""SQLite contention helpers for shadow.sqlite writers."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def is_sqlite_locked_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` indicates transient writer contention."""
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    message = str(exc).casefold()
+    return "database is locked" in message or "database is busy" in message
+
+
+def is_sqlite_corruption_error(exc: BaseException) -> bool:
+    """Return whether ``exc`` indicates schema or file corruption (not contention)."""
+    if isinstance(exc, sqlite3.DatabaseError) and not isinstance(exc, sqlite3.OperationalError):
+        return True
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    message = str(exc).casefold()
+    if is_sqlite_locked_error(exc):
+        return False
+    return any(
+        token in message
+        for token in (
+            "malformed",
+            "corrupt",
+            "no such table",
+            "no such column",
+            "schema",
+        )
+    )
+
+
+def format_sqlite_busy_error(graph_root: str, *, waited_ms: int) -> str:
+    """Bounded diagnostic when shadow.sqlite stays busy past ``busy_timeout``."""
+    return f"shadow.sqlite busy after {waited_ms}ms for {graph_root}"
+
+
+__all__ = [
+    "format_sqlite_busy_error",
+    "is_sqlite_corruption_error",
+    "is_sqlite_locked_error",
+]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -25,6 +25,7 @@ from .connection import open_shadow_db
 from .errors import ShadowSyncError, format_duplicate_block_uuid_error
 from .meta import META_LAST_INCREMENTAL_SYNC_AT, set_meta
 from .runtime_state import defer_sync_path, is_shadow_bootstrapping
+from .writer_lock import shadow_writer_lock
 
 _bridge_lock = threading.Lock()
 _bridge_registered = False
@@ -118,16 +119,17 @@ def delete_shadow_page_by_file_path(graph_root: Path | str, rel_path: str) -> No
     if not shadow_db_enabled():
         return
     root = resolved_graph_root(graph_root)
-    conn = open_shadow_db(root)
-    try:
-        conn.execute("DELETE FROM pages WHERE file_path = ?", (rel_path,))
-        set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-    finally:
-        conn.close()
+    with shadow_writer_lock(root):
+        conn = open_shadow_db(root)
+        try:
+            conn.execute("DELETE FROM pages WHERE file_path = ?", (rel_path,))
+            set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
 
 def sync_page_into_connection(
@@ -223,16 +225,17 @@ def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
         defer_sync_path(root, rel)
         return
 
-    conn = open_shadow_db(root)
-    try:
-        sync_page_into_connection(conn, root, path)
-        set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
-        conn.commit()
-    except Exception:
-        conn.rollback()
-        raise
-    finally:
-        conn.close()
+    with shadow_writer_lock(root):
+        conn = open_shadow_db(root)
+        try:
+            sync_page_into_connection(conn, root, path)
+            set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
 
 def _on_shadow_page_written(event: PageWrittenEvent) -> None:

--- a/src/shadow/writer_lock.py
+++ b/src/shadow/writer_lock.py
@@ -1,0 +1,60 @@
+"""Cross-process advisory lock for all Matryca shadow.sqlite writers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from ..utils.platform_lock import cross_process_sidecar_lock
+from .config import shadow_rebuild_lock_timeout_s, shadow_writer_lock_timeout_s
+from .connection import shadow_db_path
+
+_SHADOW_WRITER_LOCK_FILENAME = "shadow.writer.flock"
+
+
+def _writer_lock_depth_key(lock_path: Path) -> str:
+    """Thread-local reentrancy key scoped to the resolved lock path."""
+    return str(lock_path.expanduser().resolve(strict=False))
+
+
+def shadow_writer_lock_path(graph_root: Path | str) -> Path:
+    """Return the sandboxed sidecar flock path for shadow writers."""
+    root = resolved_graph_root(graph_root)
+    db_path = shadow_db_path(root)
+    lock_path = db_path.parent / _SHADOW_WRITER_LOCK_FILENAME
+    return assert_path_within_graph(lock_path, root)
+
+
+@contextmanager
+def shadow_writer_lock(graph_root: Path | str) -> Iterator[None]:
+    """Serialize incremental sync/delete writers for one graph root."""
+    lock_path = shadow_writer_lock_path(graph_root)
+    with cross_process_sidecar_lock(
+        lock_path,
+        depth_key=_writer_lock_depth_key(lock_path),
+        unavailable_label="shadow writer lock",
+        max_wait_s=shadow_writer_lock_timeout_s(),
+    ):
+        yield
+
+
+@contextmanager
+def shadow_rebuild_lock(graph_root: Path | str) -> Iterator[None]:
+    """Serialize full rebuild writers (longer default timeout than incremental)."""
+    lock_path = shadow_writer_lock_path(graph_root)
+    with cross_process_sidecar_lock(
+        lock_path,
+        depth_key=_writer_lock_depth_key(lock_path),
+        unavailable_label="shadow rebuild lock",
+        max_wait_s=shadow_rebuild_lock_timeout_s(),
+    ):
+        yield
+
+
+__all__ = [
+    "shadow_rebuild_lock",
+    "shadow_writer_lock",
+    "shadow_writer_lock_path",
+]

--- a/src/utils/env_parse.py
+++ b/src/utils/env_parse.py
@@ -25,6 +25,34 @@ def env_int(key: str, default: int) -> int:
         return default
 
 
+def env_int_clamped(
+    key: str,
+    default: int,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """Parse an integer env var and clamp to ``[minimum, maximum]``."""
+    value = env_int(key, default)
+    if value < minimum:
+        logger.warning(
+            "Integer for {}={} below minimum {}; clamping",
+            key,
+            value,
+            minimum,
+        )
+        return minimum
+    if value > maximum:
+        logger.warning(
+            "Integer for {}={} above maximum {}; clamping",
+            key,
+            value,
+            maximum,
+        )
+        return maximum
+    return value
+
+
 def env_float(key: str, default: float) -> float:
     raw = os.environ.get(key, "").strip()
     if not raw:
@@ -41,4 +69,4 @@ def env_str(key: str, default: str = "") -> str:
     return raw if raw else default
 
 
-__all__ = ["env_bool", "env_float", "env_int", "env_str"]
+__all__ = ["env_bool", "env_float", "env_int", "env_int_clamped", "env_str"]

--- a/src/utils/platform_lock.py
+++ b/src/utils/platform_lock.py
@@ -50,11 +50,16 @@ def clear_flock_depths() -> None:
         del _flock_depth_local.depths
 
 
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=clear_flock_depths)
+
+
 def acquire_exclusive_flock(
     fd: int,
     lock_path: Path,
     *,
     unavailable_label: str = "sidecar lock",
+    max_wait_s: float | None = None,
 ) -> bool:
     """Acquire exclusive flock with exponential backoff.
 
@@ -72,27 +77,41 @@ def acquire_exclusive_flock(
             return True
         except BlockingIOError:
             if attempt >= IO_RETRY_ATTEMPTS - 1:
-                logger.warning(
-                    "{} sidecar contended after {} NB retries; blocking until free: {}",
-                    unavailable_label,
-                    IO_RETRY_ATTEMPTS - 1,
-                    lock_path,
-                )
-                try:
-                    _fcntl.flock(fd, _fcntl.LOCK_EX)
-                    return True
-                except OSError as exc:
-                    if not flock_degradation_allowed():
-                        raise PageLockUnavailableError(
-                            f"Could not acquire {unavailable_label} for {lock_path}: {exc}",
-                        ) from exc
-                    logger.info(
-                        "[LOCK FILE SYSTEM DEGRADATION] Shared process lock not supported by "
-                        "filesystem ({}), falling back to in-process coordination for {}.",
-                        exc,
+                if max_wait_s is None:
+                    logger.warning(
+                        "{} sidecar contended after {} NB retries; blocking until free: {}",
+                        unavailable_label,
+                        IO_RETRY_ATTEMPTS - 1,
                         lock_path,
                     )
-                    return False
+                    try:
+                        _fcntl.flock(fd, _fcntl.LOCK_EX)
+                        return True
+                    except OSError as exc:
+                        if not flock_degradation_allowed():
+                            raise PageLockUnavailableError(
+                                f"Could not acquire {unavailable_label} for {lock_path}: {exc}",
+                            ) from exc
+                        logger.info(
+                            "[LOCK FILE SYSTEM DEGRADATION] Shared process lock not supported by "
+                            "filesystem ({}), falling back to in-process coordination for {}.",
+                            exc,
+                            lock_path,
+                        )
+                        return False
+                deadline = time.monotonic() + max_wait_s
+                poll_delay = min(IO_RETRY_INITIAL_DELAY_S, max_wait_s / 10.0)
+                while time.monotonic() < deadline:
+                    try:
+                        _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                        return True
+                    except BlockingIOError:
+                        time.sleep(min(poll_delay, max(0.0, deadline - time.monotonic())))
+                        poll_delay = min(IO_RETRY_MAX_DELAY_S, poll_delay * 2)
+                raise PageLockUnavailableError(
+                    f"Timed out acquiring {unavailable_label} for {lock_path} "
+                    f"after {max_wait_s:.1f}s",
+                ) from None
             time.sleep(min(IO_RETRY_MAX_DELAY_S, delay))
             delay = min(IO_RETRY_MAX_DELAY_S, delay * 2)
         except OSError as exc:
@@ -146,6 +165,7 @@ def cross_process_sidecar_lock(
     *,
     depth_key: str,
     unavailable_label: str = "sidecar lock",
+    max_wait_s: float | None = None,
 ) -> Iterator[None]:
     """Hold an exclusive cross-process flock on ``lock_path`` with reentrancy depth tracking."""
     depths = flock_depths()
@@ -173,6 +193,7 @@ def cross_process_sidecar_lock(
             fd,
             lock_path,
             unavailable_label=unavailable_label,
+            max_wait_s=max_wait_s,
         )
         if not acquired and not flock_degradation_allowed():
             raise PageLockUnavailableError(

--- a/tests/test_env_example_coverage.py
+++ b/tests/test_env_example_coverage.py
@@ -25,7 +25,7 @@ _ENV_HELPER_RE = re.compile(
     r"""_env_(?:bool|int|float|str)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
 )
 _ENV_PARSE_RE = re.compile(
-    r"""env_(?:bool|int|float|str)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
+    r"""env_(?:bool|int(?:_clamped)?|float|str)\(\s*["']([A-Z][A-Z0-9_]*)["']""",
 )
 _ENV_MAP_RE = re.compile(
     r"""_map_(?:bool|int|float|str)(?:_nonempty)?\(\s*env\s*,\s*["']([A-Z][A-Z0-9_]*)["']""",

--- a/tests/test_env_parse.py
+++ b/tests/test_env_parse.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from src.graph.concurrency_probe import probe_concurrency_capability
-from src.utils.env_parse import env_bool, env_float, env_int
+from src.utils.env_parse import env_bool, env_float, env_int, env_int_clamped
 
 
 def test_env_bool_truthy_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,6 +30,13 @@ def test_env_int_warns_on_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("MATRYCA_TEST_INT_ENV", "not-a-number")
     assert env_int("MATRYCA_TEST_INT_ENV", 42) == 42
     assert any("MATRYCA_TEST_INT_ENV" in warning for warning in warnings)
+
+
+def test_env_int_clamped_enforces_bounds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_TEST_CLAMP", "500")
+    assert env_int_clamped("MATRYCA_TEST_CLAMP", 10, minimum=1, maximum=100) == 100
+    monkeypatch.setenv("MATRYCA_TEST_CLAMP", "0")
+    assert env_int_clamped("MATRYCA_TEST_CLAMP", 10, minimum=1, maximum=100) == 1
 
 
 def test_env_float_warns_on_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_shadow_config.py
+++ b/tests/test_shadow_config.py
@@ -1,9 +1,35 @@
-"""Tests for Shadow DB env flag (#184)."""
+"""Tests for Shadow DB env flags and writer-lock safety."""
 
 from __future__ import annotations
 
+import os
+import sys
+from pathlib import Path
+
 import pytest
-from src.shadow.config import shadow_db_enabled
+from src.graph.io_retry import PageLockUnavailableError
+from src.graph.path_sandbox import PathTraversalSecurityError
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.config import (
+    shadow_db_busy_timeout_ms,
+    shadow_db_enabled,
+    shadow_rebuild_lock_timeout_s,
+    shadow_writer_lock_timeout_s,
+)
+from src.shadow.connection import open_shadow_db
+from src.shadow.meta import (
+    META_GENERATION,
+    META_LAST_FULL_SYNC_COMPLETED,
+    META_LAST_SYNC_ERROR,
+    get_meta,
+)
+from src.shadow.writer_lock import shadow_rebuild_lock, shadow_writer_lock_path
+from src.utils.platform_lock import clear_flock_depths, flock_depths
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fcntl flock is not available on Windows",
+)
 
 
 def test_shadow_db_enabled_default_false(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -27,3 +53,127 @@ def test_shadow_db_enabled_true_tokens(
 ) -> None:
     monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", value)
     assert shadow_db_enabled() is True
+
+
+def test_shadow_busy_timeout_ms_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS", "999999")
+    assert shadow_db_busy_timeout_ms() == 60_000
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS", "-5")
+    assert shadow_db_busy_timeout_ms() == 0
+
+
+def test_shadow_writer_lock_timeout_s_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S", raising=False)
+    assert shadow_writer_lock_timeout_s() == 10.0
+    monkeypatch.setenv("MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S", "0")
+    assert shadow_writer_lock_timeout_s() == 1.0
+    monkeypatch.setenv("MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S", "9999")
+    assert shadow_writer_lock_timeout_s() == 300.0
+
+
+def test_shadow_rebuild_lock_timeout_s_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S", raising=False)
+    assert shadow_rebuild_lock_timeout_s() == 120.0
+    monkeypatch.setenv("MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S", "9999")
+    assert shadow_rebuild_lock_timeout_s() == 600.0
+
+
+def test_shadow_writer_lock_path_rejects_cache_symlink_escape(tmp_path: Path) -> None:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    (graph / ".matryca_semantic_cache").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(PathTraversalSecurityError):
+        shadow_writer_lock_path(graph)
+
+
+def test_writer_lock_reentrancy_keyed_by_resolved_lock_path(tmp_path: Path) -> None:
+    graph_a = tmp_path / "vault-a"
+    graph_b = tmp_path / "vault-b"
+    (graph_a / "pages").mkdir(parents=True)
+    (graph_b / "pages").mkdir(parents=True)
+    lock_a = shadow_writer_lock_path(graph_a)
+    lock_b = shadow_writer_lock_path(graph_b)
+    assert lock_a != lock_b
+    clear_flock_depths()
+    with shadow_rebuild_lock(graph_a):
+        depths = flock_depths()
+        assert depths[str(lock_a.resolve(strict=False))] == 1
+        assert str(lock_b.resolve(strict=False)) not in depths
+
+
+def test_page_lock_unavailable_does_not_invalidate_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    page = graph / "pages" / "Stable.md"
+    page.write_text(
+        "- stable\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        generation_before = get_meta(conn, META_GENERATION)
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S", "1")
+    import subprocess
+    import sys
+    import time
+
+    repo_root = Path(__file__).resolve().parents[1]
+    ready_file = tmp_path / "rebuild-holder.ready"
+    hold_script = f"""
+import os
+import time
+from pathlib import Path
+from src.shadow.writer_lock import shadow_rebuild_lock
+
+os.environ["MATRYCA_SHADOW_DB_ENABLED"] = "true"
+graph = Path({str(graph)!r})
+ready = Path({str(ready_file)!r})
+with shadow_rebuild_lock(graph):
+    ready.write_text("ok", encoding="utf-8")
+    time.sleep(5)
+"""
+    proc = subprocess.Popen([sys.executable, "-c", hold_script], cwd=str(repo_root))
+    try:
+        deadline = time.monotonic() + 5.0
+        while not ready_file.is_file() and proc.poll() is None:
+            if time.monotonic() >= deadline:
+                pytest.fail("holder subprocess did not acquire rebuild lock in time")
+            time.sleep(0.05)
+        with pytest.raises(PageLockUnavailableError):
+            rebuild_shadow_from_graph(graph)
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert get_meta(conn, META_GENERATION) == generation_before
+        assert (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip() == ""
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork unavailable")
+def test_fork_child_clears_flock_depth_state() -> None:
+    clear_flock_depths()
+    flock_depths()["synthetic-depth"] = 2
+    pid = os.fork()
+    if pid == 0:
+        child_depths = flock_depths()
+        assert "synthetic-depth" not in child_depths
+        os._exit(0)
+    _, status = os.waitpid(pid, 0)
+    assert os.WEXITSTATUS(status) == 0
+    clear_flock_depths()

--- a/tests/test_shadow_hardening_axis1_concurrency.py
+++ b/tests/test_shadow_hardening_axis1_concurrency.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import sqlite3
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -39,11 +40,13 @@ from src.shadow.sync import (
     sync_page_into_connection,
     sync_page_to_shadow,
 )
+from src.shadow.writer_lock import shadow_writer_lock, shadow_writer_lock_path
 
 
 @pytest.fixture(autouse=True)
 def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS", "200")
     reset_shadow_runtime_state_for_tests()
     reset_shadow_bootstrap_checked_for_tests()
     reset_shadow_sync_bridge_for_tests()
@@ -258,7 +261,6 @@ def _multiprocess_rebuild_worker(graph_str: str) -> None:
     rebuild_shadow_from_graph(graph_str)
 
 
-@pytest.mark.xfail(strict=True, reason="A1-PROC-01/02: no cross-process rebuild lock (#262)")
 @pytest.mark.slow
 def test_a1_cross_process_rebuild_completes_while_sqlite_writer_active(
     tmp_path: Path,
@@ -273,15 +275,16 @@ def test_a1_cross_process_rebuild_completes_while_sqlite_writer_active(
         )
     rebuild_shadow_from_graph(graph)
 
-    holder = open_shadow_db(graph)
-    holder.execute("BEGIN IMMEDIATE")
-    try:
-        ctx = mp.get_context("spawn")
-        with ctx.Pool(processes=1) as pool:
-            pool.apply(_multiprocess_rebuild_worker, (str(graph),))
-    finally:
-        holder.rollback()
-        holder.close()
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=1) as pool:
+        with shadow_writer_lock(graph):
+            holder = open_shadow_db(graph)
+            holder.execute("BEGIN IMMEDIATE")
+            async_rebuild = pool.apply_async(_multiprocess_rebuild_worker, (str(graph),))
+            time.sleep(0.2)
+            holder.rollback()
+            holder.close()
+        async_rebuild.get(timeout=60)
 
     conn = open_shadow_db(graph)
     try:
@@ -293,11 +296,9 @@ def test_a1_cross_process_rebuild_completes_while_sqlite_writer_active(
         conn.close()
 
 
-def test_a1_rebuild_lock_is_in_process_only_probe() -> None:
-    """A1-PROC-02 probe (non-gating): documents in-process ``threading.Lock`` scope."""
-    from src.shadow.runtime_state import rebuild_lock_for
-
-    lock_a = rebuild_lock_for("/tmp/vault-a")
-    lock_b = rebuild_lock_for("/tmp/vault-a")
-    assert lock_a is lock_b
-    assert type(lock_a).__name__ == "lock"
+def test_a1_shadow_writer_lock_is_cross_process(tmp_path: Path) -> None:
+    """A1-PROC-02: shadow writers share a graph-root flock sidecar under semantic cache."""
+    graph = _minimal_graph(tmp_path)
+    lock_path = shadow_writer_lock_path(graph)
+    assert lock_path.name == "shadow.writer.flock"
+    assert lock_path.parent.name == ".matryca_semantic_cache"

--- a/tests/test_shadow_writer_lock.py
+++ b/tests/test_shadow_writer_lock.py
@@ -1,0 +1,217 @@
+"""Cross-process shadow writer flock and SQLite busy handling (#262)."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from src.graph.io_retry import PageLockUnavailableError
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.connection import open_shadow_db
+from src.shadow.meta import META_LAST_FULL_SYNC_COMPLETED, get_meta
+from src.shadow.runtime_state import reset_shadow_runtime_state_for_tests
+from src.shadow.sync import sync_page_to_shadow
+from src.shadow.writer_lock import shadow_writer_lock, shadow_writer_lock_path
+from src.utils.platform_lock import clear_flock_depths
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fcntl flock is not available on Windows",
+)
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS", "200")
+    reset_shadow_runtime_state_for_tests()
+    clear_flock_depths()
+
+
+def _minimal_graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    (graph / "journals").mkdir(parents=True)
+    return graph
+
+
+def _write_page(graph: Path, rel: str, body: str) -> Path:
+    target = graph / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _multiprocess_rebuild_worker(graph_str: str) -> None:
+    os.environ["MATRYCA_SHADOW_DB_ENABLED"] = "true"
+    from src.shadow.bootstrap import rebuild_shadow_from_graph
+
+    rebuild_shadow_from_graph(graph_str)
+
+
+def test_shadow_writer_lock_path_under_semantic_cache(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    lock_path = shadow_writer_lock_path(graph)
+    assert lock_path.name == "shadow.writer.flock"
+    assert lock_path.parent.name == ".matryca_semantic_cache"
+
+
+def test_concurrent_rebuilds_serialize_across_processes(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    for index in range(3):
+        _write_page(
+            graph,
+            f"pages/P{index}.md",
+            f"- p{index}\n  id:: {index:08d}-1111-4111-8111-111111111111\n",
+        )
+    rebuild_shadow_from_graph(graph)
+
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=2) as pool:
+        results = [
+            pool.apply_async(_multiprocess_rebuild_worker, (str(graph),)),
+            pool.apply_async(_multiprocess_rebuild_worker, (str(graph),)),
+        ]
+        for result in results:
+            result.get(timeout=60)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 3
+    finally:
+        conn.close()
+
+
+def test_rebuild_and_incremental_sync_serialize(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Base.md",
+        "- base\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    late = _write_page(
+        graph,
+        "pages/Late.md",
+        "- late\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n",
+    )
+
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=1) as pool:
+        with shadow_writer_lock(graph):
+            async_rebuild = pool.apply_async(_multiprocess_rebuild_worker, (str(graph),))
+            time.sleep(0.15)
+            sync_page_to_shadow(graph, late)
+        async_rebuild.get(timeout=60)
+
+    conn = open_shadow_db(graph)
+    try:
+        titles = {row[0] for row in conn.execute("SELECT title FROM pages").fetchall()}
+        assert {"Base", "Late"} <= titles
+    finally:
+        conn.close()
+
+
+def test_different_graph_roots_do_not_block_each_other(tmp_path: Path) -> None:
+    graph_a = _minimal_graph(tmp_path / "a")
+    graph_b = _minimal_graph(tmp_path / "b")
+    _write_page(
+        graph_a,
+        "pages/A.md",
+        "- a\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+    )
+    _write_page(
+        graph_b,
+        "pages/B.md",
+        "- b\n  id:: bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb\n",
+    )
+    rebuild_shadow_from_graph(graph_a)
+    rebuild_shadow_from_graph(graph_b)
+
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=2) as pool:
+        start = time.monotonic()
+        results = [
+            pool.apply_async(_multiprocess_rebuild_worker, (str(graph_a),)),
+            pool.apply_async(_multiprocess_rebuild_worker, (str(graph_b),)),
+        ]
+        for result in results:
+            result.get(timeout=60)
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 8.0
+
+
+def test_writer_lock_released_after_process_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/Seed.md",
+        "- seed\n  id:: cccccccc-cccc-4ccc-8ccc-cccccccccccc\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    monkeypatch.setenv("MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S", "1")
+    repo_root = Path(__file__).resolve().parents[1]
+    ready_file = tmp_path / "holder.ready"
+    hold_script = f"""
+import os
+import time
+from pathlib import Path
+from src.shadow.writer_lock import shadow_writer_lock
+
+os.environ["MATRYCA_SHADOW_DB_ENABLED"] = "true"
+os.environ["MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S"] = "120"
+graph = Path({str(graph)!r})
+ready = Path({str(ready_file)!r})
+with shadow_writer_lock(graph):
+    ready.write_text("ok", encoding="utf-8")
+    time.sleep(30)
+"""
+    proc = subprocess.Popen([sys.executable, "-c", hold_script], cwd=str(repo_root))
+    try:
+        deadline = time.monotonic() + 5.0
+        while not ready_file.is_file() and proc.poll() is None:
+            if time.monotonic() >= deadline:
+                pytest.fail("holder subprocess did not acquire writer lock in time")
+            time.sleep(0.05)
+        with pytest.raises(PageLockUnavailableError), shadow_writer_lock(graph):
+            pass
+        proc.kill()
+        proc.wait(timeout=5)
+        with shadow_writer_lock(graph):
+            pass
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_sqlite_busy_surfaces_without_masking_corruption(tmp_path: Path) -> None:
+    graph = _minimal_graph(tmp_path)
+    page = _write_page(
+        graph,
+        "pages/Lock.md",
+        "- lock\n  id:: eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee\n",
+    )
+    rebuild_shadow_from_graph(graph)
+
+    holder = open_shadow_db(graph)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            sync_page_to_shadow(graph, page)
+    finally:
+        holder.rollback()
+        holder.close()


### PR DESCRIPTION
## Summary

Closes #262.

Introduces two-layer shadow writer coordination scoped to graph-root writers only (no routing or health validation changes):

1. **Advisory flock** — `shadow.writer.flock` under `.matryca_semantic_cache/` serializes `rebuild_shadow_from_graph`, `sync_page_to_shadow`, and `delete_shadow_page_by_file_path`. Lock path is sandboxed (`assert_path_within_graph`); reentrancy is keyed by resolved lock path + thread; `os.register_at_fork(after_in_child=clear_flock_depths)` prevents inherited in-memory depth state after `fork()`.
2. **SQLite busy** — `PRAGMA busy_timeout` via `MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS` (clamped `[0, 60000]` through `env_int_clamped`).

### Impact (GitNexus, pre-merge)

| Symbol | Risk | Blast radius |
|--------|------|----------------|
| `rebuild_shadow_from_graph` | **CRITICAL** | `ensure_shadow_runtime_at_startup` → `prepare_matryca_runtime` → daemon cluster/audit/foreground, provision L1 |
| `open_shadow_db` | **CRITICAL** | All shadow read/write opens; change is additive `busy_timeout` only |
| `sync_page_to_shadow` | LOW | post-write bridge, watchdog, deferred replay |

Read paths (`resolve_shadow_health`, FTS/subtree routing) stay outside the writer flock.

### Timeout split (review point)

Post-write and watchdog paths use **`MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` default 10s** so interactive CLI/MCP post-write does not block for minutes. Full rebuild uses **`MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` default 120s** because bootstrap may scan large vaults under contention. Operators can tune both independently.

`PageLockUnavailableError` is raised before rebuild mutates meta — generation and `last_sync_error` remain on the last committed snapshot (tested).

## Test plan

- [x] `make ci` green (1126 passed, 1 xfailed #264 probe)
- [x] A1-PROC xfail removed — cross-process rebuild completes under writer flock
- [x] Twin rebuild serialization, rebuild vs incremental, independent graph roots
- [x] Stale flock recoverable after process exit; symlink escape rejected
- [x] `tests/test_env_example_coverage.py` recognizes new env keys
- [x] `detect_changes(compare main)` — writer coordination scope only


Made with [Cursor](https://cursor.com)