### PR TITLE
docs(agents): add granular repository skill adapters

### DIFF
--- a/.agents/skills/matryca-changelog/SKILL.md
+++ b/.agents/skills/matryca-changelog/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-changelog
+description: Decide whether a completed Matryca change belongs in CHANGELOG.md and add one concise Unreleased entry when required. Use before concluding runtime, security, architecture, integration, performance, operator, or public-contract changes.
+---
+# Matryca changelog
+
+Read [`.cursor/rules/06-auto-changelog.mdc`](../../../.cursor/rules/06-auto-changelog.mdc) completely before the final change summary. Do not activate for clearly formatting-only or test-only work unless it documents a newly fixed user-visible bug.

--- a/.agents/skills/matryca-clean-architecture/SKILL.md
+++ b/.agents/skills/matryca-clean-architecture/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-clean-architecture
+description: Preserve Matryca Clean Architecture dependency direction, thin surfaces, domain ownership, typed boundaries, config parsing, and scoped refactors. Use for module moves, shared abstractions, layer imports, configuration architecture, or structural Python changes.
+---
+# Matryca clean architecture
+
+Read [`.cursor/rules/12-clean-code-architecture.mdc`](../../../.cursor/rules/12-clean-code-architecture.mdc) completely before acting. Load the full architecture SSOT only for decisions needing more detail than the rule summary.

--- a/.agents/skills/matryca-env/SKILL.md
+++ b/.agents/skills/matryca-env/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-env
+description: Keep Matryca environment-variable code, defaults, UI mappings, .env.example, coverage tests, and changelog synchronized. Use when adding, renaming, deprecating, exposing, or changing any environment variable or default.
+---
+# Matryca environment contracts
+
+Read [`.cursor/rules/07-env-example.mdc`](../../../.cursor/rules/07-env-example.mdc) completely before editing an environment contract. Apply the changelog skill if the change is user-visible.

--- a/.agents/skills/matryca-github/SKILL.md
+++ b/.agents/skills/matryca-github/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: matryca-github
+description: Apply Matryca maintainer standards for GitHub issues, pull requests, branches, reviews, merges, milestones, tags, releases, and remote comments. Use before any GitHub-facing action or artifact.
+---
+# Matryca GitHub workflow
+
+Read these canonical rules completely before acting:
+
+1. [`.cursor/rules/08-github-workflow-standards.mdc`](../../../.cursor/rules/08-github-workflow-standards.mdc)
+2. [`.cursor/rules/09-github-identity-marco-porcellato.mdc`](../../../.cursor/rules/09-github-identity-marco-porcellato.mdc)
+3. [`.cursor/rules/10-tooling-static-analysis-policy.mdc`](../../../.cursor/rules/10-tooling-static-analysis-policy.mdc)
+
+Do not perform remote mutations without explicit user authorization.

--- a/.agents/skills/matryca-logseq-io/SKILL.md
+++ b/.agents/skills/matryca-logseq-io/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-logseq-io
+description: Choose safe direct-file versus Local HTTP API access for Logseq. Use when changing graph reads, writes, background indexing, live Logseq integration, authentication, or JSON-RPC communication.
+---
+# Matryca Logseq I/O
+
+Read [`.cursor/rules/03-logseq-api.mdc`](../../../.cursor/rules/03-logseq-api.mdc) completely before acting. Also activate the Python and Logseq-paradigm skills when their triggers apply.

--- a/.agents/skills/matryca-logseq-paradigm/SKILL.md
+++ b/.agents/skills/matryca-logseq-paradigm/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-logseq-paradigm
+description: Apply Matryca's Logseq OG outliner, block/property, namespace, and Markdown semantics. Use for graph-content generation, Logseq block or page-property changes, namespace handling, or code that transforms vault content.
+---
+# Matryca Logseq paradigm
+
+Read [`.cursor/rules/01-core-paradigm.mdc`](../../../.cursor/rules/01-core-paradigm.mdc) completely before acting. Treat it as canonical and load its linked SSOT only when deeper paradigm detail is necessary.

--- a/.agents/skills/matryca-prompt-maintainer/SKILL.md
+++ b/.agents/skills/matryca-prompt-maintainer/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-prompt-maintainer
+description: Maintain Matryca prompt builders, Tier-2 OpenSpec fragments, generated SYSTEM_PROMPT.md, prompt hashes, MCP tool docstrings, and llms.txt synchronization. Use for any prompt or MCP tool-contract change.
+---
+# Matryca prompt maintainer
+
+Read [`.cursor/rules/11-prompt-maintainer.mdc`](../../../.cursor/rules/11-prompt-maintainer.mdc) completely before acting. Follow its trigger-specific builders and checks; never edit generated prompt output directly.

--- a/.agents/skills/matryca-python-standards/SKILL.md
+++ b/.agents/skills/matryca-python-standards/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-python-standards
+description: Apply Matryca Python 3.12+, uv, typing, validation, concurrency, filesystem-safety, logging, and verification standards. Use whenever creating or modifying Python source or tests.
+---
+# Matryca Python standards
+
+Read [`.cursor/rules/02-python-standards.mdc`](../../../.cursor/rules/02-python-standards.mdc) completely before editing Python. Load the clean-architecture skill separately only for boundary, configuration, or structural work.

--- a/.agents/skills/matryca-release/SKILL.md
+++ b/.agents/skills/matryca-release/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-release
+description: Prepare, cut, verify, tag, or publish a Matryca semantic-version release. Use for version bumps, changelog finalization, release notes, build metadata, tags, GitHub Releases, or PyPI publication.
+---
+# Matryca release
+
+Read [`.cursor/rules/05-release-preparation.mdc`](../../../.cursor/rules/05-release-preparation.mdc) completely before acting. Also use the changelog and GitHub workflow skills for their respective parts. Never tag, push, merge, or publish without explicit user authorization.

--- a/.agents/skills/matryca-spatial-parser/SKILL.md
+++ b/.agents/skills/matryca-spatial-parser/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: matryca-spatial-parser
+description: Reuse Matryca graph primitives and the external spatial parser safely. Use for Markdown scanning, property injection, frontmatter, namespaces, fenced-code protection, AST extraction, or spatial RAG changes.
+---
+# Matryca spatial parser
+
+Read [`.cursor/rules/04-spatial-parser.mdc`](../../../.cursor/rules/04-spatial-parser.mdc) completely before acting. Do not load it for unrelated Python work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,28 +6,44 @@ This file routes coding assistants to the correct instruction layer. **Do not lo
 
 | You are… | Read first | Do not load |
 |----------|------------|-------------|
-| **Cursor agent patching this repo** | [`.cursor/rules/00-karpathy-agent-behavior.mdc`](.cursor/rules/00-karpathy-agent-behavior.mdc), this file, [`CONTRIBUTING.md`](CONTRIBUTING.md), [`docs/CLEAN_CODE_ARCHITECTURE.md`](docs/CLEAN_CODE_ARCHITECTURE.md) | Full [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) (runtime vault law) |
+| **Repository coding agent** | This file; then activate only the matching [`.agents/skills/`](.agents/skills/) adapter below | Full [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) and broad architecture docs unless the task requires them |
+| **Cursor agent patching this repo** | This file + Cursor's matching [`.cursor/rules/`](.cursor/rules/) selected by glob/trigger | Full [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) (runtime vault law) |
 | **External agent on a user Logseq vault** | [`llms.txt`](llms.txt) → [`SYSTEM_PROMPT.md`](SYSTEM_PROMPT.md) | [`.cursor/rules/`](.cursor/rules/) |
 | **Maintainer changing MCP/CLI/prompt contracts** | [`docs/PROMPT_ARCHITECTURE.md`](docs/PROMPT_ARCHITECTURE.md), [`docs/openspec/agent-onboarding.md`](docs/openspec/agent-onboarding.md), [`docs/openspec/agent/`](docs/openspec/agent/), [`docs/openspec/llm-performance.md`](docs/openspec/llm-performance.md), rule `11-prompt-maintainer` | — |
 | **Maintainer planning v2.0 Shadow DB** | [`docs/roadmaps/ROADMAP_V2_PREPARATION.md`](docs/roadmaps/ROADMAP_V2_PREPARATION.md), [`v2_preparation_blueprints.md`](v2_preparation_blueprints.md), [Epic #20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20) | Full v1.9.x audit triage docs |
 
-## Cursor rule routing
+## Instruction loading strategy
 
-| Rule | When it applies |
-|------|-----------------|
-| [`00-karpathy-agent-behavior.mdc`](.cursor/rules/00-karpathy-agent-behavior.mdc) | Always — investigate, minimal diff, run checks |
-| [`01-core-paradigm.mdc`](.cursor/rules/01-core-paradigm.mdc) | Logseq OG blocks, properties, namespaces → SSOT [`docs/openspec/agent/paradigm.md`](docs/openspec/agent/paradigm.md) |
-| [`02-python-standards.mdc`](.cursor/rules/02-python-standards.mdc) | Any `*.py` edit |
-| [`03-logseq-api.mdc`](.cursor/rules/03-logseq-api.mdc) | `src/**/*.py` — headless file I/O default |
-| [`04-spatial-parser.mdc`](.cursor/rules/04-spatial-parser.mdc) | `src/**/*.py` graph parsing |
-| [`05-release-preparation.mdc`](.cursor/rules/05-release-preparation.mdc) | Semver release (on request) |
-| [`06-auto-changelog.mdc`](.cursor/rules/06-auto-changelog.mdc) | User-visible changes — update `CHANGELOG.md` |
-| [`07-env-example.mdc`](.cursor/rules/07-env-example.mdc) | New/changed `MATRYCA_*` env vars |
-| [`08-github-workflow-standards.mdc`](.cursor/rules/08-github-workflow-standards.mdc) | GitHub issues/PRs (on request) |
-| [`09-github-identity-marco-porcellato.mdc`](.cursor/rules/09-github-identity-marco-porcellato.mdc) | Always — zero Cursor/AI su artefatti GitHub |
-| [`10-tooling-static-analysis-policy.mdc`](.cursor/rules/10-tooling-static-analysis-policy.mdc) | Public docs / CI — vendor-agnostic tooling |
-| [`11-prompt-maintainer.mdc`](.cursor/rules/11-prompt-maintainer.mdc) | Prompt fragments, Tier-1 builders, MCP docstrings (on request) |
-| [`12-clean-code-architecture.mdc`](.cursor/rules/12-clean-code-architecture.mdc) | Clean Code & Clean Architecture — repo-wide boundaries, `env_parse`, layer tests |
+- [`.cursor/rules/`](.cursor/rules/) is the canonical detailed policy set. Do not copy those rules into this file.
+- [`.agents/skills/`](.agents/skills/) contains thin, open Agent Skills adapters. Their metadata is cheap to discover; each adapter loads its canonical `.mdc` only when its task trigger applies.
+- Keep this root file limited to always-on constraints and routing. Do not preload all rules or linked SSOT documents.
+- Do not rely on nested `AGENTS.md` for file-glob behavior: instruction discovery follows the launch directory, not every file later edited. Prefer a task-triggered skill for cross-directory work.
+
+## Always-on working agreements
+
+- Investigate the live repository before editing; state material assumptions and success criteria.
+- Make the smallest scoped change, preserve unrelated work, and run the relevant checks yourself.
+- When the active environment supports subagents, prefer a lower-cost supporting model for bounded, parallelizable evidence gathering, test execution, documentation checks, and routine implementation. Keep final integration, security-sensitive decisions, and high-risk changes with the primary agent; do not delegate when coordination would cost more than doing the task directly.
+- Keep public repository artifacts vendor-neutral. GitHub-visible authorship and prose must be maintainer-only, with no assistant/tool attribution.
+- Before concluding a significant runtime, security, architecture, integration, performance, operator, or public-contract change, activate `matryca-changelog` and apply its decision gate.
+
+## Rule and skill routing
+
+| Canonical Cursor rule | Agent Skill adapter | Activate when |
+|-----------------------|---------------------|---------------|
+| [`00-karpathy-agent-behavior.mdc`](.cursor/rules/00-karpathy-agent-behavior.mdc) | Root summary above | Always |
+| [`01-core-paradigm.mdc`](.cursor/rules/01-core-paradigm.mdc) | `matryca-logseq-paradigm` | Logseq blocks, properties, namespaces, vault content |
+| [`02-python-standards.mdc`](.cursor/rules/02-python-standards.mdc) | `matryca-python-standards` | Any Python source or test edit |
+| [`03-logseq-api.mdc`](.cursor/rules/03-logseq-api.mdc) | `matryca-logseq-io` | Logseq reads/writes or Local HTTP API decisions |
+| [`04-spatial-parser.mdc`](.cursor/rules/04-spatial-parser.mdc) | `matryca-spatial-parser` | Markdown parsing, graph transformation, spatial RAG |
+| [`05-release-preparation.mdc`](.cursor/rules/05-release-preparation.mdc) | `matryca-release` | Prepare, cut, tag, or publish a release |
+| [`06-auto-changelog.mdc`](.cursor/rules/06-auto-changelog.mdc) | `matryca-changelog` | Changelog decision gate before completion |
+| [`07-env-example.mdc`](.cursor/rules/07-env-example.mdc) | `matryca-env` | New or changed environment contract/default |
+| [`08-github-workflow-standards.mdc`](.cursor/rules/08-github-workflow-standards.mdc) | `matryca-github` | GitHub issue, PR, merge, milestone, tag, release |
+| [`09-github-identity-marco-porcellato.mdc`](.cursor/rules/09-github-identity-marco-porcellato.mdc) | Root summary + `matryca-github` | Always for GitHub-visible artifacts |
+| [`10-tooling-static-analysis-policy.mdc`](.cursor/rules/10-tooling-static-analysis-policy.mdc) | Root summary + `matryca-github` | Public docs, CI, commits, GitHub prose |
+| [`11-prompt-maintainer.mdc`](.cursor/rules/11-prompt-maintainer.mdc) | `matryca-prompt-maintainer` | Prompt builders/fragments, MCP tool contracts |
+| [`12-clean-code-architecture.mdc`](.cursor/rules/12-clean-code-architecture.mdc) | `matryca-clean-architecture` | Module boundaries, config architecture, structural refactors |
 
 ## Runtime agent surfaces
 


### PR DESCRIPTION
## Summary

- keep `AGENTS.md` as a compact always-on router
- add task-triggered Agent Skills adapters for the existing canonical repository rules
- preserve progressive instruction loading instead of preloading every policy document
- prefer lower-cost supporting agents for bounded routine work when coordination remains efficient

## Design

The existing detailed rule files remain canonical. Each adapter contains only discovery metadata and a pointer to the one detailed policy required by its task. Public repository guidance remains vendor-neutral.

## Verification

- `make agents-check`: passed
- all ten Agent Skills adapters validated
- `git diff --check`: passed
- no runtime source, dependency, prompt, or release surface changed