### PR TITLE
fix(shadow): reconcile stale page owner on incremental rename

### DIFF
--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -57,7 +57,7 @@ uvx matryca-plumber@2.0.0-alpha.1 --version   # expect 2.0.0-alpha.1 (PyPI 2.0.0
 - [ ] Full rebuild vs incremental equivalent sequence — **A2-PARITY-02/03/05 pass**
 - [ ] Shadow never writes Markdown — **A2-PARITY-04 pass**
 - [ ] Watcher create/modify/delete — **A2-WATCH-01 pass**
-- [ ] Rename on disk — **A2-WATCH-02 P1 open**
+- [x] Rename on disk — **A2-WATCH-02 fixed ([#272](https://github.com/MarcoPorcellato/matryca-plumber/issues/272))**
 - [ ] Modify during bootstrap replay — **A2-WATCH-03 pass**
 - [ ] Journals + encoded page titles — **A2-PARSE-01 pass**
 - [ ] Unicode, multiline, page properties — **A2-PARSE-02 pass**
@@ -114,7 +114,7 @@ uvx matryca-plumber@2.0.0-alpha.1 --version   # expect 2.0.0-alpha.1 (PyPI 2.0.0
 | A1-DEFER-01 | 1 | Watchdog delete deferred + file removed | — | `test_a1_watchdog_delete_during_bootstrap_replays_removal_when_file_gone` | — | **pass** |
 | A1-DEFER-02 | 1 | `post_write` during bootstrap | — | `test_a1_post_write_during_bootstrap_replays_after_rebuild` | — | **pass** |
 | A1-SQLITE-01 | 1 | Holder keeps `BEGIN IMMEDIATE` | — | `test_a1_sqlite_writer_lock_blocks_incremental_without_meta_corruption` | — | **pass** |
-| A2-WATCH-02 | 2 | Page file rename leaves stale shadow row | **P1** | `test_a2_watch_02_rename_file_path_parity` | [#272](https://github.com/MarcoPorcellato/matryca-plumber/issues/272) | **open** |
+| A2-WATCH-02 | 2 | Page file rename leaves stale shadow row | **P1** | `test_a2_watch_02_rename_file_path_parity` | [#272](https://github.com/MarcoPorcellato/matryca-plumber/issues/272) | **fixed** |
 | A2-PARITY-01 | 2 | Bootstrap structural snapshot | — | `test_a2_parity_01_bootstrap_pages_blocks_parentage_order` | — | **pass** |
 | A2-PARITY-02 | 2 | Full vs incremental create sequence | — | `test_a2_parity_02_full_rebuild_matches_incremental_create_sequence` | — | **pass** |
 | A2-PARITY-03 | 2 | Full vs incremental mutations | — | `test_a2_parity_03_full_rebuild_matches_incremental_mutations` | — | **pass** |

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -85,10 +85,15 @@ def _walk_blocks(
 
 def _preflight_block_uuids(
     connection: sqlite3.Connection,
+    graph_root: Path,
     flat: list[tuple[str, str | None, int, int, str, dict[str, Any]]],
     current_rel: str,
 ) -> None:
-    """Reject duplicate ``block_uuid`` values before insert (no silent dedup)."""
+    """Reject duplicate ``block_uuid`` values before insert (no silent dedup).
+
+    When a UUID is owned by another ``file_path`` whose Markdown file no longer
+    exists (typical rename), drop the stale shadow page in the same transaction.
+    """
     if not flat:
         return
 
@@ -108,10 +113,17 @@ def _preflight_block_uuids(
         """,
         tuple(seen_on_page),
     ).fetchall()
+    stale_paths: set[str] = set()
     for block_uuid, other_path in rows:
-        if other_path != current_rel:
-            paths = sorted({current_rel, str(other_path)})
+        other_rel = str(other_path)
+        if other_rel == current_rel:
+            continue
+        if (graph_root / other_rel).is_file():
+            paths = sorted({current_rel, other_rel})
             raise ShadowSyncError(format_duplicate_block_uuid_error(block_uuid, paths))
+        stale_paths.add(other_rel)
+    for stale_rel in sorted(stale_paths):
+        connection.execute("DELETE FROM pages WHERE file_path = ?", (stale_rel,))
 
 
 def delete_shadow_page_by_file_path(graph_root: Path | str, rel_path: str) -> None:
@@ -156,6 +168,9 @@ def sync_page_into_connection(
     is_journal = 1 if _is_journal_relpath(rel) else 0
     props_json = _props_json(dict(page.properties or {}))
 
+    flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
+    _preflight_block_uuids(connection, root, flat, rel)
+
     connection.execute(
         "DELETE FROM pages WHERE file_path = ? OR title = ?",
         (rel, title),
@@ -180,8 +195,6 @@ def sync_page_into_connection(
     page_id = int(cur.lastrowid or 0)
     if page_id <= 0:
         raise RuntimeError("shadow pages insert returned no page_id")
-    flat = _walk_blocks(list(page.root_nodes or []), parent_uuid=None, sort_base=0)
-    _preflight_block_uuids(connection, flat, rel)
     uuid_to_rowid: dict[str, int] = {}
     for block_uuid, parent_uuid, sort_order, indent, content, props in flat:
         parent_rowid = uuid_to_rowid.get(parent_uuid) if parent_uuid else None

--- a/tests/test_shadow_hardening_axis2_parity.py
+++ b/tests/test_shadow_hardening_axis2_parity.py
@@ -369,10 +369,6 @@ def test_a2_watch_01_watchdog_crud_matches_incremental_sync(tmp_path: Path) -> N
     assert_full_rebuild_matches_incremental(graph, seed_files={}, ops=ops)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="A2-WATCH-02: stale shadow page owner on rename — #272",
-)
 def test_a2_watch_02_rename_file_path_parity(tmp_path: Path) -> None:
     """A2-WATCH-02: rename on disk converges to same shadow state as full rebuild."""
     graph = _minimal_graph(tmp_path)


### PR DESCRIPTION
## Summary

- During `sync_page_into_connection`, when a `block_uuid` is owned by another `file_path` whose Markdown file no longer exists (rename), delete the stale shadow page in the same transaction before upserting blocks.
- True cross-page duplicates (both files still on disk) still raise `ShadowSyncError`.
- Remove `xfail(strict=True)` on `test_a2_watch_02_rename_file_path_parity` — probe green.

Fixes #272

## Code audit impact (pre-patch)

| Symbol | Risk | Notes |
| --- | --- | --- |
| `sync_page_into_connection` | HIGH | 2 direct callers; bootstrap + incremental sync flows |
| `sync_page_to_shadow` | LOW | post-write / watchdog path |
| `handle_shadow_watchdog_change` | LOW | indirect via sync/delete |
| `delete_shadow_page_by_file_path` | LOW | late delete remains idempotent |

Local change-scope review: **medium** — shadow sync symbols + stale-owner reconciliation in `_preflight_block_uuids`.

## Test plan

- [x] `test_a2_watch_02_rename_file_path_parity` passes (no xfail)
- [x] `tests/test_shadow_hardening_axis2_parity.py` — 14/14 pass
- [x] `make ci` green locally
- [ ] Remote CI