### PR TITLE
fix(shadow): report truncated depth-one subtrees (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - **Graph Insights silent LLM fallback ([#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114))** — `run_graph_insights_engine` now emits `logger.exception(...)` before falling back to `_fallback_insights(metrics)` when `llm.generate_graph_insights` raises; `llm_used=False` semantics unchanged. Operators can distinguish LLM-enriched vs deterministic insights in logs.
+- **Shadow CTE subtree depth truncation status (#289)** — `max_depth` clamped to `1` (including `0` and negative inputs) now returns `SubtreeStatus.TRUNCATED` when descendants exist but are excluded; anchor-only excerpt unchanged.
 
 ## [2.0.0-alpha.4] - 2026-07-19
 

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -90,9 +90,9 @@ uvx --refresh-package matryca-plumber \
 
 ### Axis 5 — CTE subtree
 
-**Status:** audit probes complete (`tests/test_shadow_hardening_axis5_cte.py`) — **40 pass, 3 xfail**.
+**Status:** audit probes complete (`tests/test_shadow_hardening_axis5_cte.py`) — **43 pass, 0 xfail** (post-#289 fix).
 
-- [x] Extreme depth / `max_depth` limits — **A5-DEPTH-01..09 (A5-DEPTH-04/05/09 → [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289))**
+- [x] Extreme depth / `max_depth` limits — **A5-DEPTH-01..09 ([#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) fixed)**
 - [x] Sibling `sort_order` + depth-first pre-order — **A5-ORDER-01..04 pass**
 - [x] `max_nodes` truncation + wide subtrees — **A5-NODES-01..06 pass**
 - [x] UTF-8 byte budget + block-boundary truncation — **A5-BYTES-01..06 pass**
@@ -190,9 +190,9 @@ uvx --refresh-package matryca-plumber \
 | A4-FAIL-03 | 4 | Health `error` skips shadow FTS | — | `test_a4_fail_03_health_not_ready_skips_shadow_fts` | — | **pass** |
 | A4-FAIL-04 | 4 | Validation errors bounded, no secret leak | — | `test_a4_fail_04_backend_exception_bounded_public_error` | — | **pass** |
 | A4-FAIL-05 | 4 | Writer lock → SQLite error, meta intact | — | `test_a4_fail_05_writer_lock_does_not_corrupt_fts_meta` | — | **pass** |
-| A5-DEPTH-04 | 5 | `max_depth=1` with descendants → reports `COMPLETE` | **P2** | `test_a5_depth_04_max_depth_one_with_child_truncated` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **open** (`xfail`) |
-| A5-DEPTH-05 | 5 | `max_depth=0` (clamped to 1) same truncation status gap | **P2** | `test_a5_depth_05_max_depth_zero_clamped_truncated` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **open** (`xfail`) |
-| A5-DEPTH-09 | 5 | `max_depth=-5` (clamped to 1) same truncation status gap | **P2** | `test_a5_depth_09_negative_max_depth_clamped` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **open** (`xfail`) |
+| A5-DEPTH-04 | 5 | `max_depth=1` with descendants → reports `COMPLETE` | **P2** | `test_a5_depth_04_max_depth_one_with_child_truncated` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **fixed** |
+| A5-DEPTH-05 | 5 | `max_depth=0` (clamped to 1) same truncation status gap | **P2** | `test_a5_depth_05_max_depth_zero_clamped_truncated` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **fixed** |
+| A5-DEPTH-09 | 5 | `max_depth=-5` (clamped to 1) same truncation status gap | **P2** | `test_a5_depth_09_negative_max_depth_clamped` | [#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) | **fixed** |
 | A5-DEPTH-01 | 5 | 32-block chain under default `max_depth` | — | `test_a5_depth_01_linear_chain_complete_within_default_max` | — | **pass** |
 | A5-DEPTH-02 | 5 | Leaf anchor single node | — | `test_a5_depth_02_leaf_anchor_single_node` | — | **pass** |
 | A5-DEPTH-03 | 5 | Root anchor includes descendants (pre-order) | — | `test_a5_depth_03_root_anchor_includes_descendants` | — | **pass** |

--- a/src/shadow/subtree.py
+++ b/src/shadow/subtree.py
@@ -346,8 +346,6 @@ def _has_depth_or_node_truncation(
         )
         if total > fetched_count:
             return True
-    if max_depth <= 1:
-        return False
     deepest = max_depth - 1
     row = connection.execute(
         """

--- a/tests/test_shadow_hardening_axis5_cte.py
+++ b/tests/test_shadow_hardening_axis5_cte.py
@@ -208,10 +208,6 @@ def test_a5_depth_03_root_anchor_includes_descendants(tmp_path: Path) -> None:
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P2 #289: max_depth=1 should TRUNCATE when descendants exist (reports COMPLETE)",
-)
 def test_a5_depth_04_max_depth_one_with_child_truncated(tmp_path: Path) -> None:
     """A5-DEPTH-04: max_depth=1 with descendants → TRUNCATED, anchor only."""
     graph = _minimal_graph(tmp_path)
@@ -226,10 +222,6 @@ def test_a5_depth_04_max_depth_one_with_child_truncated(tmp_path: Path) -> None:
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P2 #289: clamped max_depth=0 behaves like 1 but should TRUNCATE with descendants",
-)
 def test_a5_depth_05_max_depth_zero_clamped_truncated(tmp_path: Path) -> None:
     """A5-DEPTH-05: max_depth=0 clamps to 1; descendants → TRUNCATED."""
     graph = _minimal_graph(tmp_path)
@@ -288,10 +280,6 @@ def test_a5_depth_08_default_cap_truncates_beyond_64_levels(tmp_path: Path) -> N
         conn.close()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="P2 #289: clamped max_depth=-5 behaves like 1 but should TRUNCATE with descendants",
-)
 def test_a5_depth_09_negative_max_depth_clamped(tmp_path: Path) -> None:
     """A5-DEPTH-09: negative max_depth clamps to 1; descendants → TRUNCATED."""
     graph = _minimal_graph(tmp_path)


### PR DESCRIPTION
Fixes #289

Remove the max_depth <= 1 early return from subtree truncation detection.
Depth values 1, 0, and negative inputs clamped to 1 now report TRUNCATED
when direct descendants are excluded. Anchor-only content remains unchanged.

Impact:
- helper risk LOW;
- query_subtree_by_block_uuid blast radius MEDIUM;
- no schema, routing, health, or Markdown-write changes.

Verification:
- Axis 5: 43 pass, 0 xfail;
- test_shadow_subtree.py green;
- make ci: 1292 pass;
- detect_changes: LOW, zero runtime processes.