### PR TITLE
docs: align Axis 4 gate count for alpha.3

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Matryca Plumber — System Architecture
 
-**Version:** 2.0.0-alpha.3 (FTS hyphenated query #277, Axis 4 audit 27 pass) · builds on 2.0.0-alpha.2 (rename stale-owner #272, Axis 2–3 audit probes) · 2.0.0-alpha.1 (Shadow DB Axis 1 hardening — writer flock #262, meta/pages health #264) · 1.14.0 (catalog write-safety + leaf-module dependency direction + Tier F env_parse / graph→rag guards), 1.13.1 (parser 1.6.0 alignment), 1.13.0 (daemon/dispatch modularization + GraphReadPort v2 Phase 1), 1.12.0 (Tier-1 prompt Clean Architecture + L0 write safety + SYSTEM_PROMPT fragment assembly + AGENTS.md router), and 1.11.2 (graph layer boundary + bounded RAM + OCC ns parity)  
+**Version:** 2.0.0-alpha.3 (FTS hyphenated query #277; Axis 4 audit initial 27 pass + 3 xfail; alpha.3 gate 28 pass + 2 xfail) · builds on 2.0.0-alpha.2 (rename stale-owner #272, Axis 2–3 audit probes) · 2.0.0-alpha.1 (Shadow DB Axis 1 hardening — writer flock #262, meta/pages health #264) · 1.14.0 (catalog write-safety + leaf-module dependency direction + Tier F env_parse / graph→rag guards), 1.13.1 (parser 1.6.0 alignment), 1.13.0 (daemon/dispatch modularization + GraphReadPort v2 Phase 1), 1.12.0 (Tier-1 prompt Clean Architecture + L0 write safety + SYSTEM_PROMPT fragment assembly + AGENTS.md router), and 1.11.2 (graph layer boundary + bounded RAM + OCC ns parity)
 **Package:** `matryca-plumber` on PyPI  
 **Audience:** maintainers, contributors, and operators integrating Logseq OG with local LLMs
 


### PR DESCRIPTION
## Summary

Post-release editorial fix on `docs/ARCHITECTURE.md` (SSOT): distinguish Axis 4 audit #280 initial snapshot (**27 pass + 3 xfail**) from the alpha.3 gate after #282 (**28 pass + 2 xfail**).

No version bump, no `CHANGELOG.md`, no runtime impact.

## Scope

- 1 file, 1 substantive line (`docs/ARCHITECTURE.md` version header)

## Gates

- [x] `make docs-check`
- [x] `make agents-check`
- [x] `git diff --check`
- [x] GitNexus `detect_changes(compare main)` — **low**, 0 runtime processes

## Test plan

- [ ] CI (docs-only)

Made with [Cursor](https://cursor.com)