### PR TITLE
fix(shadow): bound FTS user query length before MATCH (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- **Shadow FTS query length bound (#279)** — user keywords over **512 Unicode characters** (post-`strip`) are rejected with a bounded validation error before FTS preparation or SQLite `MATCH`; no generational BM25 fallback while shadow is `ready`.
+
 - **Shadow FTS hyphenated keywords (#277 / #282)** — natural compound tokens such as `state-of-the-art` are quoted before FTS5 `MATCH`, so shadow search no longer mis-parses interior hyphens as boolean `NOT` or falls back to generational BM25 while health is `ready`.
 
 ### Tests / Quality

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -15,10 +15,23 @@ from .health import ShadowHealthState, resolve_shadow_health
 from .query import BlockHit, search_blocks_fts
 
 _FTS_VALIDATION_PREFIX = "Invalid FTS query for `method=bm25`"
+# Interactive FTS ``MATCH`` input cap (Unicode code points, post-``strip``). Chosen as 2×
+# ``MAX_REGEX_PATTERN_LEN`` (256) to allow multi-token queries with operators while
+# rejecting multi-kilobyte probes before SQLite.
+MAX_FTS_MATCH_QUERY_CHARS = 512
 
 
 class FtsQueryValidationError(ValueError):
     """User-supplied keyword is not a valid FTS5 ``MATCH`` expression."""
+
+
+def check_fts_query_length_bounded(stripped_query: str) -> None:
+    """Reject overlong user input before FTS preparation or SQLite ``MATCH``."""
+    if len(stripped_query) > MAX_FTS_MATCH_QUERY_CHARS:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: query exceeds max length "
+            f"({MAX_FTS_MATCH_QUERY_CHARS} Unicode characters)."
+        )
 
 
 def validate_fts_match_query(keyword: str) -> None:
@@ -28,6 +41,7 @@ def validate_fts_match_query(keyword: str) -> None:
         raise FtsQueryValidationError(
             f"{_FTS_VALIDATION_PREFIX}: query is empty after trimming whitespace."
         )
+    check_fts_query_length_bounded(q)
     if q.count('"') % 2 != 0:
         raise FtsQueryValidationError(
             f"{_FTS_VALIDATION_PREFIX}: unbalanced double quotes in {q!r}."
@@ -132,6 +146,8 @@ def resolve_bm25_search_markdown(
 
 __all__ = [
     "FtsQueryValidationError",
+    "MAX_FTS_MATCH_QUERY_CHARS",
+    "check_fts_query_length_bounded",
     "format_shadow_fts_markdown",
     "resolve_bm25_search_markdown",
     "validate_fts_match_query",

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -11,41 +11,15 @@ from ..graph.path_sandbox import resolved_graph_root
 from ..rag.local_query import format_keyword_query_markdown
 from .config import shadow_db_enabled
 from .connection import open_shadow_db
+from .fts_validation import (
+    _FTS_VALIDATION_PREFIX,
+    MAX_FTS_MATCH_QUERY_CHARS,
+    FtsQueryValidationError,
+    check_fts_query_length_bounded,
+    validate_fts_match_query,
+)
 from .health import ShadowHealthState, resolve_shadow_health
 from .query import BlockHit, search_blocks_fts
-
-_FTS_VALIDATION_PREFIX = "Invalid FTS query for `method=bm25`"
-# Interactive FTS ``MATCH`` input cap (Unicode code points, post-``strip``). Chosen as 2×
-# ``MAX_REGEX_PATTERN_LEN`` (256) to allow multi-token queries with operators while
-# rejecting multi-kilobyte probes before SQLite.
-MAX_FTS_MATCH_QUERY_CHARS = 512
-
-
-class FtsQueryValidationError(ValueError):
-    """User-supplied keyword is not a valid FTS5 ``MATCH`` expression."""
-
-
-def check_fts_query_length_bounded(stripped_query: str) -> None:
-    """Reject overlong user input before FTS preparation or SQLite ``MATCH``."""
-    if len(stripped_query) > MAX_FTS_MATCH_QUERY_CHARS:
-        raise FtsQueryValidationError(
-            f"{_FTS_VALIDATION_PREFIX}: query exceeds max length "
-            f"({MAX_FTS_MATCH_QUERY_CHARS} Unicode characters)."
-        )
-
-
-def validate_fts_match_query(keyword: str) -> None:
-    """Reject obviously invalid FTS5 query syntax before hitting SQLite."""
-    q = keyword.strip()
-    if not q:
-        raise FtsQueryValidationError(
-            f"{_FTS_VALIDATION_PREFIX}: query is empty after trimming whitespace."
-        )
-    check_fts_query_length_bounded(q)
-    if q.count('"') % 2 != 0:
-        raise FtsQueryValidationError(
-            f"{_FTS_VALIDATION_PREFIX}: unbalanced double quotes in {q!r}."
-        )
 
 
 def _page_rows_for_hits(

--- a/src/shadow/fts_validation.py
+++ b/src/shadow/fts_validation.py
@@ -1,0 +1,44 @@
+"""Bounded FTS5 user-query validation (leaf module; no query/format imports)."""
+
+from __future__ import annotations
+
+_FTS_VALIDATION_PREFIX = "Invalid FTS query for `method=bm25`"
+# Interactive FTS ``MATCH`` input cap (Unicode code points, post-``strip``). Chosen as 2×
+# ``MAX_REGEX_PATTERN_LEN`` (256) to allow multi-token queries with operators while
+# rejecting multi-kilobyte probes before SQLite.
+MAX_FTS_MATCH_QUERY_CHARS = 512
+
+
+class FtsQueryValidationError(ValueError):
+    """User-supplied keyword is not a valid FTS5 ``MATCH`` expression."""
+
+
+def check_fts_query_length_bounded(stripped_query: str) -> None:
+    """Reject overlong user input before FTS preparation or SQLite ``MATCH``."""
+    if len(stripped_query) > MAX_FTS_MATCH_QUERY_CHARS:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: query exceeds max length "
+            f"({MAX_FTS_MATCH_QUERY_CHARS} Unicode characters)."
+        )
+
+
+def validate_fts_match_query(keyword: str) -> None:
+    """Reject obviously invalid FTS5 query syntax before hitting SQLite."""
+    q = keyword.strip()
+    if not q:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: query is empty after trimming whitespace."
+        )
+    check_fts_query_length_bounded(q)
+    if q.count('"') % 2 != 0:
+        raise FtsQueryValidationError(
+            f"{_FTS_VALIDATION_PREFIX}: unbalanced double quotes in {q!r}."
+        )
+
+
+__all__ = [
+    "FtsQueryValidationError",
+    "MAX_FTS_MATCH_QUERY_CHARS",
+    "check_fts_query_length_bounded",
+    "validate_fts_match_query",
+]

--- a/src/shadow/query.py
+++ b/src/shadow/query.py
@@ -6,6 +6,8 @@ import re
 import sqlite3
 from dataclasses import dataclass
 
+from .fts_validation import check_fts_query_length_bounded
+
 # ASCII hyphen + common Unicode dash code points (en/em/figure dashes).
 _HYPHEN_DASH_CLASS = "-\u2010\u2011\u2012\u2013\u2014"
 _FTS_RESERVED_TOKENS = frozenset({"OR", "AND", "NOT", "NEAR"})
@@ -95,8 +97,6 @@ def search_blocks_fts(
     stripped = query.strip()
     if not stripped:
         return []
-    from .fts_format import check_fts_query_length_bounded
-
     check_fts_query_length_bounded(stripped)
     q = prepare_fts_user_query(query)
     capped = max(1, min(int(limit), 500))

--- a/src/shadow/query.py
+++ b/src/shadow/query.py
@@ -92,9 +92,13 @@ def search_blocks_fts(
     should supply FTS5 query syntax (plain tokens are fine for simple search).
     Empty / whitespace-only queries return an empty list.
     """
-    q = prepare_fts_user_query(query)
-    if not q:
+    stripped = query.strip()
+    if not stripped:
         return []
+    from .fts_format import check_fts_query_length_bounded
+
+    check_fts_query_length_bounded(stripped)
+    q = prepare_fts_user_query(query)
     capped = max(1, min(int(limit), 500))
     rows = connection.execute(
         """

--- a/tests/test_shadow_fts.py
+++ b/tests/test_shadow_fts.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from src.shadow.connection import open_shadow_db
+from src.shadow.fts_format import FtsQueryValidationError
 from src.shadow.query import prepare_fts_user_query, search_blocks_fts
 from src.shadow.sync import sync_page_to_shadow
 
@@ -72,6 +73,14 @@ def test_prepare_fts_user_query_quotes_natural_hyphen_compounds() -> None:
     assert prepare_fts_user_query("needle state-of-the-art") == 'needle "state-of-the-art"'
     assert prepare_fts_user_query("alpha OR beta") == "alpha OR beta"
     assert prepare_fts_user_query('"state-of-the-art"') == '"state-of-the-art"'
+
+
+def test_validate_fts_match_query_rejects_overlong_input() -> None:
+    from src.shadow.fts_format import MAX_FTS_MATCH_QUERY_CHARS, validate_fts_match_query
+
+    validate_fts_match_query("n" * MAX_FTS_MATCH_QUERY_CHARS)
+    with pytest.raises(FtsQueryValidationError, match="exceeds max length"):
+        validate_fts_match_query("n" * (MAX_FTS_MATCH_QUERY_CHARS + 1))
 
 
 def test_search_blocks_fts_hyphenated_user_query(tmp_path: Path) -> None:

--- a/tests/test_shadow_fts_validation_boundary.py
+++ b/tests/test_shadow_fts_validation_boundary.py
@@ -1,0 +1,24 @@
+"""Shadow FTS validation layering — leaf module must not depend on query/format."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_query_module_does_not_import_fts_format() -> None:
+    query_path = Path(__file__).resolve().parents[1] / "src" / "shadow" / "query.py"
+    text = query_path.read_text(encoding="utf-8")
+    assert "fts_format" not in text
+
+
+def test_fts_validation_leaf_has_no_query_or_format_imports() -> None:
+    validation_path = Path(__file__).resolve().parents[1] / "src" / "shadow" / "fts_validation.py"
+    text = validation_path.read_text(encoding="utf-8")
+    forbidden = (
+        "from .query",
+        "from src.shadow.query",
+        "from .fts_format",
+        "from src.shadow.fts_format",
+    )
+    offenders = [needle for needle in forbidden if needle in text]
+    assert offenders == []

--- a/tests/test_shadow_hardening_axis4_fts5.py
+++ b/tests/test_shadow_hardening_axis4_fts5.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from src.agent.dispatch_search_handlers import handle_search_bm25
 from src.shadow.bootstrap import rebuild_shadow_from_graph
 from src.shadow.connection import open_shadow_db, shadow_db_path
 from src.shadow.fts_format import (
+    MAX_FTS_MATCH_QUERY_CHARS,
     FtsQueryValidationError,
     format_shadow_fts_markdown,
     resolve_bm25_search_markdown,
@@ -325,15 +326,110 @@ def test_a4_query_09_invalid_syntax_validation_error(tmp_path: Path) -> None:
         validate_fts_match_query('"unclosed')
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P2 #279: FTS query length should be bounded before SQLite MATCH",
-)
 def test_a4_query_10_very_long_query_bounded(tmp_path: Path) -> None:
-    """A4-QUERY-10: overlong query rejected with validation error (bounded input)."""
+    """A4-QUERY-10 (#279): overlong query rejected with validation error (bounded input)."""
     long_query = "needle " + ("x" * 5000)
-    with pytest.raises(FtsQueryValidationError):
+    with pytest.raises(FtsQueryValidationError, match="exceeds max length"):
         validate_fts_match_query(long_query)
+
+
+def test_a4_query_10b_length_at_limit_minus_one_accepted(tmp_path: Path) -> None:
+    """A4-QUERY-10b (#279): query at limit-1 passes validation."""
+    query = "n" * (MAX_FTS_MATCH_QUERY_CHARS - 1)
+    validate_fts_match_query(query)
+
+
+def test_a4_query_10c_length_at_limit_accepted(tmp_path: Path) -> None:
+    """A4-QUERY-10c (#279): query at exact limit passes validation."""
+    query = "n" * MAX_FTS_MATCH_QUERY_CHARS
+    validate_fts_match_query(query)
+
+
+def test_a4_query_10d_length_over_limit_rejected(tmp_path: Path) -> None:
+    """A4-QUERY-10d (#279): query at limit+1 is rejected."""
+    query = "n" * (MAX_FTS_MATCH_QUERY_CHARS + 1)
+    with pytest.raises(FtsQueryValidationError, match="exceeds max length"):
+        validate_fts_match_query(query)
+
+
+def test_a4_query_10e_unicode_multibyte_counts_characters_not_bytes(tmp_path: Path) -> None:
+    """A4-QUERY-10e (#279): limit uses Unicode code points, not UTF-8 byte length."""
+    query = "café" + ("é" * (MAX_FTS_MATCH_QUERY_CHARS - 4))
+    validate_fts_match_query(query)
+    over = "café" + ("é" * (MAX_FTS_MATCH_QUERY_CHARS - 3))
+    with pytest.raises(FtsQueryValidationError, match="exceeds max length"):
+        validate_fts_match_query(over)
+
+
+def test_a4_query_10f_whitespace_only_still_empty_at_fts_layer(tmp_path: Path) -> None:
+    """A4-QUERY-10f (#279): whitespace-only input unchanged at FTS search layer."""
+    graph = _minimal_graph(tmp_path)
+    _seed_fts_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        assert search_blocks_fts(conn, "   \t\n") == []
+    finally:
+        conn.close()
+
+
+def test_a4_query_10g_operator_prefix_hyphen_within_limit(tmp_path: Path) -> None:
+    """A4-QUERY-10g (#279): operators, prefix, and hyphenated tokens within limit."""
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/BoundOps.md",
+        "- alpha state-of-the-art prefixneedle token\n"
+        "  id:: 19191919-1919-4191-8191-919191919191\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        query = 'alpha OR "state-of-the-art" prefix*'
+        validate_fts_match_query(query)
+        assert len(search_blocks_fts(conn, query)) == 1
+    finally:
+        conn.close()
+
+
+def test_a4_query_10h_overlong_skips_sqlite_match() -> None:
+    """A4-QUERY-10h (#279): overlong query never reaches SQLite ``MATCH``."""
+    conn = MagicMock(spec=sqlite3.Connection)
+    overlong = "n" * (MAX_FTS_MATCH_QUERY_CHARS + 1)
+    with pytest.raises(FtsQueryValidationError):
+        search_blocks_fts(conn, overlong)
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a4_query_10i_overlong_public_bm25_validation_error(tmp_path: Path) -> None:
+    """A4-QUERY-10i (#279): MCP/CLI BM25 envelope returns validation error, no fallback."""
+    graph = _minimal_graph(tmp_path)
+    _seed_fts_graph(graph)
+    overlong = "needle " + ("x" * 5000)
+    out = await handle_search_bm25(str(graph), overlong)
+    assert "Invalid FTS query" in out
+    assert "exceeds max length" in out
+    assert "block `" not in out
+    assert "xxxx" not in out
+
+
+def test_a4_query_10j_overlong_error_message_bounded(tmp_path: Path) -> None:
+    """A4-QUERY-10j (#279): validation error omits full query and vault paths."""
+    graph = _minimal_graph(tmp_path)
+    secret = "supersecretvaulttoken"
+    _write_page(
+        graph,
+        f"pages/{secret}.md",
+        "- body\n  id:: 20202020-2020-4202-8202-020202020202\n",
+    )
+    rebuild_shadow_from_graph(graph)
+    overlong = secret + ("z" * 5000)
+    with pytest.raises(FtsQueryValidationError) as exc:
+        format_shadow_fts_markdown(graph, overlong)
+    msg = str(exc.value)
+    assert secret not in msg
+    assert str(graph) not in msg
+    assert len(msg) < 500
 
 
 # --- A4-CONTENT ---


### PR DESCRIPTION
## Summary

Bounds shadow FTS user keywords to **512 Unicode characters** (post-`strip`) before FTS preparation or SQLite `MATCH`. Overlong input returns a bounded `FtsQueryValidationError` on the public BM25 path — no SQLite call, no generational fallback while shadow is `ready`.

Fixes #279

## Limit choice

| Factor | Decision |
|--------|----------|
| Regex search cap | `MAX_REGEX_PATTERN_LEN = 256` (`src/utils/regex_policy.py`) |
| FTS needs multi-token + operators | **2× regex → 512 Unicode code points** |
| Unit | Python `len()` on stripped `str` (Unicode code points, not UTF-8 bytes) |
| Enforcement | `check_fts_query_length_bounded()` in `validate_fts_match_query` **and** `search_blocks_fts` (before `prepare_fts_user_query` / `MATCH`) |
| Env var / schema | None |

## Architecture

- Shared FTS validation extracted to leaf module `src/shadow/fts_validation.py` (acyclic: `query` and `fts_format` import validation; no `query → fts_format` cycle)
- Layering guard: `tests/test_shadow_fts_validation_boundary.py`

## Impact (GitNexus)

- `validate_fts_match_query`, `search_blocks_fts`, `resolve_bm25_search_markdown`: **LOW** upstream (BM25 dispatch only)
- No HIGH/CRITICAL blast radius
- `detect_changes(compare main)`: low, 0 runtime processes

## Tests

- Removed **only** A4-QUERY-10 xfail (#279)
- **#278** (`test_a4_query_07_unicode_diacritic_fold`) remains `xfail(strict=True)`
- Added `10b`–`10j`: limit±1, Unicode multibyte, whitespace, operators/prefix/hyphen, SQLite skip proof, BM25 envelope, bounded error message
- Axis 4: **29 pass + 1 xfail**; full CI: **1244 pass, 1 xfail**

## Gates

- [x] Axis 4 + Axis 2–3 regression
- [x] `make docs-check` / `make agents-check` / `make ci`
- [x] GitNexus `detect_changes(compare main)`
- [x] Ironclad + CodeQL green

## Release recommendation

No immediate `alpha.4` — finish #278 first for fully green Axis 4, then `v2.0.0-alpha.4`.

## Test plan

- [x] CI green
- [ ] Post-merge: comment tracker #261