### PR TITLE
fix: recover hyphenated FTS queries instead of silent BM25 fallback (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Shadow FTS hyphenated-query silent fallback (#277)** — an unquoted hyphenated keyword such as `state-of-the-art` made FTS5 read the hyphen fragments as column filters and raise `no such column: of`; `format_shadow_fts_markdown` only classified `syntax` errors, so this propagated into the `bm25` router's broad `except` and silently fell back to generational BM25 while shadow health was `ready`. The `no such column` case is now recovered as a quoted-phrase retry (returns the real shadow hit); genuine syntax errors still raise `FtsQueryValidationError`, and backend failures (missing table, locked db) still fall back.
+
 ## [2.0.0-alpha.2] - 2026-07-18
 
 **v2.0.0-alpha.2** — Shadow DB hardening after **v2.0.0-alpha.1** ([#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)): ships the **P1 rename stale-owner fix** ([#272](https://github.com/MarcoPorcellato/matryca-plumber/issues/272) / [#274](https://github.com/MarcoPorcellato/matryca-plumber/pull/274)) missing from PyPI **`2.0.0a1`**, plus Axis 2 parity and Axis 3 routing audit probes. **Not an RC** — Axes 4–7 remain open on [#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261). Supersedes **`v2.0.0-alpha.1`** / PyPI **`2.0.0a1`** for new installs; **`2.0.0a0`–`2.0.0a1` remain on PyPI** (not yanked).

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -16,9 +16,55 @@ from .query import BlockHit, search_blocks_fts
 
 _FTS_VALIDATION_PREFIX = "Invalid FTS query for `method=bm25`"
 
+# FTS5 reports an unrecognised bareword column filter (e.g. the ``-of`` / ``-the``
+# fragments of ``state-of-the-art``, which it reads as NOT operators against a
+# ``of``/``the`` column) as ``OperationalError: no such column: <name>``. This is
+# neither an FTS5 *syntax* error nor a shadow backend failure, so it must not reach
+# the generational fallback — the query is recoverable as a literal phrase.
+_FTS_COLUMN_FILTER_MARKER = "no such column"
+
 
 class FtsQueryValidationError(ValueError):
     """User-supplied keyword is not a valid FTS5 ``MATCH`` expression."""
+
+
+def _as_fts_phrase(keyword: str) -> str:
+    """Wrap ``keyword`` as a single FTS5 quoted phrase, escaping embedded quotes."""
+    return '"' + keyword.strip().replace('"', '""') + '"'
+
+
+def _search_blocks_fts_recovering(
+    connection: sqlite3.Connection,
+    keyword: str,
+    *,
+    limit: int,
+) -> list[BlockHit]:
+    """Run the FTS5 ``MATCH`` for ``keyword``, recovering misparsed bareword input.
+
+    A user keyword such as ``state-of-the-art`` is a valid search intent but not a
+    valid FTS5 expression: FTS5 reads the hyphenated fragments as column filters and
+    raises ``no such column: of``. Rather than let that surface as a backend failure
+    (which would silently fall back to generational BM25), retry the raw keyword as a
+    quoted phrase so it matches the indexed content literally. Genuine syntax errors
+    (e.g. a stray apostrophe) still raise :class:`FtsQueryValidationError`, and other
+    ``OperationalError``\\ s (missing table, locked database) propagate unchanged.
+    """
+    try:
+        return search_blocks_fts(connection, keyword, limit=limit)
+    except sqlite3.OperationalError as exc:
+        message = str(exc).lower()
+        if "syntax" in message:
+            raise FtsQueryValidationError(
+                f"{_FTS_VALIDATION_PREFIX}: {keyword!r} is not valid FTS5 syntax."
+            ) from exc
+        if _FTS_COLUMN_FILTER_MARKER in message:
+            try:
+                return search_blocks_fts(connection, _as_fts_phrase(keyword), limit=limit)
+            except sqlite3.OperationalError as retry_exc:
+                raise FtsQueryValidationError(
+                    f"{_FTS_VALIDATION_PREFIX}: {keyword!r} is not valid FTS5 syntax."
+                ) from retry_exc
+        raise
 
 
 def validate_fts_match_query(keyword: str) -> None:
@@ -61,14 +107,7 @@ def format_shadow_fts_markdown(
     root = resolved_graph_root(graph_root)
     conn = open_shadow_db(root)
     try:
-        try:
-            hits = search_blocks_fts(conn, keyword, limit=limit)
-        except sqlite3.OperationalError as exc:
-            if "syntax" in str(exc).lower():
-                raise FtsQueryValidationError(
-                    f"{_FTS_VALIDATION_PREFIX}: {keyword!r} is not valid FTS5 syntax."
-                ) from exc
-            raise
+        hits = _search_blocks_fts_recovering(conn, keyword, limit=limit)
         page_rows = _page_rows_for_hits(conn, hits)
     finally:
         conn.close()

--- a/tests/test_shadow_hardening_axis4_fts5.py
+++ b/tests/test_shadow_hardening_axis4_fts5.py
@@ -137,10 +137,6 @@ def test_a4_query_04_operators_and_parentheses(tmp_path: Path) -> None:
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P1 #277: unquoted hyphenated queries must not fall back to generational BM25",
-)
 @pytest.mark.asyncio
 async def test_a4_query_05_hyphenated_phrase_no_generational_fallback(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

<!-- Why does this change exist? What trade-offs did you consider? -->

- An unquoted hyphenated keyword such as `state-of-the-art` makes the FTS5 query parser read the `-of` / `-the` fragments as column filters and raise `sqlite3.OperationalError: no such column: of`.
- `format_shadow_fts_markdown` only mapped `OperationalError`s whose message contains `syntax` to `FtsQueryValidationError`. This `no such column` error slipped through, propagated into the broad `except Exception` in `resolve_bm25_search_markdown`, and **silently fell back to generational BM25** while shadow health was `ready` — breaking the routing contract that user keyword input must either return shadow hits or a bounded validation error (never a surprise fallback).
- Fix: classify the `no such column` family explicitly and retry the raw keyword as a **quoted phrase** (`"state-of-the-art"`), which matches the indexed content and returns the real shadow hit. I chose phrase-recovery over raising a validation error because A4-QUERY-05 expects an actual hit, and it preserves the user's literal intent.
- Trade-off considered: kept the recovery narrow to `no such column` so the A4-FAIL backend-failure paths (`no such table`, `database is locked`) still fall back to generational BM25 unchanged, and genuine syntax errors (e.g. a stray apostrophe, A4-QUERY-06) still surface as `FtsQueryValidationError`.

Verified locally against the audit probes from #280 (`--runxfail`): `test_a4_query_05_hyphenated_phrase_no_generational_fallback` now passes (confirmed red→green by reverting the source change), while `test_a4_query_04` (boolean OR) and `test_a4_query_06` (apostrophe → validation error) stay green. Note: since the reproducer lives on the unmerged #280 branch, once that lands the `xfail(strict=True)` marker on `test_a4_query_05_...` should be removed — happy to fold that into this PR if you rebase #280 first.

## Test plan

- [ ] `make check` passes locally (or `make ci` for format-check too)
- [x] OCC / CRLF: graph writes preserve `id::` lines and page frontmatter at line 0 — N/A, read-only FTS query path, no graph writes
- [x] User-visible behavior change documented in [`CHANGELOG.md`](../CHANGELOG.md) under `[Unreleased]`
- [x] If CLI/MCP/env changed: [`llms.txt`](../llms.txt) and [`.well-known/llms.txt`](../.well-known/llms.txt) stay in sync — N/A, no CLI/MCP/env surface change

Ran locally: `pytest tests/test_shadow_fts.py tests/test_shadow_fts_routing.py tests/test_shadow_hardening_axis2_parity.py tests/test_shadow_hardening_axis3_routing.py` (46 passed), the A4-QUERY probes from #280, plus `ruff check`, `ruff format --check`, and `mypy` on the changed file (all clean).

## Issue linking

<!-- Use Closes #N / Fixes #N for auto-close on merge; Refs #N for partial work -->

Closes #277