### PR TITLE
feat(graph): bounded spawn worker for single-page parse (#297 PR2B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -489,6 +489,12 @@ MATRYCA_MEMORY_GRAPH_ENABLED=false
 # Range / notes: opt-in v2.0.0-alpha; FTS5 BM25 + subtree CTE when healthy; Markdown/BM25 fallback otherwise
 MATRYCA_SHADOW_DB_ENABLED=false
 
+# SQLite busy_timeout (ms) for shadow.sqlite connections. src/shadow/config.py
+# Default (code): 5000
+# Template: 5000
+# Range / notes: clamped [0, 60000]; 0 disables waiting
+MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS=5000
+
 # Per-page Logos/StackMachine parse hard deadline (seconds). src/graph/bounded_page_parse.py
 # Default (code): 15
 # Template: 15

--- a/.env.example
+++ b/.env.example
@@ -489,11 +489,11 @@ MATRYCA_MEMORY_GRAPH_ENABLED=false
 # Range / notes: opt-in v2.0.0-alpha; FTS5 BM25 + subtree CTE when healthy; Markdown/BM25 fallback otherwise
 MATRYCA_SHADOW_DB_ENABLED=false
 
-# SQLite busy_timeout (ms) for shadow.sqlite connections. src/shadow/config.py
-# Default (code): 5000
-# Template: 5000
-# Range / notes: clamped [0, 60000]; 0 disables waiting
-MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS=5000
+# Per-page Logos/StackMachine parse hard deadline (seconds). src/graph/bounded_page_parse.py
+# Default (code): 15
+# Template: 15
+# Range / notes: clamped [2, 120]; spawn worker always used for bounded API — no unbounded toggle
+MATRYCA_PAGE_PARSE_TIMEOUT_S=15
 
 # Cross-process shadow writer flock timeout (seconds) for incremental sync/delete. src/shadow/config.py
 # Default (code): 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). No Shadow/`GraphAstCache` integration yet; overhead measurement via `scripts/measure_bounded_page_parse_overhead.py`.
+
 ### Fixed
 
 - **CLI `search bm25` no longer eager-bootstraps AST (#297 / A-CLI-01)** — `matryca search bm25` prepares runtime with `eager_graph=False`, so LogosParser cold load cannot hang BM25 (raw Markdown / Shadow FTS). Other CLI commands keep eager AST warm-up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). Fork-safe PID ownership (`register_at_fork` where available); `BoundedParseResult.page` is `repr=False` (diagnostics only in logs). No Shadow/`GraphAstCache` integration yet. Overhead script requires `--graph PATH` (optional `--output`).
+- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). Fork-safe PID ownership (`register_at_fork` where available); `BoundedParseResult.page` is `repr=False` (diagnostics only in logs). Request/result correlation via monotonic `request_id` + echoed `content_hash` (mismatch → `protocol_mismatch`, AST never accepted). No Shadow/`GraphAstCache` integration yet. Overhead script requires `--graph PATH` (optional `--output`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). No Shadow/`GraphAstCache` integration yet; overhead measurement via `scripts/measure_bounded_page_parse_overhead.py`.
+- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). Fork-safe PID ownership (`register_at_fork` where available); `BoundedParseResult.page` is `repr=False` (diagnostics only in logs). No Shadow/`GraphAstCache` integration yet. Overhead script requires `--graph PATH` (optional `--output`).
 
 ### Fixed
 

--- a/scripts/measure_bounded_page_parse_overhead.py
+++ b/scripts/measure_bounded_page_parse_overhead.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""Measure bounded page-parse worker overhead on a local vault (privacy-safe).
+"""Measure bounded page-parse worker overhead on an explicit local vault.
 
-Writes aggregated timing only (no paths, titles, or content). Default corpus:
-Caches soak/diag vault (~1009 pages). In-process LogosParser is used solely as
-a measurement baseline — not as a production API path.
+Privacy-safe: aggregated timing only (no paths, titles, or content in the report).
+In-process LogosParser is used solely as a measurement baseline — not as a
+production API path.
 
 Usage::
 
-    uv run python scripts/measure_bounded_page_parse_overhead.py
-    uv run python scripts/measure_bounded_page_parse_overhead.py --limit 200
+    uv run python scripts/measure_bounded_page_parse_overhead.py \\
+        --graph /path/to/vault
+    uv run python scripts/measure_bounded_page_parse_overhead.py \\
+        --graph ./vault --output report.json
+    uv run python scripts/measure_bounded_page_parse_overhead.py \\
+        --graph ./vault --limit 200
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import statistics
+import sys
 import time
 from pathlib import Path
 
@@ -24,26 +29,6 @@ from src.graph.bounded_page_parse import (
     BoundedPageParseWorker,
     reset_bounded_page_parse_worker_for_tests,
 )
-
-
-def _discover_vault() -> Path | None:
-    bases = [
-        Path.home() / "Library/Caches/mp-beta-soak-a5",
-        Path.home() / "Library/Caches/mp-cli-diag-a5",
-    ]
-    best: tuple[int, Path] | None = None
-    for base in bases:
-        if not base.is_dir():
-            continue
-        for pages in base.rglob("pages"):
-            if not pages.is_dir():
-                continue
-            n = len(list(pages.glob("*.md")))
-            if n < 10:
-                continue
-            if best is None or n > best[0]:
-                best = (n, pages.parent)
-    return best[1] if best else None
 
 
 def _pct(xs: list[float], p: float) -> float:
@@ -70,8 +55,20 @@ def _summarize(xs: list[float]) -> dict[str, float | int]:
     }
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--graph",
+        type=Path,
+        required=True,
+        help="Logseq graph root (must contain pages/*.md)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write JSON report (default: stdout only)",
+    )
     parser.add_argument("--limit", type=int, default=0, help="Max pages (0=all)")
     parser.add_argument(
         "--baseline-max-bytes",
@@ -85,18 +82,23 @@ def main() -> None:
         default=30.0,
         help="Per-page worker deadline for this measurement run",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    vault = _discover_vault()
-    if vault is None:
-        raise SystemExit("no soak/diag vault found under Library/Caches")
+    vault = args.graph.expanduser().resolve()
+    pages_dir = vault / "pages"
+    if not pages_dir.is_dir():
+        print(f"error: missing pages/ under {vault}", file=sys.stderr)
+        return 2
 
-    files: list[Path] = sorted((vault / "pages").glob("*.md"))
+    files: list[Path] = sorted(pages_dir.glob("*.md"))
     journals = vault / "journals"
     if journals.is_dir():
         files.extend(sorted(journals.glob("*.md")))
     if args.limit > 0:
         files = files[: args.limit]
+    if not files:
+        print(f"error: no markdown pages under {vault}", file=sys.stderr)
+        return 2
 
     worker = BoundedPageParseWorker()
     worker_times: list[float] = []
@@ -151,22 +153,14 @@ def main() -> None:
             "uses the spawn worker (no unbounded LogosParser path)."
         ),
     }
-    print(json.dumps(report, indent=2))
-
-    out_dirs = [
-        Path.home() / "Library/Caches/mp-beta-soak-a5/report",
-        Path.home() / "Library/Application Support/mp-beta-soak-a5/latest/report",
-    ]
-    for d in out_dirs:
-        try:
-            d.mkdir(parents=True, exist_ok=True)
-            (d / "A_CLI_01_BOUNDED_PARSE_OVERHEAD.json").write_text(
-                json.dumps(report, indent=2) + "\n",
-                encoding="utf-8",
-            )
-        except OSError:
-            pass
+    payload = json.dumps(report, indent=2) + "\n"
+    sys.stdout.write(payload)
+    if args.output is not None:
+        out = args.output.expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload, encoding="utf-8")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/measure_bounded_page_parse_overhead.py
+++ b/scripts/measure_bounded_page_parse_overhead.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Measure bounded page-parse worker overhead on a local vault (privacy-safe).
+
+Writes aggregated timing only (no paths, titles, or content). Default corpus:
+Caches soak/diag vault (~1009 pages). In-process LogosParser is used solely as
+a measurement baseline — not as a production API path.
+
+Usage::
+
+    uv run python scripts/measure_bounded_page_parse_overhead.py
+    uv run python scripts/measure_bounded_page_parse_overhead.py --limit 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+from logseq_matryca_parser import LogosParser
+from src.graph.bounded_page_parse import (
+    BoundedPageParseWorker,
+    reset_bounded_page_parse_worker_for_tests,
+)
+
+
+def _discover_vault() -> Path | None:
+    bases = [
+        Path.home() / "Library/Caches/mp-beta-soak-a5",
+        Path.home() / "Library/Caches/mp-cli-diag-a5",
+    ]
+    best: tuple[int, Path] | None = None
+    for base in bases:
+        if not base.is_dir():
+            continue
+        for pages in base.rglob("pages"):
+            if not pages.is_dir():
+                continue
+            n = len(list(pages.glob("*.md")))
+            if n < 10:
+                continue
+            if best is None or n > best[0]:
+                best = (n, pages.parent)
+    return best[1] if best else None
+
+
+def _pct(xs: list[float], p: float) -> float:
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    i = min(len(s) - 1, max(0, int(round((p / 100) * (len(s) - 1)))))
+    return round(s[i], 6)
+
+
+def _summarize(xs: list[float]) -> dict[str, float | int]:
+    if not xs:
+        return {"n": 0}
+    return {
+        "n": len(xs),
+        "min": round(min(xs), 6),
+        "p50": _pct(xs, 50),
+        "p90": _pct(xs, 90),
+        "p95": _pct(xs, 95),
+        "p99": _pct(xs, 99),
+        "max": round(max(xs), 6),
+        "mean": round(statistics.mean(xs), 6),
+        "sum": round(sum(xs), 6),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=0, help="Max pages (0=all)")
+    parser.add_argument(
+        "--baseline-max-bytes",
+        type=int,
+        default=20_000,
+        help="Only pages under this size get in-process baseline compare",
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=float,
+        default=30.0,
+        help="Per-page worker deadline for this measurement run",
+    )
+    args = parser.parse_args()
+
+    vault = _discover_vault()
+    if vault is None:
+        raise SystemExit("no soak/diag vault found under Library/Caches")
+
+    files: list[Path] = sorted((vault / "pages").glob("*.md"))
+    journals = vault / "journals"
+    if journals.is_dir():
+        files.extend(sorted(journals.glob("*.md")))
+    if args.limit > 0:
+        files = files[: args.limit]
+
+    worker = BoundedPageParseWorker()
+    worker_times: list[float] = []
+    baseline_times: list[float] = []
+    paired_delta: list[float] = []
+    timeouts = 0
+    errors = 0
+    cold_s: float | None = None
+
+    try:
+        for index, path in enumerate(files):
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                errors += 1
+                continue
+            t0 = time.perf_counter()
+            result = worker.parse_text(text, mode="logos", timeout_s=args.timeout_s)
+            wall = time.perf_counter() - t0
+            if index == 0:
+                cold_s = round(wall, 6)
+            if result.timed_out:
+                timeouts += 1
+                continue
+            if not result.ok:
+                errors += 1
+                continue
+            worker_times.append(wall)
+
+            if len(text.encode("utf-8")) <= args.baseline_max_bytes:
+                b0 = time.perf_counter()
+                LogosParser().parse(text)
+                bwall = time.perf_counter() - b0
+                baseline_times.append(bwall)
+                paired_delta.append(wall - bwall)
+    finally:
+        worker.shutdown()
+        reset_bounded_page_parse_worker_for_tests()
+
+    report = {
+        "privacy": "aggregated_only_no_paths_titles_content",
+        "page_files_considered": len(files),
+        "timeout_s": args.timeout_s,
+        "cold_first_parse_s": cold_s,
+        "worker_wall_s": _summarize(worker_times),
+        "inprocess_baseline_wall_s": _summarize(baseline_times),
+        "worker_minus_baseline_s": _summarize(paired_delta),
+        "timeouts": timeouts,
+        "errors": errors,
+        "note": (
+            "In-process baseline is measurement-only. Production PR2B API always "
+            "uses the spawn worker (no unbounded LogosParser path)."
+        ),
+    }
+    print(json.dumps(report, indent=2))
+
+    out_dirs = [
+        Path.home() / "Library/Caches/mp-beta-soak-a5/report",
+        Path.home() / "Library/Application Support/mp-beta-soak-a5/latest/report",
+    ]
+    for d in out_dirs:
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "A_CLI_01_BOUNDED_PARSE_OVERHEAD.json").write_text(
+                json.dumps(report, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/graph/bounded_page_parse.py
+++ b/src/graph/bounded_page_parse.py
@@ -1,0 +1,350 @@
+"""Bounded single-page Logseq parsing via a terminable spawn worker (#297 PR2B).
+
+Every parse that must not hang indefinitely runs in a persistent child process
+with a hard deadline. The parent never relies on thread interruption.
+
+No Shadow / GraphAstCache integration in this module's callers yet — infra only.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import hashlib
+import multiprocessing as mp
+import pickle
+import threading
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from queue import Empty
+from typing import Any, Literal
+
+from loguru import logger
+
+from ..utils.env_parse import env_float_clamped
+
+ParseMode = Literal["logos", "stack"]
+
+_TIMEOUT_ENV = "MATRYCA_PAGE_PARSE_TIMEOUT_S"
+_DEFAULT_TIMEOUT_S = 15.0
+_MIN_TIMEOUT_S = 2.0
+_MAX_TIMEOUT_S = 120.0
+_TERMINATE_GRACE_S = 5.0
+_SHUTDOWN_JOIN_S = 5.0
+
+_CTX = mp.get_context("spawn")
+
+
+def page_parse_timeout_s() -> float:
+    """Hard deadline for one page parse (seconds), clamped."""
+    return env_float_clamped(
+        _TIMEOUT_ENV,
+        _DEFAULT_TIMEOUT_S,
+        minimum=_MIN_TIMEOUT_S,
+        maximum=_MAX_TIMEOUT_S,
+    )
+
+
+def content_hash16(text: str) -> str:
+    """Stable privacy-safe content fingerprint (sha256 hex prefix)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def page_line_count(text: str) -> int:
+    if not text:
+        return 0
+    return text.count("\n") + (0 if text.endswith("\n") else 1)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedParseResult:
+    """Outcome of a bounded page parse (never includes vault paths or body text)."""
+
+    ok: bool
+    timed_out: bool
+    elapsed_s: float
+    content_hash: str
+    byte_count: int
+    line_count: int
+    mode: ParseMode
+    error: str | None = None
+    page: Any | None = None
+
+
+def _worker_loop(
+    in_q: mp.Queue[dict[str, Any] | None],
+    out_q: mp.Queue[dict[str, Any]],
+) -> None:
+    """Child entry: parse requests until shutdown sentinel."""
+    while True:
+        msg = in_q.get()
+        if msg is None:
+            break
+        op = str(msg.get("op", ""))
+        if op == "shutdown":
+            break
+        if op != "parse":
+            out_q.put({"ok": False, "error": "unknown_op", "s": 0.0})
+            continue
+        mode = str(msg.get("mode", "logos"))
+        text = str(msg.get("text", ""))
+        title = str(msg.get("title", "Page"))
+        started = time.perf_counter()
+        try:
+            if mode == "stack":
+                from logseq_matryca_parser.graph import StackMachineParser
+
+                page = StackMachineParser().parse(text, page_title=title)
+            else:
+                from logseq_matryca_parser import LogosParser
+
+                page = LogosParser().parse(text)
+            blob = pickle.dumps(page, protocol=pickle.HIGHEST_PROTOCOL)
+            out_q.put(
+                {
+                    "ok": True,
+                    "blob": blob,
+                    "s": round(time.perf_counter() - started, 6),
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 - bounded type name only
+            out_q.put(
+                {
+                    "ok": False,
+                    "error": type(exc).__name__,
+                    "s": round(time.perf_counter() - started, 6),
+                }
+            )
+
+
+class BoundedPageParseWorker:
+    """Persistent spawn worker; one outstanding parse at a time (lock-serialized)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._proc: Any | None = None
+        self._in_q: Any | None = None
+        self._out_q: Any | None = None
+
+    @property
+    def pid(self) -> int | None:
+        proc = self._proc
+        return proc.pid if proc is not None and proc.is_alive() else None
+
+    def _start_unlocked(self) -> None:
+        self._in_q = _CTX.Queue(maxsize=1)
+        self._out_q = _CTX.Queue(maxsize=1)
+        self._proc = _CTX.Process(
+            target=_worker_loop,
+            args=(self._in_q, self._out_q),
+            name="matryca-bounded-page-parse",
+            daemon=True,
+        )
+        self._proc.start()
+
+    def _ensure_worker_unlocked(self) -> None:
+        if self._proc is not None and self._proc.is_alive():
+            return
+        self._discard_queues_unlocked()
+        self._start_unlocked()
+
+    def _discard_queues_unlocked(self) -> None:
+        for q in (self._in_q, self._out_q):
+            if q is None:
+                continue
+            with contextlib.suppress(Exception):
+                q.close()
+            with contextlib.suppress(Exception):
+                q.join_thread()
+        self._in_q = None
+        self._out_q = None
+
+    def _kill_worker_unlocked(self) -> None:
+        proc = self._proc
+        if proc is None:
+            self._discard_queues_unlocked()
+            return
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=_TERMINATE_GRACE_S)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=_TERMINATE_GRACE_S)
+        self._proc = None
+        self._discard_queues_unlocked()
+
+    def shutdown(self) -> None:
+        """Stop the worker process (idempotent)."""
+        with self._lock:
+            proc = self._proc
+            in_q = self._in_q
+            if proc is not None and proc.is_alive() and in_q is not None:
+                with contextlib.suppress(Exception):
+                    in_q.put_nowait(None)
+                proc.join(timeout=_SHUTDOWN_JOIN_S)
+            if proc is not None and proc.is_alive():
+                self._kill_worker_unlocked()
+            else:
+                self._proc = None
+                self._discard_queues_unlocked()
+
+    def parse_text(
+        self,
+        text: str,
+        *,
+        mode: ParseMode = "logos",
+        page_title: str = "Page",
+        timeout_s: float | None = None,
+    ) -> BoundedParseResult:
+        """Parse ``text`` in the worker; kill the worker on deadline overrun."""
+        deadline = page_parse_timeout_s() if timeout_s is None else float(timeout_s)
+        deadline = min(_MAX_TIMEOUT_S, max(_MIN_TIMEOUT_S, deadline))
+
+        digest = content_hash16(text)
+        byte_count = len(text.encode("utf-8"))
+        line_count = page_line_count(text)
+
+        with self._lock:
+            self._ensure_worker_unlocked()
+            assert self._in_q is not None
+            assert self._out_q is not None
+            assert self._proc is not None
+
+            while True:
+                try:
+                    self._out_q.get_nowait()
+                except Empty:
+                    break
+
+            request = {
+                "op": "parse",
+                "mode": mode,
+                "text": text,
+                "title": page_title,
+            }
+            wall0 = time.perf_counter()
+            self._in_q.put(request)
+            try:
+                raw = self._out_q.get(timeout=deadline)
+            except Empty:
+                wall = round(time.perf_counter() - wall0, 6)
+                logger.bind(
+                    content_hash=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=mode,
+                    timeout_s=deadline,
+                ).warning("bounded page parse timed out; terminating worker")
+                self._kill_worker_unlocked()
+                return BoundedParseResult(
+                    ok=False,
+                    timed_out=True,
+                    elapsed_s=wall,
+                    content_hash=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=mode,
+                    error="timeout",
+                    page=None,
+                )
+
+            wall = round(time.perf_counter() - wall0, 6)
+            if not raw.get("ok"):
+                err = str(raw.get("error") or "parse_error")
+                if "/" in err or "\\" in err:
+                    err = "parse_error"
+                return BoundedParseResult(
+                    ok=False,
+                    timed_out=False,
+                    elapsed_s=float(raw.get("s", wall)),
+                    content_hash=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=mode,
+                    error=err,
+                    page=None,
+                )
+
+            blob = raw.get("blob")
+            try:
+                page = pickle.loads(blob) if isinstance(blob, (bytes, bytearray)) else None
+            except Exception:  # noqa: BLE001
+                return BoundedParseResult(
+                    ok=False,
+                    timed_out=False,
+                    elapsed_s=float(raw.get("s", wall)),
+                    content_hash=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=mode,
+                    error="unpickle_error",
+                    page=None,
+                )
+            return BoundedParseResult(
+                ok=True,
+                timed_out=False,
+                elapsed_s=float(raw.get("s", wall)),
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                error=None,
+                page=page,
+            )
+
+
+_worker_lock = threading.Lock()
+_worker: BoundedPageParseWorker | None = None
+
+
+def get_bounded_page_parse_worker() -> BoundedPageParseWorker:
+    """Process-wide singleton worker."""
+    global _worker
+    with _worker_lock:
+        if _worker is None:
+            _worker = BoundedPageParseWorker()
+        return _worker
+
+
+def reset_bounded_page_parse_worker_for_tests() -> None:
+    """Shutdown and drop the singleton (tests only)."""
+    global _worker
+    with _worker_lock:
+        if _worker is not None:
+            _worker.shutdown()
+            _worker = None
+
+
+def parse_page_text_bounded(
+    text: str,
+    *,
+    mode: ParseMode = "logos",
+    page_title: str = "Page",
+    timeout_s: float | None = None,
+) -> BoundedParseResult:
+    """Public API: always process-isolated; never an unbounded in-process LogosParser call."""
+    return get_bounded_page_parse_worker().parse_text(
+        text,
+        mode=mode,
+        page_title=page_title,
+        timeout_s=timeout_s,
+    )
+
+
+def _atexit_shutdown() -> None:
+    reset_bounded_page_parse_worker_for_tests()
+
+
+atexit.register(_atexit_shutdown)
+
+__all__ = [
+    "BoundedParseResult",
+    "BoundedPageParseWorker",
+    "ParseMode",
+    "content_hash16",
+    "get_bounded_page_parse_worker",
+    "page_parse_timeout_s",
+    "parse_page_text_bounded",
+    "reset_bounded_page_parse_worker_for_tests",
+]

--- a/src/graph/bounded_page_parse.py
+++ b/src/graph/bounded_page_parse.py
@@ -29,6 +29,7 @@ from loguru import logger
 from ..utils.env_parse import env_float_clamped
 
 ParseMode = Literal["logos", "stack"]
+_VALID_MODES: frozenset[str] = frozenset({"logos", "stack"})
 
 _TIMEOUT_ENV = "MATRYCA_PAGE_PARSE_TIMEOUT_S"
 _DEFAULT_TIMEOUT_S = 15.0
@@ -77,9 +78,16 @@ class BoundedParseResult:
     content_hash: str
     byte_count: int
     line_count: int
-    mode: ParseMode
+    mode: str
     error: str | None = None
     page: Any | None = field(default=None, repr=False)
+
+
+def _echo_fields(msg: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "request_id": msg.get("request_id"),
+        "content_hash": msg.get("content_hash"),
+    }
 
 
 def _worker_loop(
@@ -94,13 +102,24 @@ def _worker_loop(
         op = str(msg.get("op", ""))
         if op == "shutdown":
             break
+        echo = _echo_fields(msg)
         if op != "parse":
-            out_q.put({"ok": False, "error": "unknown_op", "s": 0.0})
+            out_q.put({**echo, "ok": False, "error": "unknown_op", "s": 0.0})
             continue
-        mode = str(msg.get("mode", "logos"))
+        mode = str(msg.get("mode", ""))
         text = str(msg.get("text", ""))
         title = str(msg.get("title", "Page"))
         started = time.perf_counter()
+        if mode not in _VALID_MODES:
+            out_q.put(
+                {
+                    **echo,
+                    "ok": False,
+                    "error": "invalid_mode",
+                    "s": round(time.perf_counter() - started, 6),
+                }
+            )
+            continue
         try:
             if mode == "stack":
                 from logseq_matryca_parser.graph import StackMachineParser
@@ -113,6 +132,7 @@ def _worker_loop(
             blob = pickle.dumps(page, protocol=pickle.HIGHEST_PROTOCOL)
             out_q.put(
                 {
+                    **echo,
                     "ok": True,
                     "blob": blob,
                     "s": round(time.perf_counter() - started, 6),
@@ -121,6 +141,7 @@ def _worker_loop(
         except Exception as exc:  # noqa: BLE001 - bounded type name only
             out_q.put(
                 {
+                    **echo,
                     "ok": False,
                     "error": type(exc).__name__,
                     "s": round(time.perf_counter() - started, 6),
@@ -138,12 +159,15 @@ class BoundedPageParseWorker:
     def __init__(self) -> None:
         self._lock = threading.RLock()
         self._owner_pid = os.getpid()
+        self._next_request_id = 0
         self._proc: Any | None = None
         self._in_q: Any | None = None
         self._out_q: Any | None = None
 
     @property
     def pid(self) -> int | None:
+        if os.getpid() != self._owner_pid:
+            return None
         proc = self._proc
         return proc.pid if proc is not None and proc.is_alive() else None
 
@@ -229,6 +253,31 @@ class BoundedPageParseWorker:
                 self._proc = None
                 self._discard_queues_unlocked()
 
+    def _protocol_mismatch_unlocked(
+        self,
+        *,
+        digest: str,
+        byte_count: int,
+        line_count: int,
+        mode: ParseMode,
+        elapsed_s: float,
+    ) -> BoundedParseResult:
+        logger.bind(content_hash=digest, mode=mode).warning(
+            "bounded page parse protocol mismatch; terminating worker"
+        )
+        self._kill_worker_unlocked()
+        return BoundedParseResult(
+            ok=False,
+            timed_out=False,
+            elapsed_s=elapsed_s,
+            content_hash=digest,
+            byte_count=byte_count,
+            line_count=line_count,
+            mode=mode,
+            error="protocol_mismatch",
+            page=None,
+        )
+
     def parse_text(
         self,
         text: str,
@@ -238,12 +287,29 @@ class BoundedPageParseWorker:
         timeout_s: float | None = None,
     ) -> BoundedParseResult:
         """Parse ``text`` in the worker; kill the worker on deadline overrun."""
-        deadline = page_parse_timeout_s() if timeout_s is None else float(timeout_s)
-        deadline = min(_MAX_TIMEOUT_S, max(_MIN_TIMEOUT_S, deadline))
-
         digest = content_hash16(text)
         byte_count = len(text.encode("utf-8"))
         line_count = page_line_count(text)
+
+        if mode == "logos":
+            parse_mode: ParseMode = "logos"
+        elif mode == "stack":
+            parse_mode = "stack"
+        else:
+            return BoundedParseResult(
+                ok=False,
+                timed_out=False,
+                elapsed_s=0.0,
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=str(mode),
+                error="invalid_mode",
+                page=None,
+            )
+
+        deadline = page_parse_timeout_s() if timeout_s is None else float(timeout_s)
+        deadline = min(_MAX_TIMEOUT_S, max(_MIN_TIMEOUT_S, deadline))
 
         with self._lock:
             self._ensure_worker_unlocked()
@@ -251,15 +317,27 @@ class BoundedPageParseWorker:
             assert self._out_q is not None
             assert self._proc is not None
 
-            while True:
-                try:
-                    self._out_q.get_nowait()
-                except Empty:
-                    break
+            # Leftover output with no outstanding task = protocol corruption.
+            try:
+                unexpected = self._out_q.get_nowait()
+            except Empty:
+                unexpected = None
+            if unexpected is not None:
+                return self._protocol_mismatch_unlocked(
+                    digest=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=parse_mode,
+                    elapsed_s=0.0,
+                )
 
+            self._next_request_id += 1
+            request_id = self._next_request_id
             request = {
                 "op": "parse",
-                "mode": mode,
+                "request_id": request_id,
+                "content_hash": digest,
+                "mode": parse_mode,
                 "text": text,
                 "title": page_title,
             }
@@ -273,8 +351,9 @@ class BoundedPageParseWorker:
                     content_hash=digest,
                     byte_count=byte_count,
                     line_count=line_count,
-                    mode=mode,
+                    mode=parse_mode,
                     timeout_s=deadline,
+                    request_id=request_id,
                 ).warning("bounded page parse timed out; terminating worker")
                 self._kill_worker_unlocked()
                 return BoundedParseResult(
@@ -284,12 +363,21 @@ class BoundedPageParseWorker:
                     content_hash=digest,
                     byte_count=byte_count,
                     line_count=line_count,
-                    mode=mode,
+                    mode=parse_mode,
                     error="timeout",
                     page=None,
                 )
 
             wall = round(time.perf_counter() - wall0, 6)
+            if raw.get("request_id") != request_id or raw.get("content_hash") != digest:
+                return self._protocol_mismatch_unlocked(
+                    digest=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=parse_mode,
+                    elapsed_s=wall,
+                )
+
             if not raw.get("ok"):
                 err = str(raw.get("error") or "parse_error")
                 if "/" in err or "\\" in err:
@@ -301,7 +389,7 @@ class BoundedPageParseWorker:
                     content_hash=digest,
                     byte_count=byte_count,
                     line_count=line_count,
-                    mode=mode,
+                    mode=parse_mode,
                     error=err,
                     page=None,
                 )
@@ -317,7 +405,7 @@ class BoundedPageParseWorker:
                     content_hash=digest,
                     byte_count=byte_count,
                     line_count=line_count,
-                    mode=mode,
+                    mode=parse_mode,
                     error="unpickle_error",
                     page=None,
                 )
@@ -328,7 +416,7 @@ class BoundedPageParseWorker:
                 content_hash=digest,
                 byte_count=byte_count,
                 line_count=line_count,
-                mode=mode,
+                mode=parse_mode,
                 error=None,
                 page=page,
             )

--- a/src/graph/bounded_page_parse.py
+++ b/src/graph/bounded_page_parse.py
@@ -4,6 +4,10 @@ Every parse that must not hang indefinitely runs in a persistent child process
 with a hard deadline. The parent never relies on thread interruption.
 
 No Shadow / GraphAstCache integration in this module's callers yet — infra only.
+
+Privacy: diagnostic fields on :class:`BoundedParseResult` are content-free
+(hash / byte / line counts only). The optional ``page`` AST is ``repr=False``
+and must never be serialized or logged by callers — treat it as vault content.
 """
 
 from __future__ import annotations
@@ -12,11 +16,11 @@ import atexit
 import contextlib
 import hashlib
 import multiprocessing as mp
+import os
 import pickle
 import threading
 import time
-from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from queue import Empty
 from typing import Any, Literal
 
@@ -59,7 +63,13 @@ def page_line_count(text: str) -> int:
 
 @dataclass(frozen=True, slots=True)
 class BoundedParseResult:
-    """Outcome of a bounded page parse (never includes vault paths or body text)."""
+    """Outcome of a bounded page parse.
+
+    Diagnostic fields (``ok``, ``timed_out``, ``elapsed_s``, ``content_hash``,
+    ``byte_count``, ``line_count``, ``mode``, ``error``) are content-free: no
+    vault paths and no body text. ``page`` holds the AST when ``ok`` and is
+    excluded from ``repr``; callers must not log or serialize ``page``.
+    """
 
     ok: bool
     timed_out: bool
@@ -69,7 +79,7 @@ class BoundedParseResult:
     line_count: int
     mode: ParseMode
     error: str | None = None
-    page: Any | None = None
+    page: Any | None = field(default=None, repr=False)
 
 
 def _worker_loop(
@@ -119,10 +129,15 @@ def _worker_loop(
 
 
 class BoundedPageParseWorker:
-    """Persistent spawn worker; one outstanding parse at a time (lock-serialized)."""
+    """Persistent spawn worker; one outstanding parse at a time (lock-serialized).
+
+    Ownership is tied to the creating process PID. After ``os.fork``, inherited
+    handles must be abandoned without terminating the parent's worker.
+    """
 
     def __init__(self) -> None:
         self._lock = threading.RLock()
+        self._owner_pid = os.getpid()
         self._proc: Any | None = None
         self._in_q: Any | None = None
         self._out_q: Any | None = None
@@ -131,6 +146,10 @@ class BoundedPageParseWorker:
     def pid(self) -> int | None:
         proc = self._proc
         return proc.pid if proc is not None and proc.is_alive() else None
+
+    @property
+    def owner_pid(self) -> int:
+        return self._owner_pid
 
     def _start_unlocked(self) -> None:
         self._in_q = _CTX.Queue(maxsize=1)
@@ -143,7 +162,24 @@ class BoundedPageParseWorker:
         )
         self._proc.start()
 
+    def _abandon_inherited_unlocked(self) -> None:
+        """Drop inherited refs after fork; do not terminate the parent's worker."""
+        self._proc = None
+        self._in_q = None
+        self._out_q = None
+
+    def abandon_inherited_handles(self) -> None:
+        """Public: discard fork-inherited handles without killing the parent worker."""
+        with self._lock:
+            self._abandon_inherited_unlocked()
+            self._owner_pid = os.getpid()
+
     def _ensure_worker_unlocked(self) -> None:
+        if os.getpid() != self._owner_pid:
+            self._abandon_inherited_unlocked()
+            self._owner_pid = os.getpid()
+            self._start_unlocked()
+            return
         if self._proc is not None and self._proc.is_alive():
             return
         self._discard_queues_unlocked()
@@ -175,8 +211,12 @@ class BoundedPageParseWorker:
         self._discard_queues_unlocked()
 
     def shutdown(self) -> None:
-        """Stop the worker process (idempotent)."""
+        """Stop the worker process (idempotent). Skip kill if we are a forked child."""
         with self._lock:
+            if os.getpid() != self._owner_pid:
+                self._abandon_inherited_unlocked()
+                self._owner_pid = os.getpid()
+                return
             proc = self._proc
             in_q = self._in_q
             if proc is not None and proc.is_alive() and in_q is not None:
@@ -296,24 +336,39 @@ class BoundedPageParseWorker:
 
 _worker_lock = threading.Lock()
 _worker: BoundedPageParseWorker | None = None
+_worker_owner_pid: int | None = None
 
 
 def get_bounded_page_parse_worker() -> BoundedPageParseWorker:
-    """Process-wide singleton worker."""
-    global _worker
+    """Process-wide singleton worker (recreated after fork in the child)."""
+    global _worker, _worker_owner_pid
     with _worker_lock:
-        if _worker is None:
-            _worker = BoundedPageParseWorker()
+        pid = os.getpid()
+        if _worker is not None and _worker_owner_pid == pid:
+            return _worker
+        if _worker is not None:
+            # Forked child (or stale owner): drop inherited handles; do not kill.
+            _worker.abandon_inherited_handles()
+            _worker = None
+            _worker_owner_pid = None
+        _worker = BoundedPageParseWorker()
+        _worker_owner_pid = pid
         return _worker
 
 
 def reset_bounded_page_parse_worker_for_tests() -> None:
-    """Shutdown and drop the singleton (tests only)."""
-    global _worker
+    """Shutdown and drop the singleton (tests only; owner PID only)."""
+    global _worker, _worker_owner_pid
     with _worker_lock:
-        if _worker is not None:
+        if _worker is None:
+            _worker_owner_pid = None
+            return
+        if _worker_owner_pid == os.getpid():
             _worker.shutdown()
-            _worker = None
+        else:
+            _worker.abandon_inherited_handles()
+        _worker = None
+        _worker_owner_pid = None
 
 
 def parse_page_text_bounded(
@@ -336,7 +391,20 @@ def _atexit_shutdown() -> None:
     reset_bounded_page_parse_worker_for_tests()
 
 
+def _after_fork_in_child() -> None:
+    """Drop singleton after fork so the child never shares parent's queues/worker."""
+    global _worker, _worker_owner_pid
+    # register_at_fork after_in_child: avoid waiting on locks held by parent threads.
+    inherited = _worker
+    _worker = None
+    _worker_owner_pid = None
+    if inherited is not None:
+        inherited._abandon_inherited_unlocked()  # noqa: SLF001 - fork path only
+
+
 atexit.register(_atexit_shutdown)
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_after_fork_in_child)
 
 __all__ = [
     "BoundedParseResult",

--- a/src/utils/env_parse.py
+++ b/src/utils/env_parse.py
@@ -64,9 +64,44 @@ def env_float(key: str, default: float) -> float:
         return default
 
 
+def env_float_clamped(
+    key: str,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    """Parse a float env var and clamp to ``[minimum, maximum]``."""
+    value = env_float(key, default)
+    if value < minimum:
+        logger.warning(
+            "Float for {}={} below minimum {}; clamping",
+            key,
+            value,
+            minimum,
+        )
+        return minimum
+    if value > maximum:
+        logger.warning(
+            "Float for {}={} above maximum {}; clamping",
+            key,
+            value,
+            maximum,
+        )
+        return maximum
+    return value
+
+
 def env_str(key: str, default: str = "") -> str:
     raw = os.environ.get(key, "").strip().lower()
     return raw if raw else default
 
 
-__all__ = ["env_bool", "env_float", "env_int", "env_int_clamped", "env_str"]
+__all__ = [
+    "env_bool",
+    "env_float",
+    "env_float_clamped",
+    "env_int",
+    "env_int_clamped",
+    "env_str",
+]

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
+import signal
 import time
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 from src.graph.bounded_page_parse import (
     BoundedPageParseWorker,
     ParseMode,
     content_hash16,
+    get_bounded_page_parse_worker,
     page_parse_timeout_s,
     parse_page_text_bounded,
     reset_bounded_page_parse_worker_for_tests,
@@ -99,8 +103,210 @@ def test_worker_survives_success_and_shuts_clean() -> None:
             assert not _pid_alive(alive_pid)
 
 
-def test_parse_result_never_embeds_abs_paths() -> None:
-    result = parse_page_text_bounded("- hello\n", mode="logos", timeout_s=15.0)
+def test_parse_result_repr_excludes_page_and_sensitive_text() -> None:
+    """repr must stay content-free even when page AST embeds path-like / secret-like text."""
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    pathish = "/Users/marco/Documents/secret-vault/pages/Private.md"
+    title = f"Title with {pathish} and {secret}"
+    text = f"- marker {secret}\n- also {pathish}\n- body leak check\n"
+    result = parse_page_text_bounded(
+        text,
+        mode="logos",
+        page_title=title,
+        timeout_s=15.0,
+    )
+    assert result.ok is True
+    assert result.page is not None
     blob = repr(result)
+    assert "page=" not in blob
+    assert secret not in blob
+    assert pathish not in blob
     assert "/Users/" not in blob
     assert "Documents/" not in blob
+    assert "Private.md" not in blob
+    assert "body leak check" not in blob
+    assert "AKIA" not in blob
+
+
+def test_timeout_then_healthy_parse_gets_new_pid() -> None:
+    worker = BoundedPageParseWorker()
+    try:
+        timed = worker.parse_text(
+            generate_pathological_page(),
+            mode="logos",
+            timeout_s=3.0,
+        )
+        assert timed.timed_out is True
+        assert worker.pid is None
+
+        healthy_text = "- recovered after timeout\n"
+        healthy = worker.parse_text(healthy_text, mode="logos", timeout_s=15.0)
+        assert healthy.ok is True
+        assert healthy.timed_out is False
+        assert healthy.content_hash == content_hash16(healthy_text)
+        assert healthy.page is not None
+        new_pid = worker.pid
+        assert new_pid is not None
+    finally:
+        worker.shutdown()
+
+
+def test_concurrent_callers_get_matched_results() -> None:
+    texts = [f"- concurrent marker {i} unique-{i * 17}\n" for i in range(8)]
+
+    def _one(text: str) -> tuple[str, str]:
+        result = parse_page_text_bounded(text, mode="logos", timeout_s=30.0)
+        assert result.ok is True
+        return text, result.content_hash
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(_one, t) for t in texts]
+        got = {text: digest for text, digest in (f.result() for f in as_completed(futures))}
+    for text in texts:
+        assert got[text] == content_hash16(text)
+
+
+def test_worker_crash_recovers_bounded() -> None:
+    worker = BoundedPageParseWorker()
+    try:
+        first = worker.parse_text("- before crash\n", mode="logos", timeout_s=15.0)
+        assert first.ok is True
+        crash_pid = worker.pid
+        assert crash_pid is not None
+        os.kill(crash_pid, signal.SIGKILL)
+        # Wait until multiprocessing reaps the child (kill(pid,0) stays true for zombies).
+        deadline = time.monotonic() + 5.0
+        while worker.pid is not None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert worker.pid is None
+
+        recovered_text = "- after crash recovery\n"
+        recovered = worker.parse_text(recovered_text, mode="logos", timeout_s=15.0)
+        assert recovered.ok is True
+        assert recovered.content_hash == content_hash16(recovered_text)
+        assert worker.pid is not None
+        assert worker.pid != crash_pid
+    finally:
+        worker.shutdown()
+
+
+def test_no_stale_result_after_timeout() -> None:
+    worker = BoundedPageParseWorker()
+    try:
+        timed = worker.parse_text(
+            generate_pathological_page(),
+            mode="logos",
+            timeout_s=3.0,
+        )
+        assert timed.timed_out is True
+        next_text = "- fresh after timeout no stale\n"
+        nxt = worker.parse_text(next_text, mode="logos", timeout_s=15.0)
+        assert nxt.ok is True
+        assert nxt.content_hash == content_hash16(next_text)
+        assert nxt.content_hash != timed.content_hash
+    finally:
+        worker.shutdown()
+
+
+def test_shutdown_idempotent() -> None:
+    worker = BoundedPageParseWorker()
+    assert worker.parse_text("- shutdown once\n", timeout_s=15.0).ok is True
+    worker.shutdown()
+    assert worker.pid is None
+    worker.shutdown()
+    worker.shutdown()
+    assert worker.pid is None
+
+
+def _fork_ownership_probe(conn: object) -> None:
+    """Spawn-child entry: fork once in a near-single-threaded process."""
+    import multiprocessing.connection as mp_conn
+
+    assert isinstance(conn, mp_conn.Connection)
+    reset_bounded_page_parse_worker_for_tests()
+    parent_worker = get_bounded_page_parse_worker()
+    assert parent_worker.parse_text("- parent before fork\n", timeout_s=15.0).ok
+    parent_pid = parent_worker.pid
+    assert parent_pid is not None
+
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(read_fd)
+        try:
+            child_worker = get_bounded_page_parse_worker()
+            parent_still_alive = _pid_alive(parent_pid)
+            child_result = child_worker.parse_text("- child after fork\n", timeout_s=15.0)
+            child_ok = bool(
+                child_result.ok
+                and child_result.content_hash == content_hash16("- child after fork\n")
+            )
+            child_wp = child_worker.pid
+            distinct = child_wp is not None and child_wp != parent_pid
+            os.write(
+                write_fd,
+                f"{int(parent_still_alive)} {int(child_ok)} {int(distinct)}\n".encode(),
+            )
+            os.close(write_fd)
+            os._exit(0 if parent_still_alive and child_ok and distinct else 1)
+        except Exception:  # noqa: BLE001
+            with contextlib.suppress(Exception):
+                os.write(write_fd, b"0 0 0\n")
+                os.close(write_fd)
+            os._exit(2)
+
+    os.close(write_fd)
+    with os.fdopen(read_fd, "rb") as pipe:
+        raw = pipe.read()
+    _waited, status = os.waitpid(child_pid, 0)
+    ok_exit = os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+    parts = raw.decode().strip().split() if raw else []
+    parent_after = parent_worker.parse_text("- parent after child exit\n", timeout_s=15.0)
+    payload = {
+        "parent_alive": bool(
+            _pid_alive(parent_pid) and parent_after.ok and parent_worker.pid == parent_pid
+        ),
+        "child_ok": bool(ok_exit and parts == ["1", "1", "1"]),
+        "distinct": bool(len(parts) == 3 and parts[2] == "1"),
+    }
+    conn.send(payload)
+    conn.close()
+    reset_bounded_page_parse_worker_for_tests()
+    raise SystemExit(0 if all(payload.values()) else 1)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="Unix fork ownership only")
+def test_fork_child_abandons_parent_worker_without_killing() -> None:
+    """Probe runs under spawn so pytest threads do not poison os.fork()."""
+    import multiprocessing as mp
+
+    ctx = mp.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe(duplex=False)
+    proc = ctx.Process(target=_fork_ownership_probe, args=(child_conn,))
+    proc.start()
+    child_conn.close()
+    try:
+        payload = parent_conn.recv()
+    except EOFError:
+        payload = None
+    proc.join(timeout=60.0)
+    assert proc.exitcode == 0, payload
+    assert payload == {"parent_alive": True, "child_ok": True, "distinct": True}
+
+
+def test_spawn_start_method_is_used() -> None:
+    import multiprocessing as mp
+
+    worker = BoundedPageParseWorker()
+    try:
+        assert worker.parse_text("- spawn check\n", timeout_s=15.0).ok is True
+        assert mp.get_context("spawn").get_start_method() == "spawn"
+        assert worker.pid is not None
+    finally:
+        worker.shutdown()
+
+
+def test_singleton_owner_pid_tracks_process() -> None:
+    w = get_bounded_page_parse_worker()
+    assert w.owner_pid == os.getpid()
+    assert parse_page_text_bounded("- singleton\n", timeout_s=15.0).ok is True

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -8,6 +8,7 @@ import signal
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, cast
 
 import pytest
 from src.graph.bounded_page_parse import (
@@ -44,6 +45,11 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _page_raw(page: Any) -> str:
+    raw = getattr(page, "raw_content", None)
+    return raw if isinstance(raw, str) else ""
+
+
 def test_page_parse_timeout_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "0.5")
     assert page_parse_timeout_s() == 2.0
@@ -63,6 +69,19 @@ def test_control_page_parses_ok_logos_and_stack() -> None:
         assert result.page is not None
         assert result.content_hash == content_hash16(text)
         assert result.error is None
+
+
+def test_invalid_mode_rejected_without_silent_logos() -> None:
+    text = "- should not parse as logos\n"
+    result = parse_page_text_bounded(
+        text,
+        mode=cast(ParseMode, "not-a-parser"),
+        timeout_s=15.0,
+    )
+    assert result.ok is False
+    assert result.error == "invalid_mode"
+    assert result.mode == "not-a-parser"
+    assert result.page is None
 
 
 def test_pathological_page_times_out_and_kills_worker() -> None:
@@ -145,6 +164,7 @@ def test_timeout_then_healthy_parse_gets_new_pid() -> None:
         assert healthy.timed_out is False
         assert healthy.content_hash == content_hash16(healthy_text)
         assert healthy.page is not None
+        assert "recovered after timeout" in _page_raw(healthy.page)
         new_pid = worker.pid
         assert new_pid is not None
     finally:
@@ -154,16 +174,26 @@ def test_timeout_then_healthy_parse_gets_new_pid() -> None:
 def test_concurrent_callers_get_matched_results() -> None:
     texts = [f"- concurrent marker {i} unique-{i * 17}\n" for i in range(8)]
 
-    def _one(text: str) -> tuple[str, str]:
+    def _one(text: str) -> tuple[str, str, str]:
         result = parse_page_text_bounded(text, mode="logos", timeout_s=30.0)
         assert result.ok is True
-        return text, result.content_hash
+        assert result.page is not None
+        marker = text.strip().removeprefix("- ").strip()
+        assert marker in _page_raw(result.page)
+        # content_hash is only accepted after worker echo correlation.
+        assert result.content_hash == content_hash16(text)
+        return text, result.content_hash, marker
 
     with ThreadPoolExecutor(max_workers=4) as pool:
         futures = [pool.submit(_one, t) for t in texts]
-        got = {text: digest for text, digest in (f.result() for f in as_completed(futures))}
+        got = {
+            text: (digest, marker)
+            for text, digest, marker in (f.result() for f in as_completed(futures))
+        }
     for text in texts:
-        assert got[text] == content_hash16(text)
+        digest, marker = got[text]
+        assert digest == content_hash16(text)
+        assert marker in text
 
 
 def test_worker_crash_recovers_bounded() -> None:
@@ -184,6 +214,7 @@ def test_worker_crash_recovers_bounded() -> None:
         recovered = worker.parse_text(recovered_text, mode="logos", timeout_s=15.0)
         assert recovered.ok is True
         assert recovered.content_hash == content_hash16(recovered_text)
+        assert "after crash recovery" in _page_raw(recovered.page)
         assert worker.pid is not None
         assert worker.pid != crash_pid
     finally:
@@ -199,11 +230,64 @@ def test_no_stale_result_after_timeout() -> None:
             timeout_s=3.0,
         )
         assert timed.timed_out is True
-        next_text = "- fresh after timeout no stale\n"
+        next_text = "- fresh after timeout no stale MARKER-9911\n"
         nxt = worker.parse_text(next_text, mode="logos", timeout_s=15.0)
         assert nxt.ok is True
         assert nxt.content_hash == content_hash16(next_text)
         assert nxt.content_hash != timed.content_hash
+        assert nxt.page is not None
+        assert "MARKER-9911" in _page_raw(nxt.page)
+        assert "MARKER-9911" not in (timed.error or "")
+    finally:
+        worker.shutdown()
+
+
+def test_unexpected_output_is_protocol_mismatch() -> None:
+    worker = BoundedPageParseWorker()
+    try:
+        assert worker.parse_text("- seed worker\n", timeout_s=15.0).ok is True
+        assert worker._out_q is not None  # noqa: SLF001 - inject stale reply
+        worker._out_q.put(  # noqa: SLF001
+            {
+                "ok": True,
+                "request_id": 999,
+                "content_hash": "deadbeefdeadbeef",
+                "blob": b"not-a-pickle",
+                "s": 0.0,
+            }
+        )
+        result = worker.parse_text("- next legitimate request\n", timeout_s=15.0)
+        assert result.ok is False
+        assert result.error == "protocol_mismatch"
+        assert result.page is None
+        # Worker was killed; a later parse must recover on a fresh child.
+        recovered = worker.parse_text("- after mismatch recovery\n", timeout_s=15.0)
+        assert recovered.ok is True
+        assert "after mismatch recovery" in _page_raw(recovered.page)
+    finally:
+        worker.shutdown()
+
+
+def test_request_id_hash_mismatch_rejects_ast() -> None:
+    from unittest.mock import patch
+
+    worker = BoundedPageParseWorker()
+    try:
+        assert worker.parse_text("- warm\n", timeout_s=15.0).ok is True
+        assert worker._out_q is not None  # noqa: SLF001
+        real_get = worker._out_q.get
+
+        def _corrupt_echo(*args: object, **kwargs: object) -> dict[str, object]:
+            raw = real_get(*args, **kwargs)
+            assert isinstance(raw, dict)
+            # Keep blob so a naive parent would accept the wrong AST.
+            return {**raw, "request_id": -1, "content_hash": "0" * 16}
+
+        with patch.object(worker._out_q, "get", side_effect=_corrupt_echo):
+            result = worker.parse_text("- should reject mismatched echo\n", timeout_s=15.0)
+        assert result.ok is False
+        assert result.error == "protocol_mismatch"
+        assert result.page is None
     finally:
         worker.shutdown()
 
@@ -224,9 +308,10 @@ def _fork_ownership_probe(conn: object) -> None:
 
     assert isinstance(conn, mp_conn.Connection)
     reset_bounded_page_parse_worker_for_tests()
-    parent_worker = get_bounded_page_parse_worker()
-    assert parent_worker.parse_text("- parent before fork\n", timeout_s=15.0).ok
-    parent_pid = parent_worker.pid
+    # Direct (non-singleton) ref must stay fork-safe for ``.pid`` after fork.
+    direct_worker = BoundedPageParseWorker()
+    assert direct_worker.parse_text("- parent before fork\n", timeout_s=15.0).ok
+    parent_pid = direct_worker.pid
     assert parent_pid is not None
 
     read_fd, write_fd = os.pipe()
@@ -234,24 +319,34 @@ def _fork_ownership_probe(conn: object) -> None:
     if child_pid == 0:
         os.close(read_fd)
         try:
+            # Inherited direct ref: must not raise on ``.pid``.
+            try:
+                inherited_pid = direct_worker.pid
+                pid_safe = inherited_pid is None
+            except Exception:  # noqa: BLE001
+                pid_safe = False
+
             child_worker = get_bounded_page_parse_worker()
             parent_still_alive = _pid_alive(parent_pid)
             child_result = child_worker.parse_text("- child after fork\n", timeout_s=15.0)
             child_ok = bool(
                 child_result.ok
                 and child_result.content_hash == content_hash16("- child after fork\n")
+                and "child after fork" in _page_raw(child_result.page)
             )
             child_wp = child_worker.pid
             distinct = child_wp is not None and child_wp != parent_pid
             os.write(
                 write_fd,
-                f"{int(parent_still_alive)} {int(child_ok)} {int(distinct)}\n".encode(),
+                (
+                    f"{int(parent_still_alive)} {int(child_ok)} {int(distinct)} {int(pid_safe)}\n"
+                ).encode(),
             )
             os.close(write_fd)
-            os._exit(0 if parent_still_alive and child_ok and distinct else 1)
+            os._exit(0 if parent_still_alive and child_ok and distinct and pid_safe else 1)
         except Exception:  # noqa: BLE001
             with contextlib.suppress(Exception):
-                os.write(write_fd, b"0 0 0\n")
+                os.write(write_fd, b"0 0 0 0\n")
                 os.close(write_fd)
             os._exit(2)
 
@@ -261,16 +356,18 @@ def _fork_ownership_probe(conn: object) -> None:
     _waited, status = os.waitpid(child_pid, 0)
     ok_exit = os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
     parts = raw.decode().strip().split() if raw else []
-    parent_after = parent_worker.parse_text("- parent after child exit\n", timeout_s=15.0)
+    parent_after = direct_worker.parse_text("- parent after child exit\n", timeout_s=15.0)
     payload = {
         "parent_alive": bool(
-            _pid_alive(parent_pid) and parent_after.ok and parent_worker.pid == parent_pid
+            _pid_alive(parent_pid) and parent_after.ok and direct_worker.pid == parent_pid
         ),
-        "child_ok": bool(ok_exit and parts == ["1", "1", "1"]),
-        "distinct": bool(len(parts) == 3 and parts[2] == "1"),
+        "child_ok": bool(ok_exit and len(parts) == 4 and parts[:3] == ["1", "1", "1"]),
+        "distinct": bool(len(parts) == 4 and parts[2] == "1"),
+        "pid_safe": bool(len(parts) == 4 and parts[3] == "1"),
     }
     conn.send(payload)
     conn.close()
+    direct_worker.shutdown()
     reset_bounded_page_parse_worker_for_tests()
     raise SystemExit(0 if all(payload.values()) else 1)
 
@@ -291,7 +388,12 @@ def test_fork_child_abandons_parent_worker_without_killing() -> None:
         payload = None
     proc.join(timeout=60.0)
     assert proc.exitcode == 0, payload
-    assert payload == {"parent_alive": True, "child_ok": True, "distinct": True}
+    assert payload == {
+        "parent_alive": True,
+        "child_ok": True,
+        "distinct": True,
+        "pid_safe": True,
+    }
 
 
 def test_spawn_start_method_is_used() -> None:

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -1,0 +1,106 @@
+"""PR2B — bounded page parse worker (no Shadow/AST integration)."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+
+import pytest
+from src.graph.bounded_page_parse import (
+    BoundedPageParseWorker,
+    ParseMode,
+    content_hash16,
+    page_parse_timeout_s,
+    parse_page_text_bounded,
+    reset_bounded_page_parse_worker_for_tests,
+)
+
+from tests.a_cli_01_generator import (
+    PATHOLOGICAL_PAGE_LINE_COUNT,
+    generate_control_page,
+    generate_pathological_page,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_worker() -> Iterator[None]:
+    reset_bounded_page_parse_worker_for_tests()
+    yield
+    reset_bounded_page_parse_worker_for_tests()
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_page_parse_timeout_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "0.5")
+    assert page_parse_timeout_s() == 2.0
+    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "999")
+    assert page_parse_timeout_s() == 120.0
+    monkeypatch.delenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", raising=False)
+    assert page_parse_timeout_s() == 15.0
+
+
+def test_control_page_parses_ok_logos_and_stack() -> None:
+    text = generate_control_page(line_count=80)
+    modes: tuple[ParseMode, ...] = ("logos", "stack")
+    for mode in modes:
+        result = parse_page_text_bounded(text, mode=mode, timeout_s=30.0)
+        assert result.ok is True
+        assert result.timed_out is False
+        assert result.page is not None
+        assert result.content_hash == content_hash16(text)
+        assert result.error is None
+
+
+def test_pathological_page_times_out_and_kills_worker() -> None:
+    text = generate_pathological_page()
+    assert text.count("\n") == PATHOLOGICAL_PAGE_LINE_COUNT
+    worker = BoundedPageParseWorker()
+    try:
+        result = worker.parse_text(text, mode="logos", timeout_s=3.0)
+        assert result.ok is False
+        assert result.timed_out is True
+        assert result.error == "timeout"
+        assert result.page is None
+        assert "/" not in (result.error or "")
+        # Worker must not remain alive after timeout kill.
+        assert worker.pid is None
+    finally:
+        worker.shutdown()
+        assert worker.pid is None
+
+
+def test_worker_survives_success_and_shuts_clean() -> None:
+    worker = BoundedPageParseWorker()
+    try:
+        first = worker.parse_text("- ok\n", mode="logos", timeout_s=15.0)
+        assert first.ok is True
+        pid = worker.pid
+        assert pid is not None
+        second = worker.parse_text("- still ok\n", mode="stack", timeout_s=15.0)
+        assert second.ok is True
+        assert worker.pid == pid
+    finally:
+        alive_pid = worker.pid
+        worker.shutdown()
+        assert worker.pid is None
+        if alive_pid is not None:
+            # Give OS a beat; process must be gone.
+            time.sleep(0.05)
+            assert not _pid_alive(alive_pid)
+
+
+def test_parse_result_never_embeds_abs_paths() -> None:
+    result = parse_page_text_bounded("- hello\n", mode="logos", timeout_s=15.0)
+    blob = repr(result)
+    assert "/Users/" not in blob
+    assert "Documents/" not in blob


### PR DESCRIPTION
## Summary
- **PR2B infra** for [#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297): persistent `spawn` worker with hard deadline (`MATRYCA_PAGE_PARSE_TIMEOUT_S`, clamp 2–120).
- Request/result correlation: monotonic `request_id` + echoed `content_hash`; mismatch or unexpected pre-request output → kill/restart + `protocol_mismatch` (AST never accepted).
- Fork-safe `pid` (owner PID check first); runtime `mode` validation (`invalid_mode`).
- **No** Shadow / `GraphAstCache` / `load_directory` integration.

## Review follow-ups
- Restored `MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS`; `page` is `repr=False`; measure script requires `--graph`.
- Lifecycle + non-vacuous correlation tests (AST markers); fork test keeps a direct pre-fork worker ref.

## Overhead (1009-page soak vault, timeout 30s)
- Worker p50 **~2.1 ms**, overhead mediano **~0.2 ms**; **3 timeouts / 0 errors / 1006** completes.

## Test plan
- [x] `pytest tests/test_bounded_page_parse.py` (16 passed)
- [x] protocol_mismatch + invalid_mode + fork `pid` safety