### PR TITLE
fix(v2): bound graph parsing and harden persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- **Bounded AST cache parsing (PR2B/PR2C, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s); `GraphAstCache` now stages complete graph generations, atomically publishes bounded bootstrap/incremental results, and preserves the last good graph on timeout/error with hash-only diagnostics. Shadow integration remains a separate transactional follow-up. Overhead script requires `--graph PATH` (optional `--output`).
+- **Bounded AST and Shadow parsing (PR2B/PR2C, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). `GraphAstCache` atomically publishes complete bounded generations and preserves its last good graph on failure; Shadow rebuilds roll back, incremental sync keeps the prior page, persists hash-only diagnostics, and routes reads to Markdown/BM25 until a successful recovery rebuild. Overhead script requires `--graph PATH` (optional `--output`).
 
 ### Fixed
 
@@ -16,7 +16,7 @@
 
 ### Changed
 
-- **A-CLI-01 audit reproducer** — deterministic generator + `@pytest.mark.slow` parser-only probes for LogosParser pathological latency ([#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297)); bounded parser worker / Shadow containment still follow-up (PR2B/C).
+- **A-CLI-01 audit reproducer** — deterministic generator + `@pytest.mark.slow` parser-only probes for LogosParser pathological latency ([#297](https://github.com/MarcoPorcellato/matryca-plumber/issues/297)); bounded AST/Shadow containment now covers bootstrap and incremental paths.
 
 ## [2.0.0-alpha.5] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- **Catalog merge-save corruption guard (#198)** — `MasterCatalog.save(replace=False)` now aborts after quarantining unreadable or non-object `master_catalog.json` state instead of merging a stale in-memory snapshot with an empty fallback and overwriting unseen catalog rows; explicit `replace=True` remains available for deliberate rebuilds.
 - **Dependency security advisories (Dependabot #28–#31)** — require MCP Python SDK `>=1.28.1` to include task/session isolation and WebSocket transport fixes, and refresh the frontend lock to patched `brace-expansion>=5.0.7`. Matryca's MCP entrypoint remains stdio-only; no HTTP, WebSocket, or experimental task transport is enabled.
 - **CLI `search bm25` no longer eager-bootstraps AST (#297 / A-CLI-01)** — `matryca search bm25` prepares runtime with `eager_graph=False`, so LogosParser cold load cannot hang BM25 (raw Markdown / Shadow FTS). Other CLI commands keep eager AST warm-up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Security
+
+- **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.
+
 ### Added
 
 - **Bounded AST cache parsing (PR2B/PR2C, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s); `GraphAstCache` now stages complete graph generations, atomically publishes bounded bootstrap/incremental results, and preserves the last good graph on timeout/error with hash-only diagnostics. Shadow integration remains a separate transactional follow-up. Overhead script requires `--graph PATH` (optional `--output`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- **Bounded page-parse worker (PR2B infra, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). Fork-safe PID ownership (`register_at_fork` where available); `BoundedParseResult.page` is `repr=False` (diagnostics only in logs). Request/result correlation via monotonic `request_id` + echoed `content_hash` (mismatch → `protocol_mismatch`, AST never accepted). No Shadow/`GraphAstCache` integration yet. Overhead script requires `--graph PATH` (optional `--output`).
+- **Bounded AST cache parsing (PR2B/PR2C, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s); `GraphAstCache` now stages complete graph generations, atomically publishes bounded bootstrap/incremental results, and preserves the last good graph on timeout/error with hash-only diagnostics. Shadow integration remains a separate transactional follow-up. Overhead script requires `--graph PATH` (optional `--output`).
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "httpx>=0.28.0,<1.0.0",
     "packaging>=24.0,<27.0",
     "watchdog>=6.0.0",
-    "gitpython>=3.1.50",
+    "gitpython>=3.1.52",
     "ijson>=3.5.0",
     "edn-format>=0.7.5",
 ]
@@ -182,4 +182,3 @@ markers = [
     "slow: performance or memory soak tests (excluded from default CI)",
     "integration: subprocess or full-bootstrap tests (skipped by make test-fast)",
 ]
-

--- a/src/graph/ast_cache.py
+++ b/src/graph/ast_cache.py
@@ -12,10 +12,31 @@ from logseq_matryca_parser.logos_core import LogseqNode
 from logseq_matryca_parser.logseq_paths import discover_graph_files
 from loguru import logger
 
+from .bounded_ast_graph import (
+    BoundedGraphParseFailure,
+    build_graph_from_bounded_pages,
+    parse_graph_page_bounded,
+    replace_graph_page_by_source_path,
+)
+from .bounded_page_parse import reset_bounded_page_parse_worker_for_tests
+
 FileEventKind = Literal["created", "modified", "deleted"]
 
 _cache_lock = threading.Lock()
 _caches: dict[str, GraphAstCache] = {}
+
+
+class GraphAstParseError(RuntimeError):
+    """A bounded page parse failed without exposing its path or content."""
+
+    def __init__(self, failure: BoundedGraphParseFailure) -> None:
+        self.failure = failure
+        super().__init__(
+            "AST page parse failed "
+            f"(error={failure.error}, content_hash={failure.content_hash}, "
+            f"bytes={failure.byte_count}, lines={failure.line_count}, "
+            f"mode=stack)"
+        )
 
 
 def count_graph_markdown_files(graph_root: Path) -> int:
@@ -33,19 +54,35 @@ class GraphAstCache:
         self._graph: LogseqGraph | None = None
 
     def bootstrap(self) -> LogseqGraph:
-        """Full vault load on first access (idempotent, thread-safe)."""
+        """Build and atomically publish a complete bounded-parsed graph."""
         with self._lock:
             if self._graph is None:
-                markdown_files = count_graph_markdown_files(self.graph_root)
+                markdown_paths = discover_graph_files(self.graph_root)
+                markdown_files = len(markdown_paths)
                 logger.bind(
                     graph=str(self.graph_root),
                     markdown_files=markdown_files,
                     phase="start",
                 ).info("AST cache bootstrap started")
                 started = time.perf_counter()
-                self._graph = LogseqGraph.load_directory(self.graph_root)
+                pages = []
+                for path in markdown_paths:
+                    result = parse_graph_page_bounded(path, self.graph_root)
+                    if result.page is None or result.failure is not None:
+                        failure = result.failure or BoundedGraphParseFailure(
+                            content_hash="",
+                            byte_count=0,
+                            line_count=0,
+                            timed_out=False,
+                            elapsed_s=0.0,
+                            error="parse_error",
+                        )
+                        raise GraphAstParseError(failure)
+                    pages.append(result.page)
+                staged = build_graph_from_bounded_pages(self.graph_root, pages)
+                self._graph = staged
                 elapsed_s = round(time.perf_counter() - started, 3)
-                page_count = len(self._graph.pages)
+                page_count = len(staged.pages)
                 logger.bind(
                     graph=str(self.graph_root),
                     markdown_files=markdown_files,
@@ -60,25 +97,32 @@ class GraphAstCache:
         return self.bootstrap()
 
     def apply_file_event(self, path: Path, kind: FileEventKind) -> None:
-        """Apply a filesystem delta to the in-memory index."""
+        """Atomically apply a bounded filesystem delta to the in-memory index."""
         resolved = path.expanduser().resolve(strict=False)
         with self._lock:
             graph = self.bootstrap()
             if kind == "deleted" or not resolved.is_file():
-                logger.bind(path=str(resolved), kind=kind).debug(
-                    "AST cache full reload after delete or missing file",
-                )
-                self._graph = LogseqGraph.load_directory(self.graph_root)
+                self._graph = replace_graph_page_by_source_path(graph, resolved, None)
+                return
+            result = parse_graph_page_bounded(resolved, self.graph_root)
+            if result.page is None or result.failure is not None:
+                failure = result.failure
+                logger.bind(
+                    content_hash=failure.content_hash if failure else "",
+                    byte_count=failure.byte_count if failure else 0,
+                    line_count=failure.line_count if failure else 0,
+                    mode="stack",
+                    error=failure.error if failure else "parse_error",
+                ).warning("AST cache page reload rejected; preserving last complete graph")
                 return
             try:
-                graph.invalidate_and_reload_page(resolved)
-            except Exception as exc:  # noqa: BLE001 - parser edge cases
-                logger.warning(
-                    "AST cache page reload failed for {} ({}); full reload",
-                    resolved,
-                    exc,
+                staged = replace_graph_page_by_source_path(graph, resolved, result.page)
+            except Exception as exc:  # noqa: BLE001 - parser compatibility boundary
+                logger.bind(error=type(exc).__name__).warning(
+                    "AST cache page reindex failed; preserving last complete graph"
                 )
-                self._graph = LogseqGraph.load_directory(self.graph_root)
+                return
+            self._graph = staged
 
     def get_block_by_uuid(self, block_uuid: str) -> LogseqNode | None:
         """Resolve a block by registry UUID or on-disk ``id::`` embed ref."""
@@ -139,11 +183,13 @@ def clear_graph_ast_cache() -> None:
         _caches.clear()
     with _ast_bridge_lock:
         _ast_write_bridge_registered = False
+    reset_bounded_page_parse_worker_for_tests()
 
 
 __all__ = [
     "FileEventKind",
     "GraphAstCache",
+    "GraphAstParseError",
     "clear_graph_ast_cache",
     "count_graph_markdown_files",
     "get_graph_ast_cache",

--- a/src/graph/bounded_ast_graph.py
+++ b/src/graph/bounded_ast_graph.py
@@ -1,0 +1,210 @@
+"""Atomic ``LogseqGraph`` construction backed by bounded page parsing.
+
+This adapter turns a successful isolated Stack-Machine page parse into the
+same graph-native page shape produced by ``StackMachineParser.parse_page_file``.
+It also centralizes the parser package's currently-private graph-index helpers,
+so the cache integration has one compatibility boundary to audit.
+
+Failure values contain only a content hash and coarse measurements.  They
+intentionally never expose the source path or Markdown body.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from logseq_matryca_parser.graph import (
+    LogseqGraph,
+    _build_backlink_registry,
+    _build_lower_title_map,
+    _build_node_registry_from_pages,
+    _enrich_pages_index,
+)
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+from logseq_matryca_parser.logseq_markdown import detect_tab_size_from_markdown
+from logseq_matryca_parser.logseq_paths import (
+    derive_page_title_from_source_path,
+)
+
+from .bounded_page_parse import (
+    BoundedParseResult,
+    parse_page_text_bounded,
+)
+from .path_sandbox import assert_path_within_graph, read_graph_file_text
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedGraphParseFailure:
+    """Content-free result for a failed bounded file parse.
+
+    ``source_path`` and page text are deliberately absent: callers may record
+    this value in operational diagnostics without disclosing vault content.
+    """
+
+    content_hash: str
+    byte_count: int
+    line_count: int
+    timed_out: bool
+    elapsed_s: float
+    error: str
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedGraphPageResult:
+    """Either a graph-native page or a content-free parse failure."""
+
+    page: LogseqPage | None = field(default=None, repr=False)
+    failure: BoundedGraphParseFailure | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Whether a page was parsed and hydrated successfully."""
+        return self.page is not None and self.failure is None
+
+
+def _apply_source_path(nodes: list[LogseqNode], source_path: str) -> list[LogseqNode]:
+    """Recursively attach the owning file path, matching parser behavior."""
+    return [
+        node.model_copy(
+            update={
+                "source_path": source_path,
+                "children": _apply_source_path(node.children, source_path),
+            }
+        )
+        for node in nodes
+    ]
+
+
+def _failure_from_bounded_result(result: BoundedParseResult) -> BoundedGraphPageResult:
+    """Project the worker result to the content-free cache-facing error type."""
+    return BoundedGraphPageResult(
+        failure=BoundedGraphParseFailure(
+            content_hash=result.content_hash,
+            byte_count=result.byte_count,
+            line_count=result.line_count,
+            timed_out=result.timed_out,
+            elapsed_s=result.elapsed_s,
+            error=result.error or "parse_error",
+        )
+    )
+
+
+def _read_failure() -> BoundedGraphPageResult:
+    """Return a path-free read failure when a source file cannot be opened."""
+    return BoundedGraphPageResult(
+        failure=BoundedGraphParseFailure(
+            content_hash="",
+            byte_count=0,
+            line_count=0,
+            timed_out=False,
+            elapsed_s=0.0,
+            error="read_error",
+        )
+    )
+
+
+def parse_graph_page_bounded(
+    source_path: Path,
+    graph_root: Path,
+    *,
+    timeout_s: float | None = None,
+) -> BoundedGraphPageResult:
+    """Read and bounded-parse one graph Markdown file in Stack-Machine mode.
+
+    On success the returned page has the same source metadata as
+    ``StackMachineParser.parse_page_file``.  On timeout or parser/read error,
+    the failure is safe to log and has no path or body field.
+    """
+    root = graph_root.expanduser().resolve(strict=False)
+    try:
+        resolved = assert_path_within_graph(source_path, root)
+        text = read_graph_file_text(resolved, root, encoding="utf-8-sig")
+        stat = resolved.stat()
+    except OSError:
+        return _read_failure()
+
+    page_title = derive_page_title_from_source_path(resolved)
+    detected_tab = detect_tab_size_from_markdown(text)
+    parsed = parse_page_text_bounded(
+        text,
+        mode="stack",
+        page_title=page_title,
+        tab_size=detected_tab,
+        timeout_s=timeout_s,
+    )
+    if not parsed.ok or not isinstance(parsed.page, LogseqPage):
+        return _failure_from_bounded_result(parsed)
+
+    source_path_text = str(resolved)
+    page = parsed.page
+    assert isinstance(page, LogseqPage)
+    created_at = page.created_at if page.created_at is not None else int(os.path.getctime(resolved))
+    updated_at = page.updated_at if page.updated_at is not None else int(stat.st_mtime)
+    return BoundedGraphPageResult(
+        page=page.model_copy(
+            update={
+                "source_path": source_path_text,
+                "graph_root": str(root),
+                "created_at": created_at,
+                "updated_at": updated_at,
+                "tab_size": detected_tab,
+                "root_nodes": _apply_source_path(page.root_nodes, source_path_text),
+            }
+        )
+    )
+
+
+def build_graph_from_bounded_pages(
+    graph_root: Path,
+    pages: Iterable[LogseqPage],
+) -> LogseqGraph:
+    """Build a fully indexed graph from parsed pages without mutating inputs.
+
+    The private helper imports are intentionally centralized in this module;
+    they reproduce ``LogseqGraph.load_directory`` index construction exactly.
+    """
+    indexed_pages: dict[str, LogseqPage] = {}
+    for page in pages:
+        indexed_pages[page.title] = page
+    _enrich_pages_index(indexed_pages)
+    return LogseqGraph(
+        graph_path=graph_root.expanduser().resolve(strict=False),
+        pages=indexed_pages,
+        node_registry=_build_node_registry_from_pages(indexed_pages),
+        backlink_registry=_build_backlink_registry(indexed_pages),
+        lower_title_map=_build_lower_title_map(indexed_pages),
+    )
+
+
+def replace_graph_page_by_source_path(
+    graph: LogseqGraph,
+    source_path: Path,
+    replacement: LogseqPage | None,
+) -> LogseqGraph:
+    """Return a new complete graph with one source path replaced or removed.
+
+    ``graph`` and its index registries are never mutated.  Alias keys are
+    eliminated by iterating canonical pages before rebuilding all indexes.
+    """
+    resolved = source_path.expanduser().resolve(strict=False)
+    kept: list[LogseqPage] = []
+    for page in graph.iter_canonical_pages():
+        page_source = page.source_path
+        if page_source and Path(page_source).resolve(strict=False) == resolved:
+            continue
+        kept.append(page)
+    if replacement is not None:
+        kept.append(replacement)
+    return build_graph_from_bounded_pages(graph.graph_path, kept)
+
+
+__all__ = [
+    "BoundedGraphPageResult",
+    "BoundedGraphParseFailure",
+    "build_graph_from_bounded_pages",
+    "parse_graph_page_bounded",
+    "replace_graph_page_by_source_path",
+]

--- a/src/graph/bounded_page_parse.py
+++ b/src/graph/bounded_page_parse.py
@@ -3,7 +3,8 @@
 Every parse that must not hang indefinitely runs in a persistent child process
 with a hard deadline. The parent never relies on thread interruption.
 
-No Shadow / GraphAstCache integration in this module's callers yet — infra only.
+``GraphAstCache`` uses this worker for bounded bootstrap and incremental page
+parsing. Shadow integration remains a separate transactional follow-up.
 
 Privacy: diagnostic fields on :class:`BoundedParseResult` are content-free
 (hash / byte / line counts only). The optional ``page`` AST is ``repr=False``
@@ -109,6 +110,7 @@ def _worker_loop(
         mode = str(msg.get("mode", ""))
         text = str(msg.get("text", ""))
         title = str(msg.get("title", "Page"))
+        tab_size = int(msg.get("tab_size", 2))
         started = time.perf_counter()
         if mode not in _VALID_MODES:
             out_q.put(
@@ -124,7 +126,10 @@ def _worker_loop(
             if mode == "stack":
                 from logseq_matryca_parser.graph import StackMachineParser
 
-                page = StackMachineParser().parse(text, page_title=title)
+                page = StackMachineParser(tab_size=tab_size).parse(
+                    text,
+                    page_title=title,
+                )
             else:
                 from logseq_matryca_parser import LogosParser
 
@@ -284,6 +289,7 @@ class BoundedPageParseWorker:
         *,
         mode: ParseMode = "logos",
         page_title: str = "Page",
+        tab_size: int = 2,
         timeout_s: float | None = None,
     ) -> BoundedParseResult:
         """Parse ``text`` in the worker; kill the worker on deadline overrun."""
@@ -340,6 +346,7 @@ class BoundedPageParseWorker:
                 "mode": parse_mode,
                 "text": text,
                 "title": page_title,
+                "tab_size": tab_size,
             }
             wall0 = time.perf_counter()
             self._in_q.put(request)
@@ -464,6 +471,7 @@ def parse_page_text_bounded(
     *,
     mode: ParseMode = "logos",
     page_title: str = "Page",
+    tab_size: int = 2,
     timeout_s: float | None = None,
 ) -> BoundedParseResult:
     """Public API: always process-isolated; never an unbounded in-process LogosParser call."""
@@ -471,6 +479,7 @@ def parse_page_text_bounded(
         text,
         mode=mode,
         page_title=page_title,
+        tab_size=tab_size,
         timeout_s=timeout_s,
     )
 

--- a/src/graph/bounded_page_parse.py
+++ b/src/graph/bounded_page_parse.py
@@ -16,9 +16,13 @@ from __future__ import annotations
 import atexit
 import contextlib
 import hashlib
+import json
 import multiprocessing as mp
 import os
 import pickle
+import struct
+import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -38,6 +42,8 @@ _MIN_TIMEOUT_S = 2.0
 _MAX_TIMEOUT_S = 120.0
 _TERMINATE_GRACE_S = 5.0
 _SHUTDOWN_JOIN_S = 5.0
+_SUBPROCESS_MODULE = "src.graph.bounded_page_parse_child"
+_SUBPROCESS_HEADER_BYTES = 4
 
 _CTX = mp.get_context("spawn")
 
@@ -91,6 +97,55 @@ def _echo_fields(msg: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _parse_request_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """Parse one trusted local request and return a content-free response envelope.
+
+    The AST is serialized separately as bytes.  This lets the daemon-parent
+    fallback verify response correlation before unpickling the AST payload.
+    """
+    op = str(msg.get("op", ""))
+    echo = _echo_fields(msg)
+    if op != "parse":
+        return {**echo, "ok": False, "error": "unknown_op", "s": 0.0}
+    mode = str(msg.get("mode", ""))
+    text = str(msg.get("text", ""))
+    title = str(msg.get("title", "Page"))
+    tab_size = int(msg.get("tab_size", 2))
+    started = time.perf_counter()
+    if mode not in _VALID_MODES:
+        return {
+            **echo,
+            "ok": False,
+            "error": "invalid_mode",
+            "s": round(time.perf_counter() - started, 6),
+        }
+    try:
+        if mode == "stack":
+            from logseq_matryca_parser.graph import StackMachineParser
+
+            page = StackMachineParser(tab_size=tab_size).parse(
+                text,
+                page_title=title,
+            )
+        else:
+            from logseq_matryca_parser import LogosParser
+
+            page = LogosParser().parse(text)
+        return {
+            **echo,
+            "ok": True,
+            "blob": pickle.dumps(page, protocol=pickle.HIGHEST_PROTOCOL),
+            "s": round(time.perf_counter() - started, 6),
+        }
+    except Exception as exc:  # noqa: BLE001 - bounded type name only
+        return {
+            **echo,
+            "ok": False,
+            "error": type(exc).__name__,
+            "s": round(time.perf_counter() - started, 6),
+        }
+
+
 def _worker_loop(
     in_q: mp.Queue[dict[str, Any] | None],
     out_q: mp.Queue[dict[str, Any]],
@@ -100,58 +155,9 @@ def _worker_loop(
         msg = in_q.get()
         if msg is None:
             break
-        op = str(msg.get("op", ""))
-        if op == "shutdown":
+        if str(msg.get("op", "")) == "shutdown":
             break
-        echo = _echo_fields(msg)
-        if op != "parse":
-            out_q.put({**echo, "ok": False, "error": "unknown_op", "s": 0.0})
-            continue
-        mode = str(msg.get("mode", ""))
-        text = str(msg.get("text", ""))
-        title = str(msg.get("title", "Page"))
-        tab_size = int(msg.get("tab_size", 2))
-        started = time.perf_counter()
-        if mode not in _VALID_MODES:
-            out_q.put(
-                {
-                    **echo,
-                    "ok": False,
-                    "error": "invalid_mode",
-                    "s": round(time.perf_counter() - started, 6),
-                }
-            )
-            continue
-        try:
-            if mode == "stack":
-                from logseq_matryca_parser.graph import StackMachineParser
-
-                page = StackMachineParser(tab_size=tab_size).parse(
-                    text,
-                    page_title=title,
-                )
-            else:
-                from logseq_matryca_parser import LogosParser
-
-                page = LogosParser().parse(text)
-            blob = pickle.dumps(page, protocol=pickle.HIGHEST_PROTOCOL)
-            out_q.put(
-                {
-                    **echo,
-                    "ok": True,
-                    "blob": blob,
-                    "s": round(time.perf_counter() - started, 6),
-                }
-            )
-        except Exception as exc:  # noqa: BLE001 - bounded type name only
-            out_q.put(
-                {
-                    **echo,
-                    "ok": False,
-                    "error": type(exc).__name__,
-                    "s": round(time.perf_counter() - started, 6),
-                }
-            )
+        out_q.put(_parse_request_message(msg))
 
 
 class BoundedPageParseWorker:
@@ -283,6 +289,177 @@ class BoundedPageParseWorker:
             page=None,
         )
 
+    def _daemon_subprocess_result_unlocked(
+        self,
+        *,
+        request: dict[str, Any],
+        request_id: int,
+        digest: str,
+        byte_count: int,
+        line_count: int,
+        mode: ParseMode,
+        deadline: float,
+    ) -> BoundedParseResult:
+        """Run one parse in a terminable subprocess for a daemon parent.
+
+        ``multiprocessing`` blocks ``spawn`` from a daemon pool worker.  The
+        fallback intentionally does not parse in-process: it starts a fresh
+        interpreter without a shell and exchanges one binary framed response.
+        The frame header is validated before the AST blob is unpickled.
+        """
+        started = time.perf_counter()
+        proc: subprocess.Popen[bytes] | None = None
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-m", _SUBPROCESS_MODULE],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+            request_bytes = json.dumps(
+                request,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+            output, _ = proc.communicate(input=request_bytes, timeout=deadline)
+        except subprocess.TimeoutExpired:
+            wall = round(time.perf_counter() - started, 6)
+            if proc is None:  # Defensive guard for static analysis and startup failures.
+                raise
+            proc.terminate()
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=_TERMINATE_GRACE_S)
+            if proc.poll() is None:
+                proc.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    proc.wait(timeout=_TERMINATE_GRACE_S)
+            logger.bind(
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                timeout_s=deadline,
+                request_id=request_id,
+            ).warning("bounded page parse timed out; terminating subprocess child")
+            return BoundedParseResult(
+                ok=False,
+                timed_out=True,
+                elapsed_s=wall,
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                error="timeout",
+                page=None,
+            )
+        except OSError:
+            return BoundedParseResult(
+                ok=False,
+                timed_out=False,
+                elapsed_s=round(time.perf_counter() - started, 6),
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                error="subprocess_error",
+                page=None,
+            )
+
+        wall = round(time.perf_counter() - started, 6)
+        if proc.returncode != 0 or len(output) < _SUBPROCESS_HEADER_BYTES:
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        header_size = struct.unpack("!I", output[:_SUBPROCESS_HEADER_BYTES])[0]
+        header_end = _SUBPROCESS_HEADER_BYTES + header_size
+        if header_end > len(output):
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        try:
+            header = json.loads(output[_SUBPROCESS_HEADER_BYTES:header_end].decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        if not isinstance(header, dict):
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        if header.get("request_id") != request_id or header.get("content_hash") != digest:
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        if not header.get("ok"):
+            error = str(header.get("error") or "parse_error")
+            if "/" in error or "\\" in error:
+                error = "parse_error"
+            return BoundedParseResult(
+                ok=False,
+                timed_out=False,
+                elapsed_s=float(header.get("s", wall)),
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                error=error,
+                page=None,
+            )
+        blob = output[header_end:]
+        if header.get("blob_length") != len(blob):
+            return self._protocol_mismatch_unlocked(
+                digest=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                elapsed_s=wall,
+            )
+        try:
+            page = pickle.loads(blob)
+        except Exception:  # noqa: BLE001 - AST payload is untrusted until correlation
+            return BoundedParseResult(
+                ok=False,
+                timed_out=False,
+                elapsed_s=float(header.get("s", wall)),
+                content_hash=digest,
+                byte_count=byte_count,
+                line_count=line_count,
+                mode=mode,
+                error="unpickle_error",
+                page=None,
+            )
+        return BoundedParseResult(
+            ok=True,
+            timed_out=False,
+            elapsed_s=float(header.get("s", wall)),
+            content_hash=digest,
+            byte_count=byte_count,
+            line_count=line_count,
+            mode=mode,
+            error=None,
+            page=page,
+        )
+
     def parse_text(
         self,
         text: str,
@@ -318,6 +495,28 @@ class BoundedPageParseWorker:
         deadline = min(_MAX_TIMEOUT_S, max(_MIN_TIMEOUT_S, deadline))
 
         with self._lock:
+            self._next_request_id += 1
+            request_id = self._next_request_id
+            request = {
+                "op": "parse",
+                "request_id": request_id,
+                "content_hash": digest,
+                "mode": parse_mode,
+                "text": text,
+                "title": page_title,
+                "tab_size": tab_size,
+            }
+            if mp.current_process().daemon:
+                return self._daemon_subprocess_result_unlocked(
+                    request=request,
+                    request_id=request_id,
+                    digest=digest,
+                    byte_count=byte_count,
+                    line_count=line_count,
+                    mode=parse_mode,
+                    deadline=deadline,
+                )
+
             self._ensure_worker_unlocked()
             assert self._in_q is not None
             assert self._out_q is not None
@@ -337,17 +536,6 @@ class BoundedPageParseWorker:
                     elapsed_s=0.0,
                 )
 
-            self._next_request_id += 1
-            request_id = self._next_request_id
-            request = {
-                "op": "parse",
-                "request_id": request_id,
-                "content_hash": digest,
-                "mode": parse_mode,
-                "text": text,
-                "title": page_title,
-                "tab_size": tab_size,
-            }
             wall0 = time.perf_counter()
             self._in_q.put(request)
             try:

--- a/src/graph/bounded_page_parse_child.py
+++ b/src/graph/bounded_page_parse_child.py
@@ -1,0 +1,51 @@
+"""One-shot parser child for daemon multiprocessing parents.
+
+``multiprocessing`` forbids daemon processes from creating child processes.
+This module runs through :class:`subprocess.Popen`, so parsing remains
+process-isolated and terminable when called by a daemon pool worker.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+from typing import Any
+
+from .bounded_page_parse import _parse_request_message
+
+_HEADER_BYTES = 4
+
+
+def _write_response(response: dict[str, Any]) -> None:
+    """Write header then AST blob; parent checks header before AST unpickle."""
+    blob = response.pop("blob", b"")
+    if not isinstance(blob, bytes):
+        blob = b""
+    header = {**response, "blob_length": len(blob)}
+    encoded_header = json.dumps(
+        header,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    sys.stdout.buffer.write(struct.pack("!I", len(encoded_header)))
+    sys.stdout.buffer.write(encoded_header)
+    sys.stdout.buffer.write(blob)
+    sys.stdout.buffer.flush()
+
+
+def main() -> int:
+    """Read one local request and write one binary response without diagnostics."""
+    try:
+        raw = sys.stdin.buffer.read()
+        request = json.loads(raw.decode("utf-8"))
+        if not isinstance(request, dict):
+            return 2
+        _write_response(_parse_request_message(request))
+    except Exception:  # noqa: BLE001 - never disclose local request content
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -10,7 +10,7 @@ import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from loguru import logger
 
@@ -44,6 +44,10 @@ _catalog_mtime_ns: dict[str, int] = {}
 
 class CatalogLoadError(OSError):
     """Raised when ``master_catalog.json`` cannot be read and no safe cache exists."""
+
+
+class CatalogSaveError(OSError):
+    """Raised when merge-save cannot safely read the existing master catalog."""
 
 
 def normalize_stored_mtime_ns(stored_mtime: int) -> int:
@@ -159,7 +163,12 @@ class MasterCatalog:
             if replace:
                 merged_pages = pending
             else:
-                disk_pages = _load_catalog_pages_unlocked(path, self.graph_root)
+                try:
+                    disk_pages = _load_catalog_pages_unlocked(path, self.graph_root)
+                except CatalogSaveError:
+                    with self._lock:
+                        self.persist_allowed = False
+                    raise
                 merged_pages = _merge_catalog_page_deltas(disk_pages, pending)
                 for title in removals:
                     merged_pages.pop(title, None)
@@ -282,22 +291,25 @@ def _load_catalog_pages_unlocked(path: Path, root: Path) -> dict[str, CatalogEnt
         return {}
     try:
         payload = read_bounded_json(path)
-    except BoundedJsonError as exc:
+    except BoundedJsonError:
         logger.warning(
-            "[METADATA CORRUPTION DETECTED] Unreadable master catalog at {} during merge-save: {}",
+            "[METADATA CORRUPTION DETECTED] Unreadable master catalog at {} during merge-save.",
             path,
-            exc,
         )
-        _quarantine_or_warn(path)
-        return {}
+        _abort_merge_save(path)
     if not isinstance(payload, dict):
         logger.warning(
             "[METADATA CORRUPTION DETECTED] Non-dict master catalog payload at {} (merge-save)",
             path,
         )
-        _quarantine_or_warn(path)
-        return {}
+        _abort_merge_save(path)
     return dict(MasterCatalog.from_json(root, payload).pages)
+
+
+def _abort_merge_save(path: Path) -> NoReturn:
+    """Quarantine malformed state best-effort, then stop the unsafe merge-save."""
+    _quarantine_or_warn(path)
+    raise CatalogSaveError("Cannot safely merge the existing master catalog during save.")
 
 
 def _quarantine_or_warn(path: Path) -> None:
@@ -635,6 +647,7 @@ def write_master_index_page(graph_root: Path, catalog: MasterCatalog) -> Path:
 __all__ = [
     "CATALOG_FILENAME",
     "CatalogLoadError",
+    "CatalogSaveError",
     "CatalogEntry",
     "MASTER_INDEX_PAGE_TITLE",
     "MATRYCA_GENERATED_INDEX_TITLES",

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -12,7 +12,7 @@ from ..graph.alias_index import iter_alias_source_paths
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
-from .errors import ShadowSyncError
+from .errors import ShadowPageParseError, ShadowSyncError
 from .meta import (
     META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_AT,
@@ -52,6 +52,8 @@ def shadow_needs_bootstrap(graph_root: Path | str) -> bool:
 
         schema_raw = get_meta(conn, "schema_version")
         if schema_raw != str(SHADOW_SCHEMA_VERSION):
+            return True
+        if (get_meta(conn, META_LAST_SYNC_ERROR) or "").strip():
             return True
         completed = (get_meta(conn, "last_full_sync_completed") or "").strip().lower()
         return completed != "true"
@@ -120,6 +122,8 @@ def _replay_deferred_syncs(graph_root: Path) -> None:
     for rel in pop_deferred_sync_paths(graph_root):
         try:
             sync_page_to_shadow(graph_root, graph_root / rel)
+        except ShadowPageParseError as exc:
+            logger.warning("Deferred shadow sync rejected: {}", exc)
         except Exception:  # noqa: BLE001
             logger.exception("Deferred shadow sync failed for {}", rel)
 
@@ -139,6 +143,8 @@ def ensure_shadow_runtime_at_startup(graph_root: Path | str) -> None:
         if shadow_needs_bootstrap(root):
             rebuild_shadow_from_graph(root)
         _BOOTSTRAP_CHECKED.add(key)
+    except ShadowPageParseError as exc:
+        logger.warning("Shadow bootstrap rejected: {}", exc)
     except Exception:  # noqa: BLE001 — must not block MCP/CLI/daemon startup
         logger.exception("Shadow bootstrap failed for {}", root)
 
@@ -170,6 +176,8 @@ def handle_shadow_watchdog_change(
             delete_shadow_page_by_file_path(root, rel)
             return
         sync_page_to_shadow(root, safe)
+    except ShadowPageParseError as exc:
+        logger.warning("Shadow watchdog sync rejected: {}", exc)
     except Exception:  # noqa: BLE001 — fail-safe like AST bridge
         logger.exception("Shadow watchdog sync failed for {} ({})", path, kind)
 

--- a/src/shadow/errors.py
+++ b/src/shadow/errors.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import re
+
 from ..utils.console_sanitize import sanitize_for_console
 
 _SHADOW_ERROR_MAX_LEN = 200
 _MAX_PATHS_IN_MESSAGE = 5
+_PARSE_ERROR_CATEGORY = re.compile(r"[^A-Za-z0-9_-]+")
+_PUBLIC_PARSE_CATEGORIES = frozenset(
+    {"timeout", "protocol_mismatch", "unpickle_error", "invalid_mode", "parse_error"}
+)
 
 
 class ShadowSyncError(RuntimeError):
     """Raised when shadow ingestion cannot proceed without ambiguous block identity."""
+
+
+class ShadowPageParseError(ShadowSyncError):
+    """Raised when the bounded worker cannot parse one source page safely."""
 
 
 def _display_uuid(block_uuid: str) -> str:
@@ -45,7 +55,42 @@ def format_duplicate_block_uuid_error(
     return body[: max_len - 1] + "…"
 
 
+def format_bounded_page_parse_error(
+    *,
+    category: str | None,
+    content_hash: str,
+    byte_count: int,
+    line_count: int,
+    mode: str,
+    max_len: int = _SHADOW_ERROR_MAX_LEN,
+) -> str:
+    """Build a content-free bounded page-parse diagnostic for persisted meta.
+
+    The source pathname, page title, body, and raw worker exception are
+    deliberately excluded.  This string can appear in health/API diagnostics.
+    """
+    raw_category = sanitize_for_console(category or "parse_error")
+    safe_category = _PARSE_ERROR_CATEGORY.sub("_", raw_category).strip("_")
+    if safe_category not in _PUBLIC_PARSE_CATEGORIES:
+        safe_category = "parse_error"
+    safe_hash = sanitize_for_console(content_hash)[:64]
+    safe_mode = _PARSE_ERROR_CATEGORY.sub("_", sanitize_for_console(mode)).strip("_")
+    if not safe_mode:
+        safe_mode = "unknown"
+    body = (
+        "bounded page parse failed: "
+        f"category={safe_category} content_hash={safe_hash} "
+        f"byte_count={max(0, byte_count)} line_count={max(0, line_count)} "
+        f"mode={safe_mode[:16]}"
+    )
+    if len(body) <= max_len:
+        return body
+    return body[: max_len - 1] + "…"
+
+
 __all__ = [
+    "ShadowPageParseError",
     "ShadowSyncError",
+    "format_bounded_page_parse_error",
     "format_duplicate_block_uuid_error",
 ]

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -13,17 +13,27 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from logseq_matryca_parser.graph import StackMachineParser
 from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
 from loguru import logger
 
+from ..graph.bounded_ast_graph import parse_graph_page_bounded
 from ..graph.page_path import page_title_from_path
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
 from ..graph.post_write import PageWrittenEvent, register_page_written_handler
 from .config import shadow_db_enabled
 from .connection import open_shadow_db
-from .errors import ShadowSyncError, format_duplicate_block_uuid_error
-from .meta import META_LAST_INCREMENTAL_SYNC_AT, set_meta
+from .errors import (
+    ShadowPageParseError,
+    ShadowSyncError,
+    format_bounded_page_parse_error,
+    format_duplicate_block_uuid_error,
+)
+from .meta import (
+    META_LAST_INCREMENTAL_SYNC_AT,
+    META_LAST_SYNC_ERROR,
+    ensure_meta_defaults,
+    set_meta,
+)
 from .runtime_state import defer_sync_path, is_shadow_bootstrapping
 from .writer_lock import shadow_writer_lock
 
@@ -162,8 +172,19 @@ def sync_page_into_connection(
         return
 
     stat = path.stat()
-    text = path.read_text(encoding="utf-8")
-    page: LogseqPage = StackMachineParser().parse(text, page_title=title)
+    parse_result = parse_graph_page_bounded(path, root)
+    if not parse_result.ok or not isinstance(parse_result.page, LogseqPage):
+        failure = parse_result.failure
+        raise ShadowPageParseError(
+            format_bounded_page_parse_error(
+                category=failure.error if failure else "parse_error",
+                content_hash=failure.content_hash if failure else "",
+                byte_count=failure.byte_count if failure else 0,
+                line_count=failure.line_count if failure else 0,
+                mode="stack",
+            )
+        )
+    page = parse_result.page
     synced_at = _utc_now_iso()
     is_journal = 1 if _is_journal_relpath(rel) else 0
     props_json = _props_json(dict(page.properties or {}))
@@ -240,15 +261,37 @@ def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
 
     with shadow_writer_lock(root):
         conn = open_shadow_db(root)
+        parse_error: ShadowPageParseError | None = None
         try:
             sync_page_into_connection(conn, root, path)
             set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
             conn.commit()
+        except ShadowPageParseError as exc:
+            conn.rollback()
+            parse_error = exc
         except Exception:
             conn.rollback()
             raise
         finally:
             conn.close()
+
+        if parse_error is not None:
+            _record_incremental_parse_error(root, str(parse_error))
+            raise parse_error
+
+
+def _record_incremental_parse_error(graph_root: Path, message: str) -> None:
+    """Persist a bounded parse failure after its page transaction has rolled back."""
+    conn = open_shadow_db(graph_root)
+    try:
+        ensure_meta_defaults(conn)
+        set_meta(conn, META_LAST_SYNC_ERROR, message)
+        conn.commit()
+    except Exception:  # noqa: BLE001 - sync failure must still propagate to caller
+        conn.rollback()
+        logger.exception("Failed to persist bounded shadow parse error")
+    finally:
+        conn.close()
 
 
 def _on_shadow_page_written(event: PageWrittenEvent) -> None:
@@ -256,6 +299,8 @@ def _on_shadow_page_written(event: PageWrittenEvent) -> None:
         return
     try:
         sync_page_to_shadow(event.graph_root, event.path)
+    except ShadowPageParseError as exc:
+        logger.warning("Shadow sync rejected after write: {}", exc)
     except Exception:  # noqa: BLE001 — fail-safe like AST bridge
         logger.exception("Shadow sync failed after write to {}", event.path)
 

--- a/tests/test_ast_cache_bounded_parse.py
+++ b/tests/test_ast_cache_bounded_parse.py
@@ -16,6 +16,8 @@ from src.graph.bounded_ast_graph import (
 )
 from src.graph.bounded_page_parse import get_bounded_page_parse_worker
 
+from tests.a_cli_01_generator import generate_pathological_page
+
 
 @pytest.fixture(autouse=True)
 def _clean_cache_and_worker() -> Iterator[None]:
@@ -78,6 +80,26 @@ def test_bootstrap_failure_does_not_publish_partial_graph(
     assert "0123456789abcdef" in rendered
     assert "private pathological body" not in rendered
     assert "Zulu.md" not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_real_pathological_page_is_bounded_without_partial_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
+    _write_page(tmp_path, "Alpha.md", "- ordinary\n")
+    _write_page(tmp_path, "Pathological.md", generate_pathological_page())
+    cache = GraphAstCache(tmp_path)
+
+    with pytest.raises(GraphAstParseError) as caught:
+        cache.bootstrap()
+
+    assert caught.value.failure.timed_out is True
+    assert caught.value.failure.error == "timeout"
+    assert cache._graph is None
+    rendered = str(caught.value)
+    assert "Pathological.md" not in rendered
     assert str(tmp_path) not in rendered
 
 

--- a/tests/test_ast_cache_bounded_parse.py
+++ b/tests/test_ast_cache_bounded_parse.py
@@ -1,0 +1,205 @@
+"""PR2C: bounded parsing is committed atomically by ``GraphAstCache``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from logseq_matryca_parser.graph import LogseqGraph, StackMachineParser
+from loguru import logger
+from src.graph.ast_cache import GraphAstCache, GraphAstParseError, clear_graph_ast_cache
+from src.graph.bounded_ast_graph import (
+    BoundedGraphPageResult,
+    BoundedGraphParseFailure,
+)
+from src.graph.bounded_page_parse import get_bounded_page_parse_worker
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache_and_worker() -> Iterator[None]:
+    clear_graph_ast_cache()
+    yield
+    clear_graph_ast_cache()
+
+
+def _write_page(root: Path, name: str, body: str) -> Path:
+    pages = root / "pages"
+    pages.mkdir(exist_ok=True)
+    path = pages / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _failure(*, content_hash: str = "0123456789abcdef") -> BoundedGraphPageResult:
+    return BoundedGraphPageResult(
+        failure=BoundedGraphParseFailure(
+            content_hash=content_hash,
+            byte_count=321,
+            line_count=17,
+            timed_out=True,
+            elapsed_s=2.0,
+            error="timeout",
+        )
+    )
+
+
+def test_bootstrap_failure_does_not_publish_partial_graph(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    good = _write_page(
+        tmp_path,
+        "Alpha.md",
+        "- good\n  id:: 11111111-1111-1111-1111-111111111111\n",
+    )
+    bad = _write_page(tmp_path, "Zulu.md", "- private pathological body\n")
+
+    def _parse(path: Path, graph_root: Path) -> BoundedGraphPageResult:
+        del graph_root
+        if path == bad:
+            return _failure()
+        return BoundedGraphPageResult(page=StackMachineParser().parse_page_file(good))
+
+    monkeypatch.setattr("src.graph.ast_cache.parse_graph_page_bounded", _parse)
+    monkeypatch.setattr(
+        LogseqGraph,
+        "load_directory",
+        lambda *_args, **_kwargs: pytest.fail("unbounded loader called"),
+    )
+    cache = GraphAstCache(tmp_path)
+
+    with pytest.raises(GraphAstParseError) as caught:
+        cache.bootstrap()
+
+    assert cache._graph is None
+    rendered = str(caught.value)
+    assert "0123456789abcdef" in rendered
+    assert "private pathological body" not in rendered
+    assert "Zulu.md" not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_incremental_timeout_preserves_exact_last_complete_graph(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    page = _write_page(
+        tmp_path,
+        "Alpha.md",
+        "- old\n  id:: 11111111-1111-1111-1111-111111111111\n",
+    )
+    cache = GraphAstCache(tmp_path)
+    original = cache.bootstrap()
+    page.write_text("- private pathological replacement\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "src.graph.ast_cache.parse_graph_page_bounded",
+        lambda *_args, **_kwargs: _failure(),
+    )
+    monkeypatch.setattr(
+        LogseqGraph,
+        "load_directory",
+        lambda *_args, **_kwargs: pytest.fail("unbounded fallback called"),
+    )
+    cache.apply_file_event(page, "modified")
+
+    assert cache._graph is original
+    assert cache.get_block_by_uuid("11111111-1111-1111-1111-111111111111") is not None
+
+
+def test_incremental_failure_log_is_hash_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    secret = "vault-secret-marker"
+    page = _write_page(tmp_path, "Secret.md", f"- {secret}\n")
+    cache = GraphAstCache(tmp_path)
+    cache.bootstrap()
+    monkeypatch.setattr(
+        "src.graph.ast_cache.parse_graph_page_bounded",
+        lambda *_args, **_kwargs: _failure(content_hash="fedcba9876543210"),
+    )
+    output = StringIO()
+    sink = logger.add(output, format="{message} {extra}")
+    try:
+        cache.apply_file_event(page, "modified")
+    finally:
+        logger.remove(sink)
+
+    rendered = output.getvalue()
+    assert "fedcba9876543210" in rendered
+    assert "timeout" in rendered
+    assert secret not in rendered
+    assert "Secret.md" not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_bootstrap_recovers_after_bounded_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    page = _write_page(tmp_path, "Alpha.md", "- first attempt\n")
+    cache = GraphAstCache(tmp_path)
+    calls = 0
+    from src.graph.bounded_ast_graph import parse_graph_page_bounded as real_parse
+
+    def _parse(path: Path, graph_root: Path) -> BoundedGraphPageResult:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _failure()
+        return real_parse(path, graph_root, timeout_s=15.0)
+
+    monkeypatch.setattr("src.graph.ast_cache.parse_graph_page_bounded", _parse)
+    with pytest.raises(GraphAstParseError):
+        cache.bootstrap()
+
+    page.write_text(
+        "- recovered\n  id:: 22222222-2222-2222-2222-222222222222\n",
+        encoding="utf-8",
+    )
+    graph = cache.bootstrap()
+    assert graph.get_node_by_embed_ref("22222222-2222-2222-2222-222222222222") is not None
+
+
+def test_clear_cache_releases_worker_and_next_bootstrap_recovers(tmp_path: Path) -> None:
+    _write_page(tmp_path, "Alpha.md", "- normal\n")
+    GraphAstCache(tmp_path).bootstrap()
+    worker = get_bounded_page_parse_worker()
+    assert worker.pid is not None
+
+    clear_graph_ast_cache()
+    clear_graph_ast_cache()
+    assert worker.pid is None
+
+    graph = GraphAstCache(tmp_path).bootstrap()
+    assert graph.get_page("Alpha") is not None
+
+
+def test_incremental_success_and_delete_publish_complete_new_graph(tmp_path: Path) -> None:
+    page = _write_page(
+        tmp_path,
+        "Alpha.md",
+        "- old\n  id:: 11111111-1111-1111-1111-111111111111\n",
+    )
+    cache = GraphAstCache(tmp_path)
+    original = cache.bootstrap()
+    page.write_text(
+        "- new #topic\n  id:: 22222222-2222-2222-2222-222222222222\n",
+        encoding="utf-8",
+    )
+
+    cache.apply_file_event(page, "modified")
+    replaced = cache.get_graph()
+    assert replaced is not original
+    assert replaced.get_node_by_embed_ref("11111111-1111-1111-1111-111111111111") is None
+    assert replaced.get_node_by_embed_ref("22222222-2222-2222-2222-222222222222") is not None
+    assert len(replaced.get_nodes_by_tag("topic")) == 1
+
+    page.unlink()
+    cache.apply_file_event(page, "deleted")
+    removed = cache.get_graph()
+    assert removed is not replaced
+    assert removed.get_node_by_embed_ref("22222222-2222-2222-2222-222222222222") is None

--- a/tests/test_bounded_ast_graph.py
+++ b/tests/test_bounded_ast_graph.py
@@ -1,0 +1,185 @@
+"""PR2C adapter contract: bounded pages form an atomic complete graph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from logseq_matryca_parser.graph import LogseqGraph, StackMachineParser
+from src.graph.bounded_ast_graph import (
+    BoundedGraphPageResult,
+    build_graph_from_bounded_pages,
+    parse_graph_page_bounded,
+    replace_graph_page_by_source_path,
+)
+
+
+def _write_page(root: Path, name: str, content: str) -> Path:
+    pages = root / "pages"
+    pages.mkdir(exist_ok=True)
+    path = pages / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _node_source_paths(page: Any) -> list[str]:
+    paths: list[str] = []
+
+    def _visit(nodes: list[Any]) -> None:
+        for node in nodes:
+            paths.append(str(node.source_path))
+            _visit(node.children)
+
+    _visit(page.root_nodes)
+    return paths
+
+
+def test_bounded_page_matches_stack_file_metadata_and_recursive_node_paths(tmp_path: Path) -> None:
+    path = _write_page(
+        tmp_path,
+        "Project.md",
+        "title:: Project/Canonical\n"
+        "- parent\n"
+        "  id:: 11111111-1111-1111-1111-111111111111\n"
+        "  - child\n"
+        "    id:: 22222222-2222-2222-2222-222222222222\n",
+    )
+    bounded = parse_graph_page_bounded(path, tmp_path, timeout_s=15.0)
+    expected = StackMachineParser().parse_page_file(path)
+
+    assert bounded.ok is True
+    assert bounded.failure is None
+    assert bounded.page is not None
+    assert bounded.page.title == expected.title
+    assert bounded.page.source_path == expected.source_path
+    assert bounded.page.graph_root == expected.graph_root
+    assert bounded.page.created_at == expected.created_at
+    assert bounded.page.updated_at == expected.updated_at
+    assert bounded.page.tab_size == expected.tab_size
+    assert _node_source_paths(bounded.page) == _node_source_paths(expected)
+
+
+def test_bounded_page_preserves_detected_non_default_tab_semantics(tmp_path: Path) -> None:
+    path = _write_page(
+        tmp_path,
+        "Tabs.md",
+        "- root\n    - four-space child\n        - grandchild\n",
+    )
+    bounded = parse_graph_page_bounded(path, tmp_path, timeout_s=15.0)
+    expected = StackMachineParser().parse_page_file(path)
+
+    assert bounded.page is not None
+    assert bounded.page.tab_size == 4
+    assert bounded.page.tab_size == expected.tab_size
+    assert [node.indent_level for node in bounded.page.root_nodes] == [
+        node.indent_level for node in expected.root_nodes
+    ]
+    assert bounded.page.root_nodes[0].children[0].indent_level == (
+        expected.root_nodes[0].children[0].indent_level
+    )
+
+
+def test_parse_failure_is_content_and_path_free(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = _write_page(tmp_path, "Secret.md", "- secret-body-should-not-leak\n")
+
+    def _failed(*args: object, **kwargs: object) -> Any:
+        from src.graph.bounded_page_parse import BoundedParseResult
+
+        return BoundedParseResult(
+            ok=False,
+            timed_out=True,
+            elapsed_s=2.0,
+            content_hash="0123456789abcdef",
+            byte_count=42,
+            line_count=1,
+            mode="stack",
+            error="timeout",
+        )
+
+    monkeypatch.setattr("src.graph.bounded_ast_graph.parse_page_text_bounded", _failed)
+    result = parse_graph_page_bounded(path, tmp_path, timeout_s=2.0)
+
+    assert isinstance(result, BoundedGraphPageResult)
+    assert result.ok is False
+    assert result.page is None
+    assert result.failure is not None
+    assert result.failure.error == "timeout"
+    rendered = repr(result.failure)
+    assert "Secret.md" not in rendered
+    assert "secret-body-should-not-leak" not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_build_matches_external_complete_indexes(tmp_path: Path) -> None:
+    alpha = _write_page(
+        tmp_path,
+        "Alpha.md",
+        "alias:: Alpha Alias\n"
+        "- alpha #topic [[Beta]]\n"
+        "  id:: 11111111-1111-1111-1111-111111111111\n",
+    )
+    beta = _write_page(
+        tmp_path,
+        "Beta.md",
+        "- beta ((11111111-1111-1111-1111-111111111111))\n"
+        "  id:: 22222222-2222-2222-2222-222222222222\n",
+    )
+    parsed = [parse_graph_page_bounded(path, tmp_path, timeout_s=15.0) for path in (alpha, beta)]
+    assert all(result.ok and result.page is not None for result in parsed)
+    pages = [result.page for result in parsed if result.page is not None]
+    bounded = build_graph_from_bounded_pages(tmp_path, pages)
+    expected = LogseqGraph.load_directory(tmp_path)
+
+    assert sorted(bounded.pages) == sorted(expected.pages)
+    assert bounded.get_page("ALPHA") is not None
+    assert bounded.get_page("ALPHA").title == expected.get_page("ALPHA").title
+    assert bounded.get_node_by_embed_ref("11111111-1111-1111-1111-111111111111") is not None
+    assert [node.source_uuid for node in bounded.get_backlinks("beta")] == [
+        node.source_uuid for node in expected.get_backlinks("beta")
+    ]
+    assert [node.source_uuid for node in bounded.get_backlinks("topic")] == [
+        node.source_uuid for node in expected.get_backlinks("topic")
+    ]
+
+
+def test_replace_and_remove_return_new_complete_graph_without_mutating_old(tmp_path: Path) -> None:
+    first = _write_page(
+        tmp_path,
+        "First.md",
+        "- first\n  id:: 11111111-1111-1111-1111-111111111111\n",
+    )
+    second = _write_page(
+        tmp_path,
+        "Second.md",
+        "- second\n  id:: 22222222-2222-2222-2222-222222222222\n",
+    )
+    initial_pages = [
+        parse_graph_page_bounded(path, tmp_path, timeout_s=15.0).page for path in (first, second)
+    ]
+    assert all(page is not None for page in initial_pages)
+    original = build_graph_from_bounded_pages(
+        tmp_path,
+        [page for page in initial_pages if page is not None],
+    )
+
+    first.write_text(
+        "- refreshed\n  id:: 33333333-3333-3333-3333-333333333333\n",
+        encoding="utf-8",
+    )
+    refreshed = parse_graph_page_bounded(first, tmp_path, timeout_s=15.0)
+    assert refreshed.page is not None
+    replaced = replace_graph_page_by_source_path(original, first, refreshed.page)
+
+    assert original.get_node_by_embed_ref("11111111-1111-1111-1111-111111111111") is not None
+    assert original.get_node_by_embed_ref("33333333-3333-3333-3333-333333333333") is None
+    assert replaced.get_node_by_embed_ref("11111111-1111-1111-1111-111111111111") is None
+    assert replaced.get_node_by_embed_ref("33333333-3333-3333-3333-333333333333") is not None
+    assert replaced.get_node_by_embed_ref("22222222-2222-2222-2222-222222222222") is not None
+
+    removed = replace_graph_page_by_source_path(replaced, second, None)
+    assert removed.get_node_by_embed_ref("33333333-3333-3333-3333-333333333333") is not None
+    assert removed.get_node_by_embed_ref("22222222-2222-2222-2222-222222222222") is None

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -50,6 +50,21 @@ def _page_raw(page: Any) -> str:
     return raw if isinstance(raw, str) else ""
 
 
+def _daemon_pool_parse_probe(text: str) -> dict[str, object]:
+    """Pool workers are daemon processes and cannot create mp children."""
+    import multiprocessing as mp
+
+    result = parse_page_text_bounded(text, mode="stack", timeout_s=15.0)
+    return {
+        "daemon": bool(mp.current_process().daemon),
+        "ok": result.ok,
+        "timed_out": result.timed_out,
+        "content_hash": result.content_hash,
+        "error": result.error,
+        "page_present": result.page is not None,
+    }
+
+
 def test_page_parse_timeout_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "0.5")
     assert page_parse_timeout_s() == 2.0
@@ -69,6 +84,25 @@ def test_control_page_parses_ok_logos_and_stack() -> None:
         assert result.page is not None
         assert result.content_hash == content_hash16(text)
         assert result.error is None
+
+
+def test_daemon_pool_worker_uses_terminable_subprocess_fallback() -> None:
+    """A daemon Pool worker must retain hard process isolation without mp.spawn."""
+    import multiprocessing as mp
+
+    text = "- parser fallback from daemon pool\n"
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=1) as pool:
+        payload = pool.apply(_daemon_pool_parse_probe, (text,))
+
+    assert payload == {
+        "daemon": True,
+        "ok": True,
+        "timed_out": False,
+        "content_hash": content_hash16(text),
+        "error": None,
+        "page_present": True,
+    }
 
 
 def test_invalid_mode_rejected_without_silent_logos() -> None:

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -1,4 +1,4 @@
-"""PR2B — bounded page parse worker (no Shadow/AST integration)."""
+"""PR2B — bounded page parse worker contracts."""
 
 from __future__ import annotations
 

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -1157,6 +1157,7 @@ def test_completion_with_structured_output_uses_lenient_json_repair(
 ) -> None:
     from src.agent.llm_client import GrammarCapability, LlmBackendProfile
 
+    monkeypatch.delenv("LOGSEQ_GRAPH_PATH", raising=False)
     client = InstructorLLMClient(base_url="http://localhost:1234/v1")
     malformed = (
         '{"ontology_report": "940 pages mapped.", '

--- a/tests/test_master_catalog.py
+++ b/tests/test_master_catalog.py
@@ -23,6 +23,7 @@ from src.graph.master_catalog import (
     SEMANTIC_INDEX_HEADER,
     CatalogEntry,
     CatalogLoadError,
+    CatalogSaveError,
     MasterCatalog,
     build_master_index_markdown,
     clear_master_catalog_cache,
@@ -329,6 +330,106 @@ def test_save_merges_concurrent_page_deltas_without_clobber(graph_root: Path) ->
     merged = load_master_catalog(graph_root, force_reload=True)
     assert merged.pages["PageA"].summary == "Alpha v2"
     assert merged.pages["PageB"].summary == "Beta"
+
+
+@pytest.mark.parametrize("corrupt_payload", ["{not-json", "[]"])
+def test_merge_save_aborts_without_overwriting_unreadable_catalog(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    corrupt_payload: str,
+) -> None:
+    """A stale in-memory merge must never replace an unreadable on-disk catalog (#198)."""
+    catalog = MasterCatalog(graph_root=graph_root)
+    catalog.upsert(
+        "Pending",
+        CatalogEntry(summary="pending", domain="", tags=[], last_mtime=1, orphan=False),
+    )
+    path = MasterCatalog.catalog_path(graph_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(corrupt_payload, encoding="utf-8")
+
+    def _unexpected_atomic_write(*args: object, **kwargs: object) -> None:
+        raise AssertionError("merge-save must not write after a catalog read failure")
+
+    monkeypatch.setattr("src.graph.master_catalog.atomic_write_bytes", _unexpected_atomic_write)
+
+    with pytest.raises(CatalogSaveError) as exc_info:
+        catalog.save()
+
+    assert corrupt_payload not in str(exc_info.value)
+    assert catalog.persist_allowed is False
+    assert catalog.get("Pending") is not None
+    assert not path.exists()
+    assert list(path.parent.glob(f"{path.name}.corrupt.*"))
+
+
+def test_merge_save_aborts_when_catalog_quarantine_fails(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed quarantine is still never permission to overwrite unreadable state."""
+    catalog = MasterCatalog(graph_root=graph_root)
+    catalog.upsert(
+        "Pending",
+        CatalogEntry(summary="pending", domain="", tags=[], last_mtime=1, orphan=False),
+    )
+    path = MasterCatalog.catalog_path(graph_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+
+    def _quarantine_failure(_path: Path) -> Path:
+        raise OSError("simulated quarantine failure")
+
+    def _unexpected_atomic_write(*args: object, **kwargs: object) -> None:
+        raise AssertionError("merge-save must not write after quarantine failure")
+
+    monkeypatch.setattr("src.graph.master_catalog._quarantine_corrupt_catalog", _quarantine_failure)
+    monkeypatch.setattr("src.graph.master_catalog.atomic_write_bytes", _unexpected_atomic_write)
+
+    with pytest.raises(CatalogSaveError):
+        catalog.save()
+
+    assert catalog.persist_allowed is False
+    assert path.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_force_reload_recovers_persistibility_after_merge_save_abort(graph_root: Path) -> None:
+    """After quarantine, a force reload may establish a fresh safe catalog."""
+    path = MasterCatalog.catalog_path(graph_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+    stale = MasterCatalog(graph_root=graph_root)
+
+    with pytest.raises(CatalogSaveError):
+        stale.save()
+
+    recovered = load_master_catalog(graph_root, force_reload=True)
+    assert recovered.persist_allowed is True
+    recovered.upsert(
+        "Recovered",
+        CatalogEntry(summary="recovered", domain="", tags=[], last_mtime=1, orphan=False),
+    )
+    recovered.save()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["pages"]["Recovered"]["summary"] == "recovered"
+
+
+def test_replace_save_remains_explicit_overwrite_for_unreadable_catalog(graph_root: Path) -> None:
+    """Replace mode is intentionally distinct from safe merge-save."""
+    path = MasterCatalog.catalog_path(graph_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[]", encoding="utf-8")
+    catalog = MasterCatalog(graph_root=graph_root)
+    catalog.upsert(
+        "Replacement",
+        CatalogEntry(summary="replacement", domain="", tags=[], last_mtime=1, orphan=False),
+    )
+
+    catalog.save(replace=True)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["pages"]["Replacement"]["summary"] == "replacement"
 
 
 def test_save_replace_mode_drops_pages_for_prune(graph_root: Path) -> None:

--- a/tests/test_shadow_bounded_parse.py
+++ b/tests/test_shadow_bounded_parse.py
@@ -1,0 +1,307 @@
+"""Bounded page parsing contracts for Shadow ingestion (#297 PR2C)."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from loguru import logger
+from src.graph.bounded_page_parse import BoundedParseResult, ParseMode, content_hash16
+from src.graph.post_write import PageWrittenEvent
+from src.shadow.bootstrap import (
+    ensure_shadow_runtime_at_startup,
+    handle_shadow_watchdog_change,
+    rebuild_shadow_from_graph,
+    reset_shadow_bootstrap_checked_for_tests,
+    shadow_needs_bootstrap,
+)
+from src.shadow.connection import open_shadow_db
+from src.shadow.errors import ShadowPageParseError
+from src.shadow.health import ShadowHealthState, resolve_shadow_health
+from src.shadow.meta import META_LAST_SYNC_ERROR, get_meta
+from src.shadow.runtime_state import reset_shadow_runtime_state_for_tests
+from src.shadow.sync import _on_shadow_page_written, sync_page_into_connection, sync_page_to_shadow
+
+from tests.a_cli_01_generator import generate_pathological_page
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    reset_shadow_runtime_state_for_tests()
+    reset_shadow_bootstrap_checked_for_tests()
+
+
+def _graph(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "pages").mkdir(parents=True)
+    return root
+
+
+def _write_page(root: Path, name: str, text: str) -> Path:
+    path = root / "pages" / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _failed_parse(text: str, *, category: str = "timeout") -> BoundedParseResult:
+    return BoundedParseResult(
+        ok=False,
+        timed_out=category == "timeout",
+        elapsed_s=2.0,
+        content_hash=content_hash16(text),
+        byte_count=len(text.encode("utf-8")),
+        line_count=text.count("\n") + (0 if text.endswith("\n") else 1),
+        mode="stack",
+        error=category,
+    )
+
+
+def test_shadow_sync_uses_bounded_stack_mode(tmp_path: Path) -> None:
+    root = _graph(tmp_path)
+    page = _write_page(root, "Alpha.md", "- alpha\n")
+    from src.graph.bounded_page_parse import parse_page_text_bounded as real_parse
+
+    seen_modes: list[str] = []
+
+    def _spy(
+        text: str,
+        *,
+        mode: ParseMode = "logos",
+        page_title: str = "Page",
+        tab_size: int = 2,
+        timeout_s: float | None = None,
+    ) -> BoundedParseResult:
+        seen_modes.append(mode)
+        return real_parse(
+            text,
+            mode=mode,
+            page_title=page_title,
+            tab_size=tab_size,
+            timeout_s=timeout_s,
+        )
+
+    conn = open_shadow_db(root)
+    try:
+        with patch("src.graph.bounded_ast_graph.parse_page_text_bounded", side_effect=_spy):
+            sync_page_into_connection(conn, root, page)
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert seen_modes == ["stack"]
+
+
+def test_full_rebuild_rolls_back_and_records_only_bounded_parse_diagnostic(
+    tmp_path: Path,
+) -> None:
+    root = _graph(tmp_path)
+    safe = _write_page(root, "Safe.md", "- safe\n")
+    rebuild_shadow_from_graph(root)
+    bad_text = "- SECRET-BODY-MUST-NOT-LEAK\n"
+    bad = _write_page(root, "PrivateTitle.md", bad_text)
+    from src.graph.bounded_page_parse import parse_page_text_bounded as real_parse
+
+    def _parse(
+        text: str,
+        *,
+        mode: ParseMode = "logos",
+        page_title: str = "Page",
+        tab_size: int = 2,
+        timeout_s: float | None = None,
+    ) -> BoundedParseResult:
+        if text == bad_text:
+            return _failed_parse(text, category="RuntimeError: SECRET-BODY-MUST-NOT-LEAK")
+        return real_parse(
+            text,
+            mode=mode,
+            page_title=page_title,
+            tab_size=tab_size,
+            timeout_s=timeout_s,
+        )
+
+    with (
+        patch("src.graph.bounded_ast_graph.parse_page_text_bounded", side_effect=_parse),
+        pytest.raises(ShadowPageParseError),
+    ):
+        rebuild_shadow_from_graph(root)
+
+    conn = open_shadow_db(root)
+    try:
+        titles = {str(row[0]) for row in conn.execute("SELECT title FROM pages")}
+        error = get_meta(conn, META_LAST_SYNC_ERROR) or ""
+    finally:
+        conn.close()
+
+    assert titles == {"Safe"}
+    assert "category=parse_error" in error
+    assert "content_hash=" in error
+    assert "byte_count=" in error
+    assert "line_count=" in error
+    assert "mode=stack" in error
+    assert len(error) <= 200
+    assert bad.name not in error
+    assert "PrivateTitle" not in error
+    assert "SECRET-BODY-MUST-NOT-LEAK" not in error
+    assert str(root) not in error
+    assert resolve_shadow_health(root) is ShadowHealthState.ERROR
+    assert safe.is_file()
+
+
+def test_incremental_parse_failure_preserves_rows_and_marks_global_error(
+    tmp_path: Path,
+) -> None:
+    root = _graph(tmp_path)
+    page = _write_page(root, "Alpha.md", "- old content\n")
+    rebuild_shadow_from_graph(root)
+    page.write_text("- NEW-PRIVATE-CONTENT\n", encoding="utf-8")
+    new_text = page.read_text(encoding="utf-8")
+
+    with (
+        patch(
+            "src.graph.bounded_ast_graph.parse_page_text_bounded",
+            return_value=_failed_parse(new_text),
+        ),
+        pytest.raises(ShadowPageParseError),
+    ):
+        sync_page_to_shadow(root, page)
+
+    conn = open_shadow_db(root)
+    try:
+        content = str(conn.execute("SELECT content FROM blocks").fetchone()[0])
+        error = get_meta(conn, META_LAST_SYNC_ERROR) or ""
+    finally:
+        conn.close()
+
+    assert content == "old content"
+    assert "NEW-PRIVATE-CONTENT" not in error
+    assert "category=timeout" in error
+    assert resolve_shadow_health(root) is ShadowHealthState.ERROR
+    assert shadow_needs_bootstrap(root) is True
+
+    other = _write_page(root, "Other.md", "- ordinary incremental change\n")
+    sync_page_to_shadow(root, other)
+    conn = open_shadow_db(root)
+    try:
+        assert get_meta(conn, META_LAST_SYNC_ERROR) == error
+    finally:
+        conn.close()
+
+
+def test_repaired_source_recovers_at_next_startup_rebuild(tmp_path: Path) -> None:
+    root = _graph(tmp_path)
+    page = _write_page(root, "Alpha.md", "- old content\n")
+    rebuild_shadow_from_graph(root)
+    page.write_text("- repaired content\n", encoding="utf-8")
+    repaired_text = page.read_text(encoding="utf-8")
+
+    with (
+        patch(
+            "src.graph.bounded_ast_graph.parse_page_text_bounded",
+            return_value=_failed_parse(repaired_text),
+        ),
+        pytest.raises(ShadowPageParseError),
+    ):
+        sync_page_to_shadow(root, page)
+
+    assert shadow_needs_bootstrap(root) is True
+    ensure_shadow_runtime_at_startup(root)
+
+    conn = open_shadow_db(root)
+    try:
+        error = get_meta(conn, META_LAST_SYNC_ERROR)
+        content = str(conn.execute("SELECT content FROM blocks").fetchone()[0])
+    finally:
+        conn.close()
+
+    assert error == ""
+    assert content == "repaired content"
+    assert resolve_shadow_health(root) is ShadowHealthState.READY
+
+
+def test_shadow_source_contains_no_direct_stack_machine_parser_call() -> None:
+    shadow_root = Path(__file__).resolve().parents[1] / "src" / "shadow"
+    assert "StackMachineParser" not in "\n".join(
+        path.read_text(encoding="utf-8") for path in shadow_root.glob("*.py")
+    )
+
+
+def test_real_pathological_page_rolls_back_full_rebuild_with_bounded_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
+    root = _graph(tmp_path)
+    _write_page(root, "Alpha.md", "- ordinary\n")
+    _write_page(root, "Pathological.md", generate_pathological_page())
+
+    with pytest.raises(ShadowPageParseError):
+        rebuild_shadow_from_graph(root)
+
+    conn = open_shadow_db(root)
+    try:
+        assert int(conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0]) == 0
+        error = get_meta(conn, META_LAST_SYNC_ERROR) or ""
+    finally:
+        conn.close()
+    assert "category=timeout" in error
+    assert "Pathological.md" not in error
+    assert str(root) not in error
+    assert resolve_shadow_health(root) is ShadowHealthState.ERROR
+
+
+def test_real_pathological_incremental_keeps_last_good_page(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
+    root = _graph(tmp_path)
+    page = _write_page(root, "Alpha.md", "- last good content\n")
+    rebuild_shadow_from_graph(root)
+    page.write_text(generate_pathological_page(), encoding="utf-8")
+
+    with pytest.raises(ShadowPageParseError):
+        sync_page_to_shadow(root, page)
+
+    conn = open_shadow_db(root)
+    try:
+        content = str(conn.execute("SELECT content FROM blocks").fetchone()[0])
+        error = get_meta(conn, META_LAST_SYNC_ERROR) or ""
+    finally:
+        conn.close()
+    assert content == "last good content"
+    assert "category=timeout" in error
+    assert "Alpha.md" not in error
+    assert str(root) not in error
+    assert resolve_shadow_health(root) is ShadowHealthState.ERROR
+
+
+def test_parse_failure_handlers_log_no_vault_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _graph(tmp_path)
+    page = _write_page(root, "PrivateTitle.md", "- secret\n")
+    safe_error = ShadowPageParseError(
+        "bounded page parse failed: category=timeout content_hash=0123456789abcdef"
+    )
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.sync_page_to_shadow", lambda *_args: (_ for _ in ()).throw(safe_error)
+    )
+    monkeypatch.setattr(
+        "src.shadow.sync.sync_page_to_shadow", lambda *_args: (_ for _ in ()).throw(safe_error)
+    )
+    output = StringIO()
+    sink = logger.add(output, format="{message} {extra}")
+    try:
+        handle_shadow_watchdog_change(root, page, "modified")
+        _on_shadow_page_written(PageWrittenEvent(root, page, None))
+    finally:
+        logger.remove(sink)
+
+    rendered = output.getvalue()
+    assert "0123456789abcdef" in rendered
+    assert "PrivateTitle.md" not in rendered
+    assert str(root) not in rendered

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1079,15 +1079,17 @@ def test_get_state_shadow_db_error_from_meta(
     page = graph_root / "pages" / "Alpha.md"
     page.write_text("- alpha\n  id:: 11111111-1111-4111-8111-111111111111\n", encoding="utf-8")
     rebuild_shadow_from_graph(graph_root)
-    conn = open_shadow_db(graph_root)
-    try:
-        set_meta(conn, META_LAST_SYNC_ERROR, "sync failed")
-        conn.commit()
-    finally:
-        conn.close()
     save_daemon_state(graph_root, DaemonState(status="idle"))
 
     with TestClient(app) as client:
+        # Startup intentionally rebuilds a generation carrying an earlier error.
+        # Set the error inside the lifespan to exercise the API's live error shape.
+        conn = open_shadow_db(graph_root)
+        try:
+            set_meta(conn, META_LAST_SYNC_ERROR, "sync failed")
+            conn.commit()
+        finally:
+            conn.close()
         response = client.get("/api/state", headers=auth_headers)
 
     shadow_db = response.json()["shadow_db"]

--- a/uv.lock
+++ b/uv.lock
@@ -661,14 +661,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ edge = [
 requires-dist = [
     { name = "edn-format", specifier = ">=0.7.5" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
-    { name = "gitpython", specifier = ">=3.1.50" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "ijson", specifier = ">=3.5.0" },


### PR DESCRIPTION
## Summary
- bound Graph AST cache bootstrap and incremental parsing in terminable workers
- extend bounded parsing to Shadow rebuild and sync while preserving the last good generation/page
- fail closed when a corrupted catalog cannot be safely merged
- update the GitPython dependency floor and lockfile to patched releases
- add hash-only diagnostics, daemon-process fallback, recovery, privacy, and pathological-page regression coverage

## Safety contracts
- Markdown remains the source of truth
- incomplete Shadow rebuilds roll back atomically
- incremental parse failures retain the previous indexed page
- Shadow health leaves `ready` and routes reads through Markdown/BM25 until recovery
- diagnostics contain hashes and aggregate counts, not vault content or absolute paths
- explicit catalog replacement behavior remains unchanged

## Code audit impact
- final diff risk: MEDIUM
- changed worker flows are limited to bounded parser lifecycle
- Shadow bootstrap/sync paths were reviewed as high-impact and are covered by rollback, recovery, concurrency, and fallback tests
- no new public API route or schema migration

## Test plan
- [x] `make ci` — 1377 passed, 2 skipped, 1 xfailed
- [x] coverage 82.79%
- [x] Ruff format/lint and mypy
- [x] pathological AST and Shadow timeout tests
- [x] daemon pool subprocess fallback
- [x] catalog corruption/recovery tests
- [x] staged code audit — expected scope only

Fixes #198
Refs #297
