### PR TITLE
fix(cli): skip eager AST bootstrap for search bm25 (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## [Unreleased]
 
+### Fixed
+
+- **CLI `search bm25` no longer eager-bootstraps AST (#297 / A-CLI-01)** — `matryca search bm25` prepares runtime with `eager_graph=False`, so LogosParser cold load cannot hang BM25 (raw Markdown / Shadow FTS). Other CLI commands keep eager AST warm-up.
+
 ### Changed
 
-- **A-CLI-01 audit reproducer** — deterministic generator + `@pytest.mark.slow` parser-only probes for LogosParser pathological latency ([#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297)); no runtime containment yet.
+- **A-CLI-01 audit reproducer** — deterministic generator + `@pytest.mark.slow` parser-only probes for LogosParser pathological latency ([#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297)); bounded parser worker / Shadow containment still follow-up (PR2B/C).
 
 ## [2.0.0-alpha.5] - 2026-07-19
 

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -396,6 +396,16 @@ async def run_cli(args: argparse.Namespace) -> int:
     return 2
 
 
+def _cli_eager_graph(args: argparse.Namespace) -> bool:
+    """Return whether this CLI invocation should warm the in-memory AST index.
+
+    ``search bm25`` scores raw Markdown / Shadow FTS and must not pay for
+    ``GraphAstCache.bootstrap`` (A-CLI-01 / #297). Other graph commands keep
+    eager load so first-read latency stays predictable.
+    """
+    return not (args.command == "search" and getattr(args, "method", None) == "bm25")
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI entrypoint: load ``.env``, parse args, run async dispatch."""
     parser = build_parser()
@@ -403,7 +413,7 @@ def main(argv: list[str] | None = None) -> None:
     ui_only = args.command == "plumber" and args.plumber_action in {"status", "ui"}
     skip_eager_bootstrap = args.command == "plumber" and args.plumber_action == "start"
     if not ui_only and not skip_eager_bootstrap:
-        try_prepare_matryca_runtime_from_env()
+        try_prepare_matryca_runtime_from_env(eager_graph=_cli_eager_graph(args))
     if ui_only:
         try:
             run_ui_server()

--- a/src/utils/runtime_bootstrap.py
+++ b/src/utils/runtime_bootstrap.py
@@ -124,10 +124,10 @@ def prepare_matryca_runtime(
     Args:
         graph_root: Resolved Logseq vault root (``pages/`` parent), or ``None``.
         wiki_config: Optional wiki orchestration config.
-        eager_graph: When ``True`` (daemon, CLI, UI), load the in-memory AST index and
-            identity config immediately. When ``False`` (MCP stdio lifespan), defer
-            heavy graph parsing until the first tool call that needs the graph — so
-            MCP ``initialize`` / ``tools/list`` complete in seconds.
+        eager_graph: When ``True`` (daemon, most CLI), load the in-memory AST index and
+            identity config immediately. When ``False`` (MCP stdio, Sovereign UI,
+            CLI ``search bm25``), defer heavy graph parsing until a caller needs the
+            AST — so BM25 / initialize stay free of LogosParser cold cost (#297).
     """
     ensure_plumber_log_directories()
     if graph_root is None:
@@ -160,8 +160,9 @@ def try_prepare_matryca_runtime_from_env(*, eager_graph: bool = True) -> None:
     """Provision runtime dirs from the current process environment (idempotent).
 
     Args:
-        eager_graph: When ``False`` (Sovereign UI, MCP stdio), defer AST parsing until
-            the first graph read. When ``True`` (daemon, agent CLI), load immediately.
+        eager_graph: When ``False`` (Sovereign UI, MCP stdio, CLI ``search bm25``),
+            defer AST parsing until the first graph read that needs it. When ``True``
+            (daemon, other agent CLI commands), load immediately.
     """
     ensure_repo_dotenv_from_example()
     from ..agent.plumber_config import reload_plumber_dotenv

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -26,11 +26,13 @@ def test_cli_main_calls_try_prepare_before_dispatch(monkeypatch: pytest.MonkeyPa
     from src.cli import main as cli_main
 
     order: list[str] = []
+    eager_flags: list[bool] = []
 
-    monkeypatch.setattr(
-        "src.cli.try_prepare_matryca_runtime_from_env",
-        lambda: order.append("prepare"),
-    )
+    def _prepare(*, eager_graph: bool = True) -> None:
+        order.append("prepare")
+        eager_flags.append(eager_graph)
+
+    monkeypatch.setattr("src.cli.try_prepare_matryca_runtime_from_env", _prepare)
 
     async def _run_cli(_args: object) -> int:
         order.append("dispatch")
@@ -51,6 +53,19 @@ def test_cli_main_calls_try_prepare_before_dispatch(monkeypatch: pytest.MonkeyPa
 
     assert exc.value.code == 0
     assert order == ["prepare", "dispatch"]
+    assert eager_flags == [True]
+
+
+def test_cli_eager_graph_route_matrix() -> None:
+    from argparse import Namespace
+
+    from src.cli import _cli_eager_graph
+
+    assert _cli_eager_graph(Namespace(command="search", method="bm25")) is False
+    assert _cli_eager_graph(Namespace(command="search", method="regex")) is True
+    assert _cli_eager_graph(Namespace(command="search", method="semantic")) is True
+    assert _cli_eager_graph(Namespace(command="read", method=None)) is True
+    assert _cli_eager_graph(Namespace(command="lint", method=None)) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **PR2A** for [#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297): `matryca search bm25` prepares runtime with `eager_graph=False`, so CLI BM25 no longer blocks on LogosParser / `GraphAstCache.bootstrap`.
- Other CLI commands keep eager AST warm-up.
- No Shadow / `load_directory` rewrite (PR2B/C later per design gate).

## Impact
- `cli.main` upstream: LOW (tests).
- Does not change `prepare_matryca_runtime` default for daemon.
- detect_changes(compare main): HIGH — reviewed.
  The reported cluster/audit flows originate from docstring-only touches to
  prepare_matryca_runtime; its logic and eager_graph=True default are unchanged.
  The runtime behavior change is limited to cli.main routing search bm25 with
  eager_graph=False.

## Test plan
- [x] `pytest tests/test_runtime_bootstrap_entrypoints.py …` (30 passed)
- [x] Smoke: vault with A-CLI-01 pathological page → `search bm25` ≈0.5s (was tens of seconds)