### PR TITLE
fix(shadow): meta/pages health consistency (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- **Shadow health meta/pages consistency (#264)** — `resolve_shadow_health` and `/api/state` no longer report `ready` when `shadow_meta` page counts diverge from the `pages` table.
+
 - **Shadow cross-process writer coordination (#262)** — advisory `shadow.writer.flock` per graph root serializes rebuild, incremental sync, and delete writers; split flock timeouts (`MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` default 10s for post-write/watchdog, `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` default 120s for full rebuild) and `PRAGMA busy_timeout` via `MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS` (clamped) prevent infinite SQLite waits without masking corruption errors.
 
 - **UI server test isolation** — `test_get_state_returns_daemon_checkpoint` clears `MATRYCA_SHADOW_DB_ENABLED` so local env cannot flip `shadow_db` expectations.

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -9,9 +9,11 @@ from ..graph.path_sandbox import resolved_graph_root
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
 from .meta import (
+    META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_COMPLETED,
     META_LAST_SYNC_ERROR,
     META_SCHEMA_VERSION,
+    META_SOURCE_PAGE_COUNT,
     get_meta,
 )
 from .runtime_state import is_shadow_bootstrapping
@@ -24,6 +26,32 @@ class ShadowHealthState(StrEnum):
     READY = "ready"
     STALE = "stale"
     ERROR = "error"
+
+
+def _parse_meta_page_count(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return max(0, int(text))
+    except ValueError:
+        return None
+
+
+def shadow_meta_matches_page_rows(
+    *,
+    indexed_page_count: str | None,
+    source_page_count: str | None,
+    actual_page_count: int,
+) -> bool:
+    """Return whether persisted meta counts match the ``pages`` table row count."""
+    indexed = _parse_meta_page_count(indexed_page_count)
+    source = _parse_meta_page_count(source_page_count)
+    if indexed is not None and indexed != actual_page_count:
+        return False
+    return source is None or source == actual_page_count
 
 
 def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
@@ -46,10 +74,21 @@ def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
             return ShadowHealthState.ERROR
         completed = (get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) or "").strip().lower()
         if completed == "true":
+            actual_pages = int(conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0])
+            if not shadow_meta_matches_page_rows(
+                indexed_page_count=get_meta(conn, META_INDEXED_PAGE_COUNT),
+                source_page_count=get_meta(conn, META_SOURCE_PAGE_COUNT),
+                actual_page_count=actual_pages,
+            ):
+                return ShadowHealthState.STALE
             return ShadowHealthState.READY
         return ShadowHealthState.STALE
     finally:
         conn.close()
 
 
-__all__ = ["ShadowHealthState", "resolve_shadow_health"]
+__all__ = [
+    "ShadowHealthState",
+    "resolve_shadow_health",
+    "shadow_meta_matches_page_rows",
+]

--- a/src/shadow/state_api.py
+++ b/src/shadow/state_api.py
@@ -12,6 +12,7 @@ from ..graph.path_sandbox import resolved_graph_root
 from ..utils.console_sanitize import sanitize_for_console
 from .config import shadow_db_enabled
 from .connection import shadow_db_path
+from .health import shadow_meta_matches_page_rows
 from .meta import (
     META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_AT,
@@ -82,10 +83,10 @@ def _last_full_sync_at(meta: dict[str, str | None]) -> str | None:
     return value or None
 
 
-def _read_meta_readonly(db_path: Path) -> dict[str, str | None]:
+def _read_meta_readonly(db_path: Path) -> tuple[dict[str, str | None], int]:
     connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     try:
-        return {
+        meta = {
             META_SCHEMA_VERSION: get_meta(connection, META_SCHEMA_VERSION),
             META_LAST_SYNC_ERROR: get_meta(connection, META_LAST_SYNC_ERROR),
             META_LAST_FULL_SYNC_AT: get_meta(connection, META_LAST_FULL_SYNC_AT),
@@ -93,16 +94,24 @@ def _read_meta_readonly(db_path: Path) -> dict[str, str | None]:
             META_SOURCE_PAGE_COUNT: get_meta(connection, META_SOURCE_PAGE_COUNT),
             META_INDEXED_PAGE_COUNT: get_meta(connection, META_INDEXED_PAGE_COUNT),
         }
+        page_count = int(connection.execute("SELECT COUNT(*) FROM pages").fetchone()[0])
+        return meta, page_count
     finally:
         connection.close()
 
 
-def _state_from_meta(meta: dict[str, str | None]) -> ShadowDbStateValue:
+def _state_from_meta(meta: dict[str, str | None], *, actual_page_count: int) -> ShadowDbStateValue:
     sync_error = (meta.get(META_LAST_SYNC_ERROR) or "").strip()
     if sync_error:
         return "error"
     completed = (meta.get(META_LAST_FULL_SYNC_COMPLETED) or "").strip().lower()
     if completed == "true":
+        if not shadow_meta_matches_page_rows(
+            indexed_page_count=meta.get(META_INDEXED_PAGE_COUNT),
+            source_page_count=meta.get(META_SOURCE_PAGE_COUNT),
+            actual_page_count=actual_page_count,
+        ):
+            return "stale"
         return "ready"
     return "stale"
 
@@ -139,7 +148,7 @@ def resolve_shadow_db_state_for_api(graph_root: Path | str) -> ShadowDbStateResp
         return ShadowDbStateResponse(enabled=True, state="stale")
 
     try:
-        meta = _read_meta_readonly(db_path)
+        meta, page_count = _read_meta_readonly(db_path)
     except sqlite3.Error as exc:
         return ShadowDbStateResponse(
             enabled=True,
@@ -155,7 +164,7 @@ def resolve_shadow_db_state_for_api(graph_root: Path | str) -> ShadowDbStateResp
             last_sync_error="Shadow schema version mismatch",
         )
 
-    state = _state_from_meta(meta)
+    state = _state_from_meta(meta, actual_page_count=page_count)
     sync_error = (meta.get(META_LAST_SYNC_ERROR) or "").strip()
     error = _bounded_error_message(sync_error) if state == "error" else None
     return _snapshot_from_meta(state=state, meta=meta, last_sync_error=error)

--- a/tests/test_shadow_hardening_axis1_concurrency.py
+++ b/tests/test_shadow_hardening_axis1_concurrency.py
@@ -120,10 +120,6 @@ def test_a1_rebuild_injected_failure_preserves_committed_generation(tmp_path: Pa
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="A1-META-01: health ready ignores meta/row mismatch (#264)",
-)
 def test_a1_health_not_ready_when_meta_completed_but_pages_empty(tmp_path: Path) -> None:
     """A1-META-01: meta/pages mismatch must report ``stale`` or ``error``, never ``ready``."""
     graph = _minimal_graph(tmp_path)

--- a/tests/test_shadow_state_api.py
+++ b/tests/test_shadow_state_api.py
@@ -212,6 +212,35 @@ def test_resolve_shadow_db_state_sqlite_read_failure(
     assert len(snapshot.last_sync_error) <= 200
 
 
+def test_resolve_shadow_db_state_stale_when_meta_completed_but_pages_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    _write_page(
+        graph,
+        "pages/Alpha.md",
+        "- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        set_meta(conn, META_LAST_FULL_SYNC_COMPLETED, "true")
+        set_meta(conn, META_LAST_SYNC_ERROR, "")
+        set_meta(conn, META_SOURCE_PAGE_COUNT, "1")
+        set_meta(conn, META_INDEXED_PAGE_COUNT, "1")
+        conn.execute("DELETE FROM pages")
+        conn.commit()
+    finally:
+        conn.close()
+
+    snapshot = resolve_shadow_db_state_for_api(graph)
+
+    assert snapshot.state == "stale"
+    assert snapshot.last_sync_error is None
+
+
 def test_shadow_db_response_model_has_stable_keys() -> None:
     payload = ShadowDbStateResponse().model_dump()
     assert set(payload.keys()) == set(DISABLED_SHADOW_DB.keys())


### PR DESCRIPTION
## Summary

Closes #264.

`resolve_shadow_health` and `resolve_shadow_db_state_for_api` now compare `source_page_count` / `indexed_page_count` against `SELECT COUNT(*) FROM pages` before reporting **`ready`**. On mismatch → **`stale`** (Markdown/BM25 fallback preserved). No automatic rebuild in this PR.

### Impact (GitNexus)

| Symbol | Risk | Consumers |
|--------|------|-----------|
| `resolve_shadow_health` | **HIGH** | `shadow_read_port_ready`, BM25 routing, subtree CTE port |

## Test plan

- [x] `make ci` green (1139 passed, 0 xfailed)
- [x] A1-META-01 xfail removed — `test_a1_health_not_ready_when_meta_completed_but_pages_empty`
- [x] `test_resolve_shadow_db_state_stale_when_meta_completed_but_pages_empty`


Made with [Cursor](https://cursor.com)