### PR TITLE
fix(shadow): redact absolute paths in state API last_sync_error (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Graph Insights silent LLM fallback ([#114](https://github.com/MarcoPorcellato/matryca-plumber/issues/114))** — `run_graph_insights_engine` now emits `logger.exception(...)` before falling back to `_fallback_insights(metrics)` when `llm.generate_graph_insights` raises; `llm_used=False` semantics unchanged. Operators can distinguish LLM-enriched vs deterministic insights in logs.
 - **Shadow CTE subtree depth truncation status (#289)** — `max_depth` clamped to `1` (including `0` and negative inputs) now returns `SubtreeStatus.TRUNCATED` when descendants exist but are excluded; anchor-only excerpt unchanged.
+- **Shadow state API `last_sync_error` path redaction (#293)** — absolute filesystem paths in `META_LAST_SYNC_ERROR` (and SQLite error strings) are replaced with a bounded generic message before the Sovereign UI `/api/state` envelope; graph-relative diagnostics such as `pages/Alpha.md` remain unchanged.
 
 ## [2.0.0-alpha.4] - 2026-07-19
 

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -102,10 +102,10 @@ uvx --refresh-package matryca-plumber \
 
 ### Axis 6 — Security & isolation
 
-**Status:** audit probes complete (`tests/test_shadow_hardening_axis6_security.py`) — **23 pass, 1 xfail** (sanitization checklist incomplete until #293).
+**Status:** audit probes complete (`tests/test_shadow_hardening_axis6_security.py`) — **24 pass, 0 xfail** (post-#293).
 
 - [x] Path traversal and symlink escape — **A6-PATH-01..07 pass** (Unix-only skip on symlink probes; portable probes always run)
-- [ ] Sanitized errors (no vault content leak) — **partial — A6-ERRORS-01..06 pass; A6-ERRORS-07 open under [#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293)**
+- [x] Sanitized errors (no vault content leak) — **A6-ERRORS-01..07 ([#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293) fixed)**
 - [x] Flag `false` must not create/open/mutate SQLite — **A6-FLAG-01..05 pass** (includes pre-existing DB immutability)
 - [x] Shadow DB must never write Markdown — **A6-MD-01..05 pass**
 
@@ -249,7 +249,7 @@ uvx --refresh-package matryca-plumber \
 | A6-ERRORS-04 | 6 | Duplicate UUID sync error omits block bodies | — | `test_a6_errors_04_sync_duplicate_uuid_error_omits_block_content` | — | **pass** |
 | A6-ERRORS-05 | 6 | INCONSISTENT subtree fallback omits SQLite leak | — | `test_a6_errors_05_inconsistent_subtree_falls_back_without_sqlite_leak` | — | **pass** |
 | A6-ERRORS-06 | 6 | FTS backend failure omits injected DB path | — | `test_a6_errors_06_fts_backend_fallback_omits_injected_path` | — | **pass** |
-| A6-ERRORS-07 | 6 | State API `last_sync_error` leaks injected path | **P2** | `test_a6_errors_07_state_api_last_sync_error_omits_injected_path` | [#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293) | **open** (`xfail`) |
+| A6-ERRORS-07 | 6 | State API `last_sync_error` leaks injected path | **P2** | `test_a6_errors_07_state_api_last_sync_error_omits_injected_path` | [#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293) | **fixed** |
 | A6-FLAG-01 | 6 | Flag off — rebuild skips DB creation | — | `test_a6_flag_01_false_flag_skips_rebuild_db_creation` | — | **pass** |
 | A6-FLAG-02 | 6 | Flag off — incremental sync no-op | — | `test_a6_flag_02_false_flag_skips_incremental_sync` | — | **pass** |
 | A6-FLAG-03 | 6 | Flag off — read port is Markdown | — | `test_a6_flag_03_false_flag_read_port_is_markdown` | — | **pass** |

--- a/src/shadow/state_api.py
+++ b/src/shadow/state_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 from typing import Literal
@@ -27,6 +28,15 @@ from .schema import SHADOW_SCHEMA_VERSION
 
 ShadowDbStateValue = Literal["disabled", "bootstrapping", "ready", "stale", "error"]
 _SHADOW_ERROR_MAX_LEN = 200
+_REDACTED_SYNC_ERROR = "Shadow sync error (path details redacted)"
+# Absolute filesystem paths (POSIX or Windows) must never reach the public API.
+_ABS_FILESYSTEM_PATH = re.compile(
+    r"(?:"
+    r"[A-Za-z]:\\[^\s]+|"  # Windows drive path
+    r"\\\\[^\s]+|"  # UNC path
+    r"/(?:[^/\s]+/)+[^/\s]*"  # POSIX absolute with ≥1 directory segment
+    r")"
+)
 
 
 class ShadowDbStateResponse(BaseModel):
@@ -49,6 +59,8 @@ def _bounded_error_message(raw: str | None) -> str | None:
     cleaned = sanitize_for_console((raw or "").strip())
     if not cleaned:
         return None
+    if _ABS_FILESYSTEM_PATH.search(cleaned):
+        return _REDACTED_SYNC_ERROR
     if len(cleaned) <= _SHADOW_ERROR_MAX_LEN:
         return cleaned
     return cleaned[: _SHADOW_ERROR_MAX_LEN - 1] + "…"

--- a/tests/test_shadow_hardening_axis6_security.py
+++ b/tests/test_shadow_hardening_axis6_security.py
@@ -318,13 +318,6 @@ def test_a6_errors_06_fts_backend_fallback_omits_injected_path(tmp_path: Path) -
     assert "SENSITIVE-FTS-PATH" not in out
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "P2 #293: resolve_shadow_db_state_for_api forwards raw last_sync_error after "
-        "ANSI sanitize only — vault/DB paths in meta reach the public API envelope"
-    ),
-)
 def test_a6_errors_07_state_api_last_sync_error_omits_injected_path(tmp_path: Path) -> None:
     """A6-ERRORS-07: state API ``last_sync_error`` must not echo vault/DB path tokens."""
     graph = _minimal_graph(tmp_path)


### PR DESCRIPTION
Fixes #293

When `META_LAST_SYNC_ERROR` or SQLite error strings contain absolute filesystem
paths, `resolve_shadow_db_state_for_api` now returns a bounded generic message
instead of echoing the path into the Sovereign UI `/api/state` envelope.
Graph-relative diagnostics such as `pages/Alpha.md` remain unchanged.

Impact:
- `_bounded_error_message` risk LOW;
- no schema, routing, health, or Markdown-write changes.

Verification:
- Axis 6: 24 pass, 0 xfail;
- `tests/test_shadow_state_api.py` green;
- `make ci`: 1322 pass;
- detect_changes: LOW.

