### PR TITLE
docs(agent): add local code-intelligence workflow

### DIFF
--- a/.agents/skills/serena/SKILL.md
+++ b/.agents/skills/serena/SKILL.md
@@ -169,4 +169,4 @@ Full parameter detail: [reference.md](reference.md).
 ## Related skills
 
 - **GitNexus** — execution-flow / call-graph impact before `src/` edits.
-- **`.agents/skills/serena/`** — same content for agent routers that load from `.agents/`.
+- Mirrored in `.cursor/skills/serena/` and `.agents/skills/serena/`; **`.cursor/skills/serena/` is canonical**.

--- a/.agents/skills/serena/SKILL.md
+++ b/.agents/skills/serena/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: serena
+description: >-
+  Use Serena MCP for semantic code navigation and symbol-level edits in
+  matryca-plumber. Prefer over blind grep/read when exploring or changing Python
+  symbols. MCP server: serena-matryca-plumber (not global serena).
+---
+
+# Serena MCP — matryca-plumber
+
+Serena is an **MCP server** that exposes IDE-like **symbol retrieval and editing** via Language Server Protocol (LSP). It operates at the **symbol level** (classes, functions, methods), not line numbers.
+
+**Official docs:** https://oraios.github.io/serena/  
+**Upstream:** https://github.com/oraios/serena
+
+## This repo — critical routing
+
+| Item | Value |
+|------|--------|
+| **MCP server** | `serena-matryca-plumber` |
+| **Do not use** | `user-serena` (bound to Matryca-per-Delineat) |
+| **Project root** | matryca-plumber checkout (passed at MCP startup) |
+| **Context** | `ide-assistant` (see `.codex/config.toml`) |
+
+One Serena instance = one project. Two repos ⇒ two MCP server entries.
+
+## First action on coding tasks
+
+1. Call **`initial_instructions`** on `serena-matryca-plumber` (Serena Instructions Manual).
+2. If memories exist, **`list_memories`** then **`read_memory`** for relevant entries (`mem:conventions`, `mem:task_completion`, `mem:suggested_commands`).
+3. Skip **`onboarding`** unless the project has no memories yet.
+
+## When to use Serena (prefer over grep/read)
+
+| Task | Serena tool | Why |
+|------|-------------|-----|
+| New file / unknown area | `get_symbols_overview` | Compact symbol map without reading whole file |
+| Find definition | `find_symbol` | LSP-accurate; supports `depth`, `substring_matching` |
+| Blast radius before edit | `find_referencing_symbols` | All references with snippets |
+| Rename / delete symbol | `rename_symbol` / `safe_delete_symbol` | Reference-aware, atomic |
+| Replace whole function/class | `replace_symbol_body` | After `include_body=True` retrieval |
+| Small in-method patch | `replace_content` (regex) | Cheaper than full symbol replace |
+| Same edit in N files | `replace_in_files` + `dry_run=True` first | One call, occurrence IDs |
+| Unknown symbol location | `search_for_pattern` | Regex; then switch to symbolic tools |
+| Post-edit sanity | `get_diagnostics_for_file` | LSP errors on touched files |
+
+## When NOT to use Serena
+
+- **Markdown, YAML, TOML, lockfiles** — use Read/Grep.
+- **Whole-file config or docs** — Read is fine.
+- **Shell / git / CI** — terminal (`make ci`, `uv run pytest …`).
+- **After `replace_symbol_body` / `rename_symbol` succeeds** — do not re-read the file to “confirm”; trust the tool.
+- **After `safe_delete_symbol` succeeds** — same.
+
+## Agent-drift guard (official recommendation)
+
+If you make **many consecutive `grep` / `read_file` calls without any Serena tool**, switch to Serena for the next exploration step. Cursor does not ship `serena-hooks remind`; self-enforce the same rule.
+
+## Standard workflow
+
+```
+get_symbols_overview(file)     # orient
+    ↓
+find_symbol(pattern, depth=0|1)  # locate; include_body only when editing
+    ↓
+find_referencing_symbols       # before non-trivial changes
+    ↓
+edit (symbol or regex tool)
+    ↓
+get_diagnostics_for_file       # optional, touched files only
+    ↓
+make check / make ci             # mem:task_completion
+```
+
+### Parallelism (token/cost)
+
+Serena runs tool calls **sequentially** internally, but you should still **batch independent Serena reads** in one turn (overview + find_symbol on different files). Do **not** re-analyze a file with symbolic tools after you already read it fully.
+
+## Name paths (Python)
+
+Within a file, symbols use `/` paths:
+
+| Pattern | Matches |
+|---------|---------|
+| `prepare_fts_user_query` | Any symbol named that |
+| `ShadowGraphRepository/read_subtree_markdown` | Method on class |
+| `/MyClass/my_method` | Exact full path in file |
+| `Foo/get` + `substring_matching=True` | `getValue`, `getData`, … |
+| `MyClass/my_method[1]` | Overloaded index (rare in Python) |
+
+**Line numbers in Serena output are 0-based** (convert mentally to editor 1-based).
+
+## Editing rules
+
+### Symbol-level (preferred for whole definitions)
+
+1. **`find_symbol` with `include_body=True`** on the target first.
+2. **`replace_symbol_body`** — pass full new body (signature + implementation per language).
+3. **`insert_after_symbol` / `insert_before_symbol`** — new top-level or member definitions.
+4. **`rename_symbol`** — never find-and-replace rename across the repo.
+
+### File-level (small patches inside a symbol)
+
+- **`replace_content`** — `mode: regex` with wildcards (`beginning.*?end`) for multi-line spans; ambiguous match ⇒ refine pattern (safe by design).
+- **`replace_in_files`** — bulk literal/regex; **always `dry_run=True` first** when risk of collateral edits; then apply by `occurrence_ids`.
+
+### Do not
+
+- `replace_symbol_body` without prior `include_body=True` retrieval.
+- Global quote-and-replace renames (use `rename_symbol`).
+- Re-run tests only to verify a successful `rename_symbol`.
+
+## Memories (project-specific)
+
+Stored under `.serena/memories/` (if present). Reference as `` `mem:name` ``.
+
+| Memory | Use when |
+|--------|----------|
+| `mem:conventions` | Style, layers, naming |
+| `mem:task_completion` | Definition of done (`make ci`) |
+| `mem:suggested_commands` | Makefile / uv commands |
+| `mem:core` | Project map entry point |
+| `mem:graph_write_safety` | Vault write / sandbox rules |
+
+CLI integrity (human): `serena memories check` from project root.
+
+## matryca-plumber completion gate
+
+After code changes:
+
+```bash
+make lint && make typecheck && make test
+# or full gate:
+make ci
+```
+
+See `mem:task_completion`. Complement with GitNexus `impact` / `detect_changes` when changing `src/` symbols (repo policy).
+
+## Tool quick reference
+
+Full parameter detail: [reference.md](reference.md).
+
+| Tool | Purpose |
+|------|---------|
+| `initial_instructions` | Manual — call once per task |
+| `get_symbols_overview` | File symbol index |
+| `find_symbol` | Resolve symbols by name path |
+| `find_referencing_symbols` | Incoming references |
+| `find_declaration` | Jump to declaration via callsite regex |
+| `find_implementations` | Implementations of interface/abstract |
+| `search_for_pattern` | Regex grep with context |
+| `replace_symbol_body` | Replace symbol definition |
+| `insert_after_symbol` / `insert_before_symbol` | Add code near symbol |
+| `rename_symbol` | Project-wide rename |
+| `safe_delete_symbol` | Delete if unreferenced |
+| `replace_content` | Single-file regex/literal edit |
+| `replace_in_files` | Multi-file regex/literal edit |
+| `get_diagnostics_for_file` | LSP diagnostics |
+| `list_memories` / `read_memory` / `write_memory` | Project knowledge |
+| `open_dashboard` | Web UI for memories (optional) |
+
+## Official concepts (short)
+
+- **Project** — directory Serena indexes (this repo).
+- **Context** — `ide` / `ide-assistant` / `agent` / `claude-code`; set at server start, not per message.
+- **Modes** — composable flags (`no-onboarding`, `no-memories`, `query-projects`, …).
+- **Indexing** — `serena project index` once; LSP updates incrementally. JetBrains plugin uses IDE index instead.
+
+## Related skills
+
+- **GitNexus** — execution-flow / call-graph impact before `src/` edits.
+- **`.agents/skills/serena/`** — same content for agent routers that load from `.agents/`.

--- a/.agents/skills/serena/reference.md
+++ b/.agents/skills/serena/reference.md
@@ -1,7 +1,7 @@
 # Serena MCP — tool reference (matryca-plumber)
 
-MCP server: **`serena-matryca-plumber`**.  
-Source of truth for schemas: call `GetMcpTools` with `server: user-serena-matryca-plumber`.
+MCP server: **`serena-matryca-plumber`** (canonical for this repo).  
+Source of truth for schemas: `GetMcpTools` with `server: serena-matryca-plumber`.
 
 Official: https://oraios.github.io/serena/02-usage/040_workflow.html
 

--- a/.agents/skills/serena/reference.md
+++ b/.agents/skills/serena/reference.md
@@ -1,0 +1,208 @@
+# Serena MCP — tool reference (matryca-plumber)
+
+MCP server: **`serena-matryca-plumber`**.  
+Source of truth for schemas: call `GetMcpTools` with `server: user-serena-matryca-plumber`.
+
+Official: https://oraios.github.io/serena/02-usage/040_workflow.html
+
+---
+
+## Retrieval
+
+### `get_symbols_overview`
+
+**First tool for an unfamiliar code file.**
+
+| Param | Notes |
+|-------|--------|
+| `relative_path` | Required. Repo-relative path. |
+| `depth` | `-1` = language default; `1` includes class methods (Java/Kotlin default). |
+| `max_answer_chars` | Truncate huge files; avoid unless necessary. |
+
+### `find_symbol`
+
+| Param | Notes |
+|-------|--------|
+| `name_path_pattern` | Simple name, suffix `class/method`, or absolute `/class/method`. |
+| `relative_path` | Optional file or directory scope. |
+| `depth` | `1` → children (e.g. class methods). Ignored if `include_body=True`. |
+| `include_body` | Full source — use only when editing. |
+| `include_info` | Hover-like docstring/signature (slow on C++). |
+| `substring_matching` | `Foo/get` matches `getValue`, `getData`. |
+| `max_matches` | Use `1` when you want a single unambiguous hit. |
+
+### `find_referencing_symbols`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Symbol to look up (not a pattern). |
+| `relative_path` | File containing the symbol. |
+| `include_kinds` / `exclude_kinds` | LSP symbol kind filters (integers). |
+
+Returns referencing symbols + short snippet around each use.
+
+### `find_declaration`
+
+Resolve declaration from a **callsite regex** (one capture group).
+
+| Param | Notes |
+|-------|--------|
+| `relative_path` | File with the callsite. |
+| `regex` | e.g. `obj\.(process)\(` — prefer enough context to disambiguate. |
+| `containing_symbol_name_path` | Limit search to a parent symbol body. |
+
+### `find_implementations`
+
+Like find_symbol but for implementers of an interface/abstract symbol.
+
+### `search_for_pattern`
+
+Regex across files when you **don't know the symbol name**.
+
+| Param | Notes |
+|-------|--------|
+| `substring_pattern` | Python `re` syntax. |
+| `relative_path` | File or subtree. |
+| `paths_include_glob` / `paths_exclude_glob` | e.g. `src/**/*.py`. |
+| `restrict_search_to_code_files` | Skip non-code files. |
+| `context_lines_before` / `after` | Surrounding lines. |
+| `multiline` | Default `true` (DOTALL + MULTILINE). |
+
+Prefer symbolic tools once you know the symbol.
+
+---
+
+## Editing
+
+### `replace_symbol_body`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Target symbol. |
+| `relative_path` | File path. |
+| `body` | Complete new symbol body (definition only). |
+
+**Requires prior `find_symbol(..., include_body=True)`.**
+
+### `insert_after_symbol` / `insert_before_symbol`
+
+Add new code adjacent to a symbol. Do not use for assignments/constants — use insert_before at file's first symbol for imports.
+
+### `rename_symbol`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Symbol to rename. |
+| `relative_path` | Defining file. |
+| `new_name` | Local rename (not path). |
+
+Updates all references project-wide.
+
+### `safe_delete_symbol`
+
+Deletes symbol if zero references; otherwise returns reference list.
+
+### `replace_content`
+
+Single-file edit.
+
+| Param | Notes |
+|-------|--------|
+| `mode` | `literal` or `regex` (MULTILINE + DOTALL). |
+| `needle` / `repl` | Search / replacement. |
+| `allow_multiple_occurrences` | Default `false` — fails if ambiguous. |
+
+**Regex tip:** `def foo.*?return x` avoids pasting huge old bodies; ambiguous match ⇒ error, refine wildcard.
+
+### `replace_in_files`
+
+Bulk edit — **preferred for repeated small changes across files**.
+
+| Param | Notes |
+|-------|--------|
+| `dry_run` | `true` → list diffs + `occurrence_ids`, no writes. |
+| `occurrence_ids` | Apply subset from dry run. |
+| `expected_count` | Guard: abort if match count differs. |
+| `relative_path` | Scope file/dir. |
+| `paths_include_glob` / `paths_exclude_glob` | Further filter. |
+
+---
+
+## Diagnostics & meta
+
+### `get_diagnostics_for_file`
+
+LSP errors/warnings/hints grouped by symbol. `min_severity`: 1=Error … 4=Hint.  
+`start_line` / `end_line` are **0-based**.
+
+### `initial_instructions`
+
+No args. Returns Serena Instructions Manual — **call at task start**.
+
+### `onboarding`
+
+One-time project familiarization; writes memories. Skip if `list_memories` is non-empty.
+
+### `open_dashboard`
+
+Opens Serena web dashboard (memories, language servers).
+
+---
+
+## Memories
+
+| Tool | Purpose |
+|------|---------|
+| `list_memories` | Optional `topic` filter (`conventions`, `global/…`). |
+| `read_memory` | Load `memory_name`. |
+| `write_memory` | Create/update markdown memory. |
+| `edit_memory` | Regex replace inside memory. |
+| `rename_memory` | Rename; rewrites `` `mem:old` `` refs. |
+| `delete_memory` | Only when user approves. |
+
+Reference other memories as `` `mem:name` `` in content.
+
+**matryca-plumber seeds:** `conventions`, `core`, `tech_stack`, `suggested_commands`, `task_completion`, `graph_write_safety`, `memory_maintenance`.
+
+---
+
+## Contexts & modes (server startup)
+
+Set in MCP launch args (not per call):
+
+| Context | Use |
+|---------|-----|
+| `ide` / `ide-assistant` | Cursor, VS Code, Cline — augment IDE tools |
+| `agent` | Standalone agent, full toolset |
+| `claude-code` | Disables tools Claude Code already has |
+
+| Mode | Effect |
+|------|--------|
+| `no-onboarding` | Skip first-run onboarding |
+| `no-memories` | Disable memory tools |
+| `query-projects` | Enable cross-project read |
+
+This repo (`.codex/config.toml`): `--context ide-assistant --project <matryca-plumber>`.
+
+---
+
+## Error handling
+
+- **Too many matches** from `find_symbol` → narrow `relative_path`, use absolute `/path`, or `max_matches=1`.
+- **Ambiguous regex** from `replace_content` → tighten wildcards or use symbol tools.
+- **`safe_delete_symbol` returns references** → remove or repoint callers first.
+- **Timeouts on `get_diagnostics_for_file`** — retry once; fall back to `make typecheck`.
+
+---
+
+## Comparison: Serena vs Cursor native tools
+
+| Need | Serena | Cursor Read/Grep |
+|------|--------|------------------|
+| Symbol body for edit | `find_symbol` + `replace_symbol_body` | Read full file + StrReplace |
+| Who calls `foo`? | `find_referencing_symbols` | Grep (no type awareness) |
+| Rename across repo | `rename_symbol` | Error-prone replace_all |
+| Find string in logs | — | Grep |
+| Read CHANGELOG | — | Read |
+
+Use both: Serena for **Python `src/` and `tests/`** structure; Grep for text and non-code.

--- a/.cursor/skills/serena/SKILL.md
+++ b/.cursor/skills/serena/SKILL.md
@@ -169,4 +169,4 @@ Full parameter detail: [reference.md](reference.md).
 ## Related skills
 
 - **GitNexus** — execution-flow / call-graph impact before `src/` edits.
-- **`.agents/skills/serena/`** — same content for agent routers that load from `.agents/`.
+- Mirrored in `.cursor/skills/serena/` and `.agents/skills/serena/`; **`.cursor/skills/serena/` is canonical**.

--- a/.cursor/skills/serena/SKILL.md
+++ b/.cursor/skills/serena/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: serena
+description: >-
+  Use Serena MCP for semantic code navigation and symbol-level edits in
+  matryca-plumber. Prefer over blind grep/read when exploring or changing Python
+  symbols. MCP server: serena-matryca-plumber (not global serena).
+---
+
+# Serena MCP — matryca-plumber
+
+Serena is an **MCP server** that exposes IDE-like **symbol retrieval and editing** via Language Server Protocol (LSP). It operates at the **symbol level** (classes, functions, methods), not line numbers.
+
+**Official docs:** https://oraios.github.io/serena/  
+**Upstream:** https://github.com/oraios/serena
+
+## This repo — critical routing
+
+| Item | Value |
+|------|--------|
+| **MCP server** | `serena-matryca-plumber` |
+| **Do not use** | `user-serena` (bound to Matryca-per-Delineat) |
+| **Project root** | matryca-plumber checkout (passed at MCP startup) |
+| **Context** | `ide-assistant` (see `.codex/config.toml`) |
+
+One Serena instance = one project. Two repos ⇒ two MCP server entries.
+
+## First action on coding tasks
+
+1. Call **`initial_instructions`** on `serena-matryca-plumber` (Serena Instructions Manual).
+2. If memories exist, **`list_memories`** then **`read_memory`** for relevant entries (`mem:conventions`, `mem:task_completion`, `mem:suggested_commands`).
+3. Skip **`onboarding`** unless the project has no memories yet.
+
+## When to use Serena (prefer over grep/read)
+
+| Task | Serena tool | Why |
+|------|-------------|-----|
+| New file / unknown area | `get_symbols_overview` | Compact symbol map without reading whole file |
+| Find definition | `find_symbol` | LSP-accurate; supports `depth`, `substring_matching` |
+| Blast radius before edit | `find_referencing_symbols` | All references with snippets |
+| Rename / delete symbol | `rename_symbol` / `safe_delete_symbol` | Reference-aware, atomic |
+| Replace whole function/class | `replace_symbol_body` | After `include_body=True` retrieval |
+| Small in-method patch | `replace_content` (regex) | Cheaper than full symbol replace |
+| Same edit in N files | `replace_in_files` + `dry_run=True` first | One call, occurrence IDs |
+| Unknown symbol location | `search_for_pattern` | Regex; then switch to symbolic tools |
+| Post-edit sanity | `get_diagnostics_for_file` | LSP errors on touched files |
+
+## When NOT to use Serena
+
+- **Markdown, YAML, TOML, lockfiles** — use Read/Grep.
+- **Whole-file config or docs** — Read is fine.
+- **Shell / git / CI** — terminal (`make ci`, `uv run pytest …`).
+- **After `replace_symbol_body` / `rename_symbol` succeeds** — do not re-read the file to “confirm”; trust the tool.
+- **After `safe_delete_symbol` succeeds** — same.
+
+## Agent-drift guard (official recommendation)
+
+If you make **many consecutive `grep` / `read_file` calls without any Serena tool**, switch to Serena for the next exploration step. Cursor does not ship `serena-hooks remind`; self-enforce the same rule.
+
+## Standard workflow
+
+```
+get_symbols_overview(file)     # orient
+    ↓
+find_symbol(pattern, depth=0|1)  # locate; include_body only when editing
+    ↓
+find_referencing_symbols       # before non-trivial changes
+    ↓
+edit (symbol or regex tool)
+    ↓
+get_diagnostics_for_file       # optional, touched files only
+    ↓
+make check / make ci             # mem:task_completion
+```
+
+### Parallelism (token/cost)
+
+Serena runs tool calls **sequentially** internally, but you should still **batch independent Serena reads** in one turn (overview + find_symbol on different files). Do **not** re-analyze a file with symbolic tools after you already read it fully.
+
+## Name paths (Python)
+
+Within a file, symbols use `/` paths:
+
+| Pattern | Matches |
+|---------|---------|
+| `prepare_fts_user_query` | Any symbol named that |
+| `ShadowGraphRepository/read_subtree_markdown` | Method on class |
+| `/MyClass/my_method` | Exact full path in file |
+| `Foo/get` + `substring_matching=True` | `getValue`, `getData`, … |
+| `MyClass/my_method[1]` | Overloaded index (rare in Python) |
+
+**Line numbers in Serena output are 0-based** (convert mentally to editor 1-based).
+
+## Editing rules
+
+### Symbol-level (preferred for whole definitions)
+
+1. **`find_symbol` with `include_body=True`** on the target first.
+2. **`replace_symbol_body`** — pass full new body (signature + implementation per language).
+3. **`insert_after_symbol` / `insert_before_symbol`** — new top-level or member definitions.
+4. **`rename_symbol`** — never find-and-replace rename across the repo.
+
+### File-level (small patches inside a symbol)
+
+- **`replace_content`** — `mode: regex` with wildcards (`beginning.*?end`) for multi-line spans; ambiguous match ⇒ refine pattern (safe by design).
+- **`replace_in_files`** — bulk literal/regex; **always `dry_run=True` first** when risk of collateral edits; then apply by `occurrence_ids`.
+
+### Do not
+
+- `replace_symbol_body` without prior `include_body=True` retrieval.
+- Global quote-and-replace renames (use `rename_symbol`).
+- Re-run tests only to verify a successful `rename_symbol`.
+
+## Memories (project-specific)
+
+Stored under `.serena/memories/` (if present). Reference as `` `mem:name` ``.
+
+| Memory | Use when |
+|--------|----------|
+| `mem:conventions` | Style, layers, naming |
+| `mem:task_completion` | Definition of done (`make ci`) |
+| `mem:suggested_commands` | Makefile / uv commands |
+| `mem:core` | Project map entry point |
+| `mem:graph_write_safety` | Vault write / sandbox rules |
+
+CLI integrity (human): `serena memories check` from project root.
+
+## matryca-plumber completion gate
+
+After code changes:
+
+```bash
+make lint && make typecheck && make test
+# or full gate:
+make ci
+```
+
+See `mem:task_completion`. Complement with GitNexus `impact` / `detect_changes` when changing `src/` symbols (repo policy).
+
+## Tool quick reference
+
+Full parameter detail: [reference.md](reference.md).
+
+| Tool | Purpose |
+|------|---------|
+| `initial_instructions` | Manual — call once per task |
+| `get_symbols_overview` | File symbol index |
+| `find_symbol` | Resolve symbols by name path |
+| `find_referencing_symbols` | Incoming references |
+| `find_declaration` | Jump to declaration via callsite regex |
+| `find_implementations` | Implementations of interface/abstract |
+| `search_for_pattern` | Regex grep with context |
+| `replace_symbol_body` | Replace symbol definition |
+| `insert_after_symbol` / `insert_before_symbol` | Add code near symbol |
+| `rename_symbol` | Project-wide rename |
+| `safe_delete_symbol` | Delete if unreferenced |
+| `replace_content` | Single-file regex/literal edit |
+| `replace_in_files` | Multi-file regex/literal edit |
+| `get_diagnostics_for_file` | LSP diagnostics |
+| `list_memories` / `read_memory` / `write_memory` | Project knowledge |
+| `open_dashboard` | Web UI for memories (optional) |
+
+## Official concepts (short)
+
+- **Project** — directory Serena indexes (this repo).
+- **Context** — `ide` / `ide-assistant` / `agent` / `claude-code`; set at server start, not per message.
+- **Modes** — composable flags (`no-onboarding`, `no-memories`, `query-projects`, …).
+- **Indexing** — `serena project index` once; LSP updates incrementally. JetBrains plugin uses IDE index instead.
+
+## Related skills
+
+- **GitNexus** — execution-flow / call-graph impact before `src/` edits.
+- **`.agents/skills/serena/`** — same content for agent routers that load from `.agents/`.

--- a/.cursor/skills/serena/reference.md
+++ b/.cursor/skills/serena/reference.md
@@ -1,7 +1,7 @@
 # Serena MCP — tool reference (matryca-plumber)
 
-MCP server: **`serena-matryca-plumber`**.  
-Source of truth for schemas: call `GetMcpTools` with `server: user-serena-matryca-plumber`.
+MCP server: **`serena-matryca-plumber`** (canonical for this repo).  
+Source of truth for schemas: `GetMcpTools` with `server: serena-matryca-plumber`.
 
 Official: https://oraios.github.io/serena/02-usage/040_workflow.html
 

--- a/.cursor/skills/serena/reference.md
+++ b/.cursor/skills/serena/reference.md
@@ -1,0 +1,208 @@
+# Serena MCP — tool reference (matryca-plumber)
+
+MCP server: **`serena-matryca-plumber`**.  
+Source of truth for schemas: call `GetMcpTools` with `server: user-serena-matryca-plumber`.
+
+Official: https://oraios.github.io/serena/02-usage/040_workflow.html
+
+---
+
+## Retrieval
+
+### `get_symbols_overview`
+
+**First tool for an unfamiliar code file.**
+
+| Param | Notes |
+|-------|--------|
+| `relative_path` | Required. Repo-relative path. |
+| `depth` | `-1` = language default; `1` includes class methods (Java/Kotlin default). |
+| `max_answer_chars` | Truncate huge files; avoid unless necessary. |
+
+### `find_symbol`
+
+| Param | Notes |
+|-------|--------|
+| `name_path_pattern` | Simple name, suffix `class/method`, or absolute `/class/method`. |
+| `relative_path` | Optional file or directory scope. |
+| `depth` | `1` → children (e.g. class methods). Ignored if `include_body=True`. |
+| `include_body` | Full source — use only when editing. |
+| `include_info` | Hover-like docstring/signature (slow on C++). |
+| `substring_matching` | `Foo/get` matches `getValue`, `getData`. |
+| `max_matches` | Use `1` when you want a single unambiguous hit. |
+
+### `find_referencing_symbols`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Symbol to look up (not a pattern). |
+| `relative_path` | File containing the symbol. |
+| `include_kinds` / `exclude_kinds` | LSP symbol kind filters (integers). |
+
+Returns referencing symbols + short snippet around each use.
+
+### `find_declaration`
+
+Resolve declaration from a **callsite regex** (one capture group).
+
+| Param | Notes |
+|-------|--------|
+| `relative_path` | File with the callsite. |
+| `regex` | e.g. `obj\.(process)\(` — prefer enough context to disambiguate. |
+| `containing_symbol_name_path` | Limit search to a parent symbol body. |
+
+### `find_implementations`
+
+Like find_symbol but for implementers of an interface/abstract symbol.
+
+### `search_for_pattern`
+
+Regex across files when you **don't know the symbol name**.
+
+| Param | Notes |
+|-------|--------|
+| `substring_pattern` | Python `re` syntax. |
+| `relative_path` | File or subtree. |
+| `paths_include_glob` / `paths_exclude_glob` | e.g. `src/**/*.py`. |
+| `restrict_search_to_code_files` | Skip non-code files. |
+| `context_lines_before` / `after` | Surrounding lines. |
+| `multiline` | Default `true` (DOTALL + MULTILINE). |
+
+Prefer symbolic tools once you know the symbol.
+
+---
+
+## Editing
+
+### `replace_symbol_body`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Target symbol. |
+| `relative_path` | File path. |
+| `body` | Complete new symbol body (definition only). |
+
+**Requires prior `find_symbol(..., include_body=True)`.**
+
+### `insert_after_symbol` / `insert_before_symbol`
+
+Add new code adjacent to a symbol. Do not use for assignments/constants — use insert_before at file's first symbol for imports.
+
+### `rename_symbol`
+
+| Param | Notes |
+|-------|--------|
+| `name_path` | Symbol to rename. |
+| `relative_path` | Defining file. |
+| `new_name` | Local rename (not path). |
+
+Updates all references project-wide.
+
+### `safe_delete_symbol`
+
+Deletes symbol if zero references; otherwise returns reference list.
+
+### `replace_content`
+
+Single-file edit.
+
+| Param | Notes |
+|-------|--------|
+| `mode` | `literal` or `regex` (MULTILINE + DOTALL). |
+| `needle` / `repl` | Search / replacement. |
+| `allow_multiple_occurrences` | Default `false` — fails if ambiguous. |
+
+**Regex tip:** `def foo.*?return x` avoids pasting huge old bodies; ambiguous match ⇒ error, refine wildcard.
+
+### `replace_in_files`
+
+Bulk edit — **preferred for repeated small changes across files**.
+
+| Param | Notes |
+|-------|--------|
+| `dry_run` | `true` → list diffs + `occurrence_ids`, no writes. |
+| `occurrence_ids` | Apply subset from dry run. |
+| `expected_count` | Guard: abort if match count differs. |
+| `relative_path` | Scope file/dir. |
+| `paths_include_glob` / `paths_exclude_glob` | Further filter. |
+
+---
+
+## Diagnostics & meta
+
+### `get_diagnostics_for_file`
+
+LSP errors/warnings/hints grouped by symbol. `min_severity`: 1=Error … 4=Hint.  
+`start_line` / `end_line` are **0-based**.
+
+### `initial_instructions`
+
+No args. Returns Serena Instructions Manual — **call at task start**.
+
+### `onboarding`
+
+One-time project familiarization; writes memories. Skip if `list_memories` is non-empty.
+
+### `open_dashboard`
+
+Opens Serena web dashboard (memories, language servers).
+
+---
+
+## Memories
+
+| Tool | Purpose |
+|------|---------|
+| `list_memories` | Optional `topic` filter (`conventions`, `global/…`). |
+| `read_memory` | Load `memory_name`. |
+| `write_memory` | Create/update markdown memory. |
+| `edit_memory` | Regex replace inside memory. |
+| `rename_memory` | Rename; rewrites `` `mem:old` `` refs. |
+| `delete_memory` | Only when user approves. |
+
+Reference other memories as `` `mem:name` `` in content.
+
+**matryca-plumber seeds:** `conventions`, `core`, `tech_stack`, `suggested_commands`, `task_completion`, `graph_write_safety`, `memory_maintenance`.
+
+---
+
+## Contexts & modes (server startup)
+
+Set in MCP launch args (not per call):
+
+| Context | Use |
+|---------|-----|
+| `ide` / `ide-assistant` | Cursor, VS Code, Cline — augment IDE tools |
+| `agent` | Standalone agent, full toolset |
+| `claude-code` | Disables tools Claude Code already has |
+
+| Mode | Effect |
+|------|--------|
+| `no-onboarding` | Skip first-run onboarding |
+| `no-memories` | Disable memory tools |
+| `query-projects` | Enable cross-project read |
+
+This repo (`.codex/config.toml`): `--context ide-assistant --project <matryca-plumber>`.
+
+---
+
+## Error handling
+
+- **Too many matches** from `find_symbol` → narrow `relative_path`, use absolute `/path`, or `max_matches=1`.
+- **Ambiguous regex** from `replace_content` → tighten wildcards or use symbol tools.
+- **`safe_delete_symbol` returns references** → remove or repoint callers first.
+- **Timeouts on `get_diagnostics_for_file`** — retry once; fall back to `make typecheck`.
+
+---
+
+## Comparison: Serena vs Cursor native tools
+
+| Need | Serena | Cursor Read/Grep |
+|------|--------|------------------|
+| Symbol body for edit | `find_symbol` + `replace_symbol_body` | Read full file + StrReplace |
+| Who calls `foo`? | `find_referencing_symbols` | Grep (no type awareness) |
+| Rename across repo | `rename_symbol` | Error-prone replace_all |
+| Find string in logs | — | Grep |
+| Read CHANGELOG | — | Read |
+
+Use both: Serena for **Python `src/` and `tests/`** structure; Grep for text and non-code.

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,8 @@ repomix-output.md
 .cursor/*
 !.cursor/rules/
 !.cursor/rules/**
+!.cursor/skills/
+!.cursor/skills/**
 
 # ========================================
 # 🌐 Frontend (React / Node.js)


### PR DESCRIPTION
## Status

Superseded by the current local-only, multi-project code-intelligence configuration.

The files proposed here are intentionally excluded from repository history under the current vendor-neutral tooling policy. No runtime or package changes from this branch are required.