### PR TITLE
docs(knowledge): add graph-plane and shadow-db architecture pilots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+- **Documentation** — extended `docs/knowledge/architecture/` with experimental `graph-plane.md` and `shadow-db.md` pilots; added `legacy_sources` validation to `make docs-check`.
 - **Documentation** — added `docs/knowledge/` OKF-inspired pilot bundle (`profile.md`, architecture system-overview, curated `inventory.json` + generated `inventory.md`) with `make docs-check` / `make docs-audit`; discovery index only — legacy `docs/ARCHITECTURE.md` and other canonical paths remain authoritative during Phase 1.
 
 ## [2.0.0-alpha.1] - 2026-07-18

--- a/docs/knowledge/architecture/graph-plane.md
+++ b/docs/knowledge/architecture/graph-plane.md
@@ -1,0 +1,111 @@
+---
+type: Architecture
+title: Graph plane
+description: Markdown SSOT, parser-backed mutation plane, OCC, locks, and path sandbox boundaries.
+resource: src/graph/
+tags: [graph, occ, parser, sandbox, graph-dispatch]
+timestamp: 2026-07-18T00:00:00Z
+status: experimental
+audience: [maintainer, contributor, agent]
+owner: graph-runtime
+supersedes: []
+related:
+  - /architecture/system-overview.md
+  - /architecture/shadow-db.md
+legacy_sources:
+  - ../../ARCHITECTURE.md
+  - ../../openspec/logseq-paradigm.md
+  - ../../openspec/security-sandbox.md
+  - ../../CLEAN_CODE_ARCHITECTURE.md
+---
+
+# Graph plane
+
+> **Pilot document — [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) remains authoritative during Phase 1.**
+
+The graph plane is Matryca's **headless mutation and read contract** over Logseq OG Markdown on disk. All surfaces (daemon, MCP, CLI) share the same path: `graph_dispatch.py` delegates to `dispatch_*_handlers.py` and `src/graph/` primitives. Logseq Markdown under `LOGSEQ_GRAPH_PATH` is the **system of record**.
+
+## Parser-backed spatial truth
+
+**[logseq-matryca-parser](https://github.com/MarcoPorcellato/logseq-matryca-parser)** (`>=1.6.0`) owns block hierarchy, indentation, and `id::` semantics. Matryca does not maintain a competing full-file AST for vault-wide work.
+
+| Concern | Module(s) |
+| --- | --- |
+| Block/page surgery | `markdown_blocks.py`, `property_line_edit.py`, `page_properties.py` |
+| Fence-safe scanning | `global_fence_scanner.py` |
+| Property grammar | `mldoc_properties.py`, `mldoc_guards.py` |
+| Path confinement | `path_sandbox.py` — `is_relative_to(graph_root)` before every read/write |
+| Atomic commits | `atomic_write_bytes` — temp file, `fsync`, `os.replace` |
+| Agent read adapter | `src/rag/matryca_hooks.py` |
+
+Normative block/property rules: [`openspec/logseq-paradigm.md`](../../openspec/logseq-paradigm.md).
+
+## `graph_dispatch` routing
+
+| Handler module | Mega-tool | Role |
+| --- | --- | --- |
+| `dispatch_read_handlers.py` | `read_graph_data` | Page, subtree, xray, dashboard |
+| `dispatch_search_handlers.py` | `search_graph` | bm25, semantic, regex, journal_tasks |
+| `dispatch_mutate_handlers.py` | `mutate_graph` | write_outline, edit_property, append_journal |
+| `dispatch_refactor_handlers.py` | `refactor_blocks` | split, reparent, flashcards |
+| `dispatch_lint_handlers.py` | `run_linter` | unify_tags, block_refs, wiki scan |
+
+Subtree reads use **`GraphReadPort`** (`MarkdownGraphRepository` by default; optional shadow routing — see [Shadow DB](shadow-db.md)). Writes flow through OCC-aware helpers such as `_headless_append_child` in `graph_dispatch.py`.
+
+## Safe-Sync read/write boundary
+
+Tier-2 agents read through Plumber tools and write through atomic mutators. They must not scrape daemon JSON sidecars as L2 truth or touch Logseq's internal app database.
+
+```mermaid
+flowchart LR
+  subgraph readPlane [READ plane]
+    R1[read_graph_data]
+    R2[search_graph]
+    MD[(pages/ journals/ md)]
+    R1 --> MD
+    R2 --> MD
+  end
+
+  subgraph writePlane [WRITE plane]
+    W1[mutate_graph refactor_blocks]
+    Gate[OCC plus page_rmw_lock]
+    W1 --> Gate --> MD
+  end
+
+  Forbidden[Logseq app SQLite/KV forbidden]
+  MD -.-> Forbidden
+```
+
+Contract detail: [`openspec/llm-os-instructions.md`](../../openspec/llm-os-instructions.md).
+
+## Optimistic concurrency control (OCC)
+
+Local LLM work is slow; humans keep editing. Matryca uses **two complementary layers**:
+
+| Layer | Mechanism | Prevents |
+| --- | --- | --- |
+| Serialization | `page_rmw_lock` — in-process registry + cross-process flock sidecar | Torn RMW interleaving |
+| Lost-update detection | `baseline_mtime` / `st_mtime_ns` snapshot → verify → commit | Stale LLM output overwriting fresher bytes |
+
+Canonical order: `occ_snapshot` → inference → `occ_verify_before_write` → `page_rmw_lock` → re-read + drift check → `atomic_write_bytes_if_unchanged`. Phase-2 cognitive lint holds the page lock only for the final commit, not across inference.
+
+`platform_lock.py` unifies page RMW flock and JSON sidecar flock (NB acquire, exponential backoff, thread-local reentrancy). Hub pages (`write_generated_hub_page`) snapshot mtime before compile and skip gracefully if humans edit during generation.
+
+## Sandbox and reads
+
+| Concern | Implementation |
+| --- | --- |
+| Path traversal | `path_sandbox.assert_path_within_graph` |
+| Graph UTF-8 reads | `read_graph_file_text()` — enforced by CI `sandbox-read-check` |
+| Bounded JSON sidecars | `read_bounded_json()` + `MATRYCA_JSON_MAX_BYTES` |
+| Page lock registry | LRU cap in `page_write_lock.py`; cross-process sidecar via `platform_lock` |
+
+Full security contract: [`openspec/security-sandbox.md`](../../openspec/security-sandbox.md). Layer map: [`CLEAN_CODE_ARCHITECTURE.md`](../../CLEAN_CODE_ARCHITECTURE.md).
+
+## Legacy deep dives
+
+| Topic | Legacy document |
+| --- | --- |
+| Full OCC sequence diagrams | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#optimistic-concurrency-control-occ) |
+| Trust & Safety tiers | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#trust--safety-levels) |
+| JSON sidecar flock details | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#json-sidecar-concurrency-v1100--v1106) |

--- a/docs/knowledge/architecture/index.md
+++ b/docs/knowledge/architecture/index.md
@@ -1,17 +1,17 @@
 # Architecture
 
-Pilot index for system structure. **Legacy [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) remains authoritative in Phase 1.**
+Pilot index for system structure. **Legacy [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) remains authoritative during Phase 1.**
 
 ## Current pilot
 
-- [System overview](system-overview.md) — Three-surface runtime, shared mutation plane, vault topology, daemon phases.
+- [System overview](system-overview.md) — Three-surface runtime, vault topology, daemon phase model.
+- [Graph plane](graph-plane.md) — Markdown SSOT, parser, OCC, locks, sandbox, `graph_dispatch`.
+- [Shadow DB](shadow-db.md) — Opt-in SQLite read cache, sync, health, routing, fallback (`v2.0.0-alpha`+).
 
-## Planned concepts (Phase 2+)
+## Planned concepts
 
 | Concept | Legacy source |
 | --- | --- |
-| Graph plane | [`docs/CLEAN_CODE_ARCHITECTURE.md`](../../CLEAN_CODE_ARCHITECTURE.md), [`docs/openspec/logseq-paradigm.md`](../../openspec/logseq-paradigm.md) |
-| Shadow DB | [`docs/roadmaps/ROADMAP_V2_SHADOW_DB.md`](../../roadmaps/ROADMAP_V2_SHADOW_DB.md) |
 | Daemon runtime | [`docs/CLEAN_CODE_ARCHITECTURE.md`](../../CLEAN_CODE_ARCHITECTURE.md#maintenance-daemon-module-map-issue-58) |
 | Sovereign UI | [`docs/openspec/live-telemetry-ui.md`](../../openspec/live-telemetry-ui.md) |
 | Prompt stack | [`docs/PROMPT_ARCHITECTURE.md`](../../PROMPT_ARCHITECTURE.md) |

--- a/docs/knowledge/architecture/shadow-db.md
+++ b/docs/knowledge/architecture/shadow-db.md
@@ -1,0 +1,108 @@
+---
+type: Architecture
+title: Shadow DB read architecture
+description: Opt-in SQLite read cache, synchronization, health, routing, and fallback boundaries.
+resource: src/shadow/
+tags: [shadow-db, sqlite, fts5, cte, concurrency]
+timestamp: 2026-07-18T00:00:00Z
+status: experimental
+audience: [maintainer, contributor, operator, agent]
+owner: shadow-runtime
+since: v2.0.0-alpha
+supersedes: []
+related:
+  - /architecture/system-overview.md
+  - /architecture/graph-plane.md
+legacy_sources:
+  - ../../ARCHITECTURE.md
+  - ../../roadmaps/ROADMAP_V2_SHADOW_DB.md
+  - ../../../llms.txt
+---
+
+# Shadow DB read architecture
+
+> **Pilot document — [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) remains authoritative during Phase 1.**
+
+Logseq Markdown on disk remains the **system of record**. `shadow.sqlite` is an **opt-in read cache** owned by the daemon under `.matryca_semantic_cache/`. It accelerates hierarchical reads when healthy; it never replaces vault writes or OCC on `.md` files.
+
+**Introduced:** `v2.0.0-alpha` (opt-in read path). **Current hardening baseline:** `v2.0.0-alpha.1` (writer coordination and meta/pages health — see below).
+
+## Activation gate
+
+| Check | Module / symbol |
+| --- | --- |
+| Env flag (default off) | `shadow_db_enabled()` — `MATRYCA_SHADOW_DB_ENABLED` |
+| Runtime health | `resolve_shadow_health()` → `ShadowHealthState` |
+| Read port selection | `get_graph_read_port()` → `ShadowGraphRepository` when `shadow_read_port_ready()` |
+
+Routing applies only when the flag is **on** and health is **`ready`**. Otherwise `search_graph(bm25)` uses generational BM25 and `read_graph_data(subtree)` uses `MarkdownGraphRepository` — unchanged v1 behavior.
+
+## Schema and memory tables
+
+Canonical DDL: [`src/shadow/schema.py`](../../../src/shadow/schema.py). Default path: `shadow_db_path()` → `<vault>/.matryca_semantic_cache/shadow.sqlite`.
+
+| Layer | Tables | Runtime status |
+| --- | --- | --- |
+| Meta | `shadow_meta` | **Active** — schema version, sync timestamps, error keys |
+| Read cache | `pages`, `blocks`, `block_refs`, `blocks_fts` | **Active** — FTS5 BM25 + recursive CTE subtree reads |
+| Memory graph | `memory_nodes`, `memory_edges`, … | **Schema only** — reserved for biological-memory Phase 4; **not** a shipped read/write path today |
+
+Do not treat memory-graph tables as a live feature; they are forward-compatible DDL, not operator surface.
+
+## Lifecycle
+
+```mermaid
+flowchart TB
+  Flag[MATRYCA_SHADOW_DB_ENABLED]
+  Boot[ensure_shadow_runtime_at_startup]
+  Rebuild[rebuild_shadow_from_graph]
+  Sync[sync_page_to_shadow via post_write bridge]
+  Health[resolve_shadow_health]
+  Route[get_graph_read_port]
+
+  Flag -->|false| Fallback[MarkdownGraphRepository + generational BM25]
+  Flag -->|true| Boot
+  Boot --> Rebuild
+  Rebuild --> Sync
+  Sync --> Health
+  Health -->|ready| Route
+  Health -->|disabled bootstrapping stale error| Fallback
+```
+
+| Stage | Key symbols |
+| --- | --- |
+| Bootstrap / reconcile | `shadow_needs_bootstrap`, `rebuild_shadow_from_graph`, `ensure_shadow_runtime_at_startup` |
+| Incremental sync | `sync_page_to_shadow`, `ensure_shadow_sync_bridge` (hooks `post_write`) |
+| FTS search | `search_blocks_fts` → `handle_search_bm25` when routed |
+| Subtree read | `query_subtree_by_block_uuid` → `ShadowGraphRepository.read_subtree_markdown` |
+
+## Health and fallback
+
+`resolve_shadow_health` returns `disabled`, `bootstrapping`, `ready`, `stale`, or `error`. Since **v2.0.0-alpha.1**, `ready` requires `shadow_meta` page counts to match the `pages` table (`shadow_meta_matches_page_rows`) — mismatches downgrade to `stale` rather than serving inconsistent cache rows.
+
+SQLite errors, schema mismatch, or sync errors also force fallback; the vault Markdown path is unaffected.
+
+## Writer coordination (v2.0.0-alpha.1)
+
+Cross-process writers serialize through advisory **`shadow.writer.flock`** (`shadow_writer_lock`, `shadow_rebuild_lock` in `src/shadow/writer_lock.py`):
+
+| Operation | Lock | Default timeout env |
+| --- | --- | --- |
+| Post-write / incremental sync | `shadow_writer_lock` | `MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` (10s) |
+| Full rebuild | `shadow_rebuild_lock` | `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` (120s) |
+
+`MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS` sets SQLite `busy_timeout` on connections.
+
+## Operator surfaces
+
+- Sovereign UI: `/api/state.shadow_db` via `resolve_shadow_db_state_for_api`
+- Operator contract: [`llms.txt`](../../../llms.txt) §2.6
+- Roadmap checklist: [`ROADMAP_V2_SHADOW_DB.md`](../../roadmaps/ROADMAP_V2_SHADOW_DB.md)
+
+## Legacy deep dives
+
+| Topic | Document |
+| --- | --- |
+| Full architecture contract | [`ARCHITECTURE.md`](../../ARCHITECTURE.md) |
+| Epic tracking | [GitHub #20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20), [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) |
+| Graph write plane (unaffected) | [Graph plane](graph-plane.md) |

--- a/docs/knowledge/architecture/system-overview.md
+++ b/docs/knowledge/architecture/system-overview.md
@@ -9,7 +9,9 @@ status: experimental
 audience: [maintainer, contributor, operator]
 owner: core-runtime
 supersedes: []
-related: []
+related:
+  - /architecture/graph-plane.md
+  - /architecture/shadow-db.md
 legacy_sources:
   - ../../ARCHITECTURE.md
   - ../../CLEAN_CODE_ARCHITECTURE.md
@@ -21,7 +23,7 @@ legacy_sources:
 
 > **Pilot document — [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) remains authoritative during Phase 1.**
 
-Matryca Plumber is a **local-first background AI daemon** that mutates Logseq OG Markdown on disk. It is not a Logseq plugin, not a cloud service, and not dependent on Logseq HTTP JSON-RPC. Humans and the daemon co-edit the same `.md` trees; safety is enforced through **AST parity**, **optimistic concurrency control (OCC)**, **path sandboxing**, and operator-visible **Trust & Safety** tiers.
+Matryca Plumber is a **local-first background AI daemon** that mutates Logseq OG Markdown on disk. It is not a Logseq plugin, not a cloud service, and not dependent on Logseq HTTP JSON-RPC. Humans and the daemon co-edit the same `.md` trees. Safety on the graph plane — AST parity, OCC, path sandboxing — is documented in [Graph plane](graph-plane.md). Operator Trust & Safety tiers remain in the legacy architecture contract.
 
 ## Clean Architecture map
 
@@ -85,7 +87,7 @@ flowchart TB
 | **Sovereign UI** | `matryca plumber ui` → `src/cli/ui_server.py` | Monolithic Uvicorn on loopback; REST + static SPA; reads daemon checkpoints — never a second source of truth |
 | **MCP sidecar** | `matryca-plumber` with no CLI argv → `src/main.py` | Five polymorphic mega-tools plus `store_fact`, `ingest_document`, `import_tana`; lazy AST bootstrap on large vaults |
 
-The daemon orchestrator delegates to `daemon_*` modules (state, locks, semantic writes, page queue, LLM cycle). `graph_dispatch.py` routes read/search/mutate/refactor/lint through `dispatch_*_handlers.py` and `GraphReadPort` adapters. Canonical graph primitives live in `src/graph/` with agent/daemon shims.
+The daemon orchestrator delegates to `daemon_*` modules. `graph_dispatch.py` routes through `dispatch_*_handlers.py` and `GraphReadPort` adapters — see [Graph plane](graph-plane.md) for the mutation contract.
 
 ## System topology
 
@@ -172,13 +174,14 @@ stateDiagram-v2
 
 ### Journal pages — structural-only indexing
 
-Daily fleeting notes under **`journals/`** receive structural indexing only in Phase 2; semantic LLM indexing and dual embeddings are skipped. Pages under **`pages/`** receive full cognitive lint when env-gated modules are enabled. Spec detail: [`openspec/llm-performance.md`](../../openspec/llm-performance.md).
+Daily fleeting notes under **`journals/`** receive structural indexing only in Phase 2; semantic LLM indexing is skipped for journals. Detail: [`openspec/llm-performance.md`](../../openspec/llm-performance.md).
 
-## Shadow DB boundary (v2 pilot)
+## Architecture pilots
 
-Logseq Markdown on disk remains the **authoritative system of record**. The optional Shadow DB (`shadow.sqlite` under `.matryca_semantic_cache/`) is an **opt-in read cache** gated by `MATRYCA_SHADOW_DB_ENABLED` (default off). When enabled and healthy, BM25 search and subtree reads may route through SQLite FTS5 and recursive CTEs; otherwise the generational BM25 and `MarkdownGraphRepository` paths apply unchanged.
-
-Operator contract and roadmap: [`roadmaps/ROADMAP_V2_SHADOW_DB.md`](../../roadmaps/ROADMAP_V2_SHADOW_DB.md), [`llms.txt`](../../llms.txt) §2.6.
+| Topic | Pilot document |
+| --- | --- |
+| Graph plane (parser, OCC, sandbox) | [Graph plane](graph-plane.md) |
+| Shadow DB read cache (opt-in) | [Shadow DB](shadow-db.md) |
 
 ## Legacy deep dives
 
@@ -186,10 +189,11 @@ This pilot omits operational depth available in the legacy architecture contract
 
 | Topic | Legacy document |
 | --- | --- |
-| OCC, locks, hub writes | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#optimistic-concurrency-control-occ) |
+| Graph plane (full OCC/sandbox) | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#optimistic-concurrency-control-occ) · [pilot](graph-plane.md) |
+| Shadow DB | [`ARCHITECTURE.md`](../../ARCHITECTURE.md) · [pilot](shadow-db.md) |
 | Trust & Safety tiers | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#trust--safety-levels) |
 | Runtime bootstrap | [`ARCHITECTURE.md`](../../ARCHITECTURE.md#runtime-bootstrap) |
-| Sandboxing | [`openspec/security-sandbox.md`](../../openspec/security-sandbox.md) |
+| Sandboxing (normative) | [`openspec/security-sandbox.md`](../../openspec/security-sandbox.md) |
 | Release engineering | [`RELEASE_PROCESS.md`](../../RELEASE_PROCESS.md) |
 | Maintainer timeline | [`PROJECT_DIARY.md`](../../PROJECT_DIARY.md) |
 | Agent runtime law | [`SYSTEM_PROMPT.md`](../../SYSTEM_PROMPT.md) |

--- a/docs/knowledge/inventory.json
+++ b/docs/knowledge/inventory.json
@@ -208,7 +208,7 @@
       "destination": "docs/knowledge/architecture/",
       "action": "split",
       "supersedes": [],
-      "notes": "",
+      "notes": "Split pilots: system-overview, graph-plane, shadow-db (Phase 2). Legacy remains SSOT.",
       "missing": false
     },
     {
@@ -2621,7 +2621,7 @@
       "destination": "docs/knowledge/roadmaps/active/",
       "action": "migrate",
       "supersedes": [],
-      "notes": "",
+      "notes": "Pilot distilled in docs/knowledge/architecture/shadow-db.md (experimental).",
       "missing": false
     },
     {

--- a/docs/knowledge/profile.md
+++ b/docs/knowledge/profile.md
@@ -74,7 +74,7 @@ The pilot applies stricter producer rules inside `docs/knowledge/`:
 | `okf_target` | profile only | Target OKF revision |
 | `conformance` | profile only | `partial` until Phase 5 |
 
-Do not place legacy file paths in `related`. Use `legacy_sources` for transitional authority pointers.
+Do not place legacy file paths in `related`. Use `legacy_sources` for transitional authority pointers. `make docs-check` validates that each `legacy_sources` entry is repo-relative, resolves inside the repository root, and points to an existing file.
 
 ## Inventory extensions
 

--- a/scripts/docs_knowledge_check.py
+++ b/scripts/docs_knowledge_check.py
@@ -547,6 +547,50 @@ def resolve_bundle_link(target: str) -> Path:
     return KNOWLEDGE_DIR / clean.lstrip("/")
 
 
+def resolve_legacy_source(source: str, concept_path: Path) -> Path:
+    if not isinstance(source, str) or not source.strip():
+        msg = "legacy_sources entries must be non-empty strings"
+        raise ValueError(msg)
+    normalized = source.strip()
+    if normalized.startswith("/") or Path(normalized).is_absolute():
+        msg = f"legacy_sources must be repo-relative paths, not absolute: {source}"
+        raise ValueError(msg)
+    resolved = (concept_path.parent / normalized).resolve()
+    root = ROOT.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        msg = f"legacy_sources must resolve inside repository root: {source}"
+        raise ValueError(msg) from exc
+    return resolved
+
+
+def validate_legacy_sources(
+    meta: Mapping[str, Any],
+    concept_path: Path,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+    legacy_sources = meta.get("legacy_sources")
+    if legacy_sources is None:
+        return errors
+    if not isinstance(legacy_sources, list):
+        errors.append(f"{label}: legacy_sources must be a list")
+        return errors
+    for index, source in enumerate(legacy_sources):
+        if not isinstance(source, str):
+            errors.append(f"{label}: legacy_sources[{index}] must be a string")
+            continue
+        try:
+            resolved = resolve_legacy_source(source, concept_path)
+        except ValueError as exc:
+            errors.append(f"{label}: {exc}")
+            continue
+        if not resolved.is_file():
+            errors.append(f"{label}: missing legacy_sources target {source!r}")
+    return errors
+
+
 def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     rel = path.relative_to(KNOWLEDGE_DIR).as_posix()
@@ -602,6 +646,7 @@ def check_bundle() -> None:
             errors.append(f"{rel}: concept documents require YAML frontmatter")
             continue
         errors.extend(validate_concept_frontmatter(concept_path, meta))
+        errors.extend(validate_legacy_sources(meta, concept_path, rel))
 
         canonical_for = meta.get("canonical_for")
         if canonical_for is not None:

--- a/tests/test_docs_knowledge_check.py
+++ b/tests/test_docs_knowledge_check.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 from scripts.docs_knowledge_check import (
+    KNOWLEDGE_DIR,
     build_default_entry,
     discover_inventory_paths,
     inventory_sync,
     render_inventory_md,
     resolve_bundle_link,
+    resolve_legacy_source,
     split_frontmatter,
     validate_inventory_schema,
+    validate_legacy_sources,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -228,3 +233,110 @@ def test_inventory_probe_drift_gate_lifecycle(
     assert probe_entry["title"] == "Inventory probe"
 
     module.inventory_sync(check=True)
+
+
+ARCHITECTURE_PILOTS = (
+    "architecture/system-overview.md",
+    "architecture/graph-plane.md",
+    "architecture/shadow-db.md",
+)
+
+
+def test_resolve_legacy_source_valid_llms_txt() -> None:
+    concept = KNOWLEDGE_DIR / "architecture" / "shadow-db.md"
+    resolved = resolve_legacy_source("../../../llms.txt", concept)
+    assert resolved == (ROOT / "llms.txt").resolve()
+    assert resolved.is_file()
+
+
+def test_resolve_legacy_source_rejects_absolute_path() -> None:
+    concept = KNOWLEDGE_DIR / "architecture" / "shadow-db.md"
+    with pytest.raises(ValueError, match="repo-relative"):
+        resolve_legacy_source("/etc/passwd", concept)
+
+
+def test_resolve_legacy_source_rejects_escape_outside_repo(tmp_path: Path) -> None:
+    concept = tmp_path / "docs" / "knowledge" / "architecture" / "pilot.md"
+    concept.parent.mkdir(parents=True)
+    with pytest.raises(ValueError, match="inside repository root"):
+        resolve_legacy_source("../../../../outside.md", concept)
+
+
+def test_validate_legacy_sources_missing_file() -> None:
+    concept = KNOWLEDGE_DIR / "architecture" / "graph-plane.md"
+    errors = validate_legacy_sources(
+        {"legacy_sources": ["../../DOES_NOT_EXIST.md"]},
+        concept,
+        "architecture/graph-plane.md",
+    )
+    assert any("missing legacy_sources" in error for error in errors)
+
+
+def test_validate_legacy_sources_rejects_absolute() -> None:
+    concept = KNOWLEDGE_DIR / "architecture" / "graph-plane.md"
+    errors = validate_legacy_sources(
+        {"legacy_sources": ["/tmp/secret.md"]},
+        concept,
+        "architecture/graph-plane.md",
+    )
+    assert any("repo-relative" in error for error in errors)
+
+
+def test_architecture_pilot_frontmatter_required_fields() -> None:
+    required = ("type", "title", "description", "tags", "timestamp", "status", "audience", "owner")
+    for rel in ARCHITECTURE_PILOTS:
+        meta, _ = split_frontmatter(KNOWLEDGE_DIR / rel)
+        assert meta is not None, rel
+        for field in required:
+            assert field in meta, f"{rel} missing {field}"
+        assert meta["type"] == "Architecture"
+        assert meta["status"] == "experimental"
+        assert "canonical_for" not in meta
+
+
+def test_shadow_db_since_version() -> None:
+    meta, _ = split_frontmatter(KNOWLEDGE_DIR / "architecture" / "shadow-db.md")
+    assert meta is not None
+    assert meta.get("since") == "v2.0.0-alpha"
+    assert meta.get("since") != "v2.0.0-alpha.1"
+
+
+def test_architecture_pilot_related_reciprocal() -> None:
+    concepts: dict[str, set[str]] = {}
+    for rel in ARCHITECTURE_PILOTS:
+        meta, _ = split_frontmatter(KNOWLEDGE_DIR / rel)
+        assert meta is not None
+        related = meta.get("related", [])
+        assert isinstance(related, list)
+        concepts[rel] = {item for item in related if isinstance(item, str)}
+
+    overview = "architecture/system-overview.md"
+    graph = "architecture/graph-plane.md"
+    shadow = "architecture/shadow-db.md"
+
+    assert f"/{overview}" in concepts[graph]
+    assert f"/{graph}" in concepts[overview]
+    assert f"/{shadow}" in concepts[overview]
+    assert f"/{overview}" in concepts[shadow]
+    assert f"/{graph}" in concepts[shadow]
+    assert f"/{shadow}" in concepts[graph]
+
+
+def test_check_bundle_passes_concept_rel_to_validate_legacy_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: check_bundle must pass concept rel, not an undefined label."""
+    import scripts.docs_knowledge_check as module
+
+    captured: list[str] = []
+
+    def spy(meta: Mapping[str, Any], concept_path: Path, label: str) -> list[str]:
+        captured.append(label)
+        return validate_legacy_sources(meta, concept_path, label)
+
+    monkeypatch.setattr(module, "validate_legacy_sources", spy)
+    module.check_bundle()
+    assert captured, "expected validate_legacy_sources to run for pilot concepts"
+    assert "architecture/shadow-db.md" in captured
+    assert "architecture/graph-plane.md" in captured
+    assert all(isinstance(label, str) and label for label in captured)


### PR DESCRIPTION
## Summary

- Add experimental architecture pilots `graph-plane.md` and `shadow-db.md` under `docs/knowledge/architecture/`, distilled from HEAD runtime symbols (graph dispatch/OCC/sandbox; shadow bootstrap/sync/health/routing) — **not** from stale line ranges in legacy docs.
- Extend `make docs-check` with `legacy_sources` validation (repo-relative paths, in-repo resolution, existing files; rejects absolute paths and escapes).
- Update `system-overview.md` to delegate graph-plane and shadow-db detail instead of growing inline; refresh architecture index, inventory notes, and profile guidance.
- Fix `check_bundle()` `NameError` (`label` → `rel` when calling `validate_legacy_sources`); add regression and validation tests.

**Authority:** All three pilots remain `status: experimental`. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) remains authoritative during the Phase 2 architecture pilot — no legacy moves, redirects, or `canonical_for` promotion.

## Impact (GitNexus)

`detect_changes(scope=compare, base_ref=main)` → **LOW** — 7 changed files, 0 indexed runtime symbols, 0 affected execution flows.

`check_bundle()` / `validate_legacy_sources()` are documentation-tooling only (invoked via `make docs-check` / CI `docs-check` step). No daemon, MCP, or graph runtime paths affected.

## Test plan

- [x] `make docs-check` (includes `inventory-md` drift gate)
- [x] `make docs-audit`
- [x] `make agents-check`
- [x] `make ci` (local)
- [x] Remote CI green before squash merge