### PR TITLE
fix(shadow): quote hyphenated FTS user tokens (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Shadow FTS hyphenated keywords (#277)** — natural compound tokens such as `state-of-the-art` are quoted before FTS5 `MATCH`, so shadow search no longer mis-parses interior hyphens as boolean `NOT` or falls back to generational BM25 while health is `ready`.
+
 ## [2.0.0-alpha.2] - 2026-07-18
 
 **v2.0.0-alpha.2** — Shadow DB hardening after **v2.0.0-alpha.1** ([#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)): ships the **P1 rename stale-owner fix** ([#272](https://github.com/MarcoPorcellato/matryca-plumber/issues/272) / [#274](https://github.com/MarcoPorcellato/matryca-plumber/pull/274)) missing from PyPI **`2.0.0a1`**, plus Axis 2 parity and Axis 3 routing audit probes. **Not an RC** — Axes 4–7 remain open on [#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261). Supersedes **`v2.0.0-alpha.1`** / PyPI **`2.0.0a1`** for new installs; **`2.0.0a0`–`2.0.0a1` remain on PyPI** (not yanked).

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -79,7 +79,7 @@ uvx matryca-plumber@2.0.0-alpha.2 --version   # expect 2.0.0-alpha.2 (PyPI 2.0.0
 
 **Status:** audit probes complete (`tests/test_shadow_hardening_axis4_fts5.py`).
 
-- [x] Special chars, quotes, operators, Unicode — **A4-QUERY-01..09 pass; A4-QUERY-05/07 xfail**
+- [x] Special chars, quotes, operators, Unicode — **A4-QUERY-01..09 pass; A4-QUERY-05 fixed (#277); A4-QUERY-07 xfail**
 - [x] Very long queries — **A4-QUERY-10 xfail (unbounded input)**
 - [x] Limits and deterministic ordering — **A4-RANK-01..04 pass**
 - [x] MCP/CLI envelope parity — **A4-CONTENT-06 / A4-FAIL envelope probes pass**
@@ -153,7 +153,7 @@ uvx matryca-plumber@2.0.0-alpha.2 --version   # expect 2.0.0-alpha.2 (PyPI 2.0.0
 | A3-SURFACE-01 | 3 | MCP BM25 ≡ direct resolver envelope | — | `test_a3_surface_01_bm25_mcp_handler_matches_direct_resolver` | — | **pass** |
 | A3-SURFACE-02 | 3 | CLI subtree ≡ port; selector side-effect free | — | `test_a3_surface_02_subtree_handler_matches_port_and_selector_is_side_effect_free` | — | **pass** |
 | A3-HEALTH-FLIP | 3 | Health flip after port selection → Markdown fallback | — | `test_a3_health_change_between_port_selection_and_subtree_query` | — | **pass** |
-| A4-QUERY-05 | 4 | Unquoted hyphenated query → generational BM25 fallback | **P1** | `test_a4_query_05_hyphenated_phrase_no_generational_fallback` | [#277](https://github.com/MarcoPorcellato/matryca-plumber/issues/277) | **open** |
+| A4-QUERY-05 | 4 | Unquoted hyphenated query → generational BM25 fallback | **P1** | `test_a4_query_05_hyphenated_phrase_no_generational_fallback` | [#277](https://github.com/MarcoPorcellato/matryca-plumber/issues/277) | **fixed** (PR pending) |
 | A4-QUERY-07 | 4 | `cafe` misses indexed `caffè` | **P2** | `test_a4_query_07_unicode_diacritic_fold` | [#278](https://github.com/MarcoPorcellato/matryca-plumber/issues/278) | **open** |
 | A4-QUERY-10 | 4 | No bounded max FTS query length | **P2** | `test_a4_query_10_very_long_query_bounded` | [#279](https://github.com/MarcoPorcellato/matryca-plumber/issues/279) | **open** |
 | A4-QUERY-01 | 4 | Simple token match | — | `test_a4_query_01_simple_token` | — | **pass** |

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -64,7 +64,15 @@ def format_shadow_fts_markdown(
         try:
             hits = search_blocks_fts(conn, keyword, limit=limit)
         except sqlite3.OperationalError as exc:
-            if "syntax" in str(exc).lower():
+            msg = str(exc).lower()
+            if any(
+                fragment in msg
+                for fragment in (
+                    "syntax",
+                    "no such column",
+                    "unknown special query",
+                )
+            ):
                 raise FtsQueryValidationError(
                     f"{_FTS_VALIDATION_PREFIX}: {keyword!r} is not valid FTS5 syntax."
                 ) from exc

--- a/src/shadow/query.py
+++ b/src/shadow/query.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from dataclasses import dataclass
+
+# ASCII hyphen + common Unicode dash code points (en/em/figure dashes).
+_HYPHEN_DASH_CLASS = "-\u2010\u2011\u2012\u2013\u2014"
+_FTS_RESERVED_TOKENS = frozenset({"OR", "AND", "NOT", "NEAR"})
+_NATURAL_COMPOUND_TOKEN = re.compile(rf"^[A-Za-z0-9][A-Za-z0-9{_HYPHEN_DASH_CLASS}]*[A-Za-z0-9]$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +20,64 @@ class BlockHit:
     content: str
     page_id: int
     rank: float
+
+
+def _quote_natural_hyphenated_token(token: str) -> str:
+    """Quote a bare token that FTS5 would parse as boolean NOT chains."""
+    prefix = ""
+    suffix = ""
+    core = token
+    while core.startswith("("):
+        prefix += "("
+        core = core[1:]
+    while core.endswith(")"):
+        suffix = ")" + suffix
+        core = core[:-1]
+    if not core or core.upper() in _FTS_RESERVED_TOKENS:
+        return token
+    if core.startswith("-") or "*" in core:
+        return token
+    if not any(ch in _HYPHEN_DASH_CLASS for ch in core):
+        return token
+    if not _NATURAL_COMPOUND_TOKEN.match(core):
+        return token
+    escaped = core.replace('"', '""')
+    return f'{prefix}"{escaped}"{suffix}'
+
+
+def prepare_fts_user_query(query: str) -> str:
+    """Prepare user keyword input for safe FTS5 ``MATCH`` binding.
+
+    Natural compound tokens such as ``state-of-the-art`` are wrapped as phrase
+    literals so FTS5 does not interpret interior hyphens as ``NOT``. Explicit
+    quoted spans, boolean operators, prefix terms (``*``), and leading ``-``
+    negation are left unchanged.
+    """
+    q = query.strip()
+    if not q:
+        return q
+    parts: list[str] = []
+    i = 0
+    n = len(q)
+    while i < n:
+        while i < n and q[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        if q[i] == '"':
+            j = i + 1
+            while j < n and q[j] != '"':
+                j += 1
+            end = j + 1 if j < n else n
+            parts.append(q[i:end])
+            i = end
+        else:
+            j = i
+            while j < n and not q[j].isspace():
+                j += 1
+            parts.append(_quote_natural_hyphenated_token(q[i:j]))
+            i = j
+    return " ".join(parts)
 
 
 def search_blocks_fts(
@@ -28,7 +92,7 @@ def search_blocks_fts(
     should supply FTS5 query syntax (plain tokens are fine for simple search).
     Empty / whitespace-only queries return an empty list.
     """
-    q = query.strip()
+    q = prepare_fts_user_query(query)
     if not q:
         return []
     capped = max(1, min(int(limit), 500))
@@ -56,5 +120,6 @@ def search_blocks_fts(
 
 __all__ = [
     "BlockHit",
+    "prepare_fts_user_query",
     "search_blocks_fts",
 ]

--- a/tests/test_shadow_fts.py
+++ b/tests/test_shadow_fts.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from src.shadow.connection import open_shadow_db
-from src.shadow.query import search_blocks_fts
+from src.shadow.query import prepare_fts_user_query, search_blocks_fts
 from src.shadow.sync import sync_page_to_shadow
 
 
@@ -63,5 +63,28 @@ def test_search_blocks_fts_respects_limit(tmp_path: Path) -> None:
     try:
         hits = search_blocks_fts(conn, "shared", limit=2)
         assert len(hits) == 2
+    finally:
+        conn.close()
+
+
+def test_prepare_fts_user_query_quotes_natural_hyphen_compounds() -> None:
+    assert prepare_fts_user_query("state-of-the-art") == '"state-of-the-art"'
+    assert prepare_fts_user_query("needle state-of-the-art") == 'needle "state-of-the-art"'
+    assert prepare_fts_user_query("alpha OR beta") == "alpha OR beta"
+    assert prepare_fts_user_query('"state-of-the-art"') == '"state-of-the-art"'
+
+
+def test_search_blocks_fts_hyphenated_user_query(tmp_path: Path) -> None:
+    page = tmp_path / "pages" / "Hyphen.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(
+        "- state-of-the-art needle\n  id:: 66666666-6666-4666-8666-666666666666\n",
+        encoding="utf-8",
+    )
+    sync_page_to_shadow(tmp_path, page)
+    conn = open_shadow_db(tmp_path)
+    try:
+        hits = search_blocks_fts(conn, "state-of-the-art")
+        assert len(hits) == 1
     finally:
         conn.close()

--- a/tests/test_shadow_hardening_axis4_fts5.py
+++ b/tests/test_shadow_hardening_axis4_fts5.py
@@ -137,10 +137,6 @@ def test_a4_query_04_operators_and_parentheses(tmp_path: Path) -> None:
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P1 #277: unquoted hyphenated queries must not fall back to generational BM25",
-)
 @pytest.mark.asyncio
 async def test_a4_query_05_hyphenated_phrase_no_generational_fallback(
     tmp_path: Path,
@@ -159,6 +155,129 @@ async def test_a4_query_05_hyphenated_phrase_no_generational_fallback(
     assert "block `" in out
     assert "Hyphen.md" in out
     assert "Invalid FTS query" not in out
+
+
+def test_a4_query_05b_hyphenated_ascii_token_hits(tmp_path: Path) -> None:
+    """A4-QUERY-05b (#277): bare ASCII hyphenated token matches indexed block content."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/HyphenAscii.md",
+        "- state-of-the-art token\n  id:: 67676767-6767-4676-8676-676767676767\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        hits = search_blocks_fts(conn, "state-of-the-art")
+        assert len(hits) == 1
+        assert "state-of-the-art" in hits[0].content
+    finally:
+        conn.close()
+
+
+def test_a4_query_05c_unicode_dash_hyphenated_token(tmp_path: Path) -> None:
+    """A4-QUERY-05c (#277): Unicode dash compounds are quoted like ASCII hyphens."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/HyphenUnicode.md",
+        "- state–of–the–art token\n  id:: 68686868-6868-4686-8686-686868686868\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        hits = search_blocks_fts(conn, "state–of–the–art")
+        assert len(hits) == 1
+    finally:
+        conn.close()
+
+
+def test_a4_query_05d_leading_hyphen_is_not_compound_quoting(tmp_path: Path) -> None:
+    """A4-QUERY-05d (#277): leading ``-`` remains FTS negation, not phrase quoting."""
+    from src.shadow.query import prepare_fts_user_query
+
+    assert prepare_fts_user_query("-needle") == "-needle"
+
+
+def test_a4_query_05e_trailing_hyphen_not_auto_quoted(tmp_path: Path) -> None:
+    """A4-QUERY-05e (#277): trailing hyphen tokens are not rewritten as compounds."""
+    from src.shadow.query import prepare_fts_user_query
+
+    assert prepare_fts_user_query("token-") == "token-"
+
+
+def test_a4_query_05f_multi_term_with_one_hyphenated(tmp_path: Path) -> None:
+    """A4-QUERY-05f (#277): mixed query quotes only the hyphenated bare token."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/MixHyphen.md",
+        "- needle state-of-the-art token\n  id:: 69696969-6969-4696-8696-696969696969\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        hits = search_blocks_fts(conn, "needle state-of-the-art")
+        assert len(hits) == 1
+    finally:
+        conn.close()
+
+
+def test_a4_query_05g_quoted_hyphenated_phrase_unchanged(tmp_path: Path) -> None:
+    """A4-QUERY-05g (#277): user-supplied quoted spans are not re-quoted."""
+    from src.shadow.query import prepare_fts_user_query
+
+    assert prepare_fts_user_query('"state-of-the-art"') == '"state-of-the-art"'
+
+
+@pytest.mark.asyncio
+async def test_a4_query_05h_hyphenated_with_supported_or_operator(tmp_path: Path) -> None:
+    """A4-QUERY-05h (#277): hyphenated token coexists with explicit OR syntax."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/OrHyphen.md",
+        "- alpha state-of-the-art token\n  id:: 70707070-7070-4707-8707-707070707070\n"
+        "- beta plain token\n  id:: 71717171-7171-4717-8717-717171717171\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        hits = search_blocks_fts(conn, "state-of-the-art OR beta")
+        assert len(hits) == 2
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_a4_query_05i_invalid_syntax_still_validation_error(tmp_path: Path) -> None:
+    """A4-QUERY-05i (#277): truly invalid FTS input still raises validation error."""
+    graph = _minimal_graph(tmp_path)
+    _seed_fts_graph(graph)
+    out = await handle_search_bm25(str(graph), '"unclosed')
+    assert "Invalid FTS query" in out
+    assert "## Ranked pages (BM25)" not in out
+
+
+@pytest.mark.asyncio
+async def test_a4_query_05j_backend_failure_still_generational_fallback(
+    tmp_path: Path,
+) -> None:
+    """A4-QUERY-05j (#277): real SQLite backend failures still fall back once."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/FallbackHyphen.md",
+        "- state-of-the-art fallback marker\n",
+    )
+    _seed_fts_graph(graph)
+    with patch(
+        "src.shadow.fts_format.search_blocks_fts",
+        side_effect=sqlite3.OperationalError("database disk image is malformed"),
+    ):
+        out = await handle_search_bm25(str(graph), "state-of-the-art")
+    assert "FallbackHyphen.md" in out
+    assert "malformed" not in out
 
 
 def test_a4_query_06_apostrophe_raises_validation_not_sqlite(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `prepare_fts_user_query()` — wraps natural hyphen/dash compound bare tokens (e.g. `state-of-the-art`) as FTS5 phrase literals before `MATCH`, preserving quoted spans, `OR`/`AND`, prefix `*`, and leading `-` negation.
- Broadens `format_shadow_fts_markdown` query-syntax `OperationalError` mapping (`syntax`, `no such column`, `unknown special query`) so malformed input returns validation errors instead of silent generational fallback.
- Removes `xfail` on **A4-QUERY-05**; adds targeted #277 regression probes.
- Updates `CHANGELOG.md` and tracker #261.

Fixes #277

## Root cause

FTS5 parses unquoted hyphens as boolean `NOT` (`state-of-the-art` → `no such column: of`). That error lacked `syntax` in the message, so `resolve_bm25_search_markdown` fell back to generational BM25 while shadow was `ready`.

## Semantics

Hyphenated **bare tokens** matching `[A-Za-z0-9](hyphen|unicode-dash)+[A-Za-z0-9]` are quoted as phrase literals — aligned with `unicode61` indexed content and explicit `"state-of-the-art"` queries.

## Test plan

- [x] Axis 4 FTS: **37 pass**, **2 xfail** (#278, #279 unchanged)
- [x] Axis 2–3 regression: **33 pass**
- [x] `make docs-check`, `make agents-check`, `make ci` (**1231 pass**)
- [x] GitNexus `detect_changes(compare main)` — risk LOW

**Release:** recommend `v2.0.0-alpha.3` after merge (P1 user-visible fix).

Made with [Cursor](https://cursor.com)