### PR TITLE
feat(quality): add resumable beta evidence harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- **Beta-readiness evidence harness** — add a resumable, privacy-bounded maintainer CLI that validates beta/package versions, evaluates sanitized P0–P2 disposition input, and emits schema-versioned JSON/checkpoints plus a path-free Markdown verdict; uncollected wheel, soak, and final code-audit gates fail closed as `NOT READY`.
 - **Bounded AST and Shadow parsing (PR2B/PR2C, #297)** — `src/graph/bounded_page_parse.py` runs Logos/StackMachine parse in a terminable `spawn` worker with `MATRYCA_PAGE_PARSE_TIMEOUT_S` (clamped 2–120s). `GraphAstCache` atomically publishes complete bounded generations and preserves its last good graph on failure; Shadow rebuilds roll back, incremental sync keeps the prior page, persists hash-only diagnostics, and routes reads to Markdown/BM25 until a successful recovery rebuild. Overhead script requires `--graph PATH` (optional `--output`).
 
 ### Fixed

--- a/scripts/beta_readiness_evidence.py
+++ b/scripts/beta_readiness_evidence.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Collect deterministic, sanitized evidence for the v2 beta readiness gate.
+
+Input schemas (both JSON files must use ``schema_version: 1``):
+
+``--issues-json``::
+
+    {"schema_version": 1, "issues": [
+      {"number": 297, "severity": "P2", "state": "open", "in_scope": true}
+    ]}
+
+``--p2-dispositions``::
+
+    {"schema_version": 1, "dispositions": [
+      {"number": 297, "status": "accepted"}
+    ]}
+
+The script deliberately stores only issue number, severity, state, scope and
+the controlled disposition status. Do not place issue titles, bodies, URLs,
+vault paths, or vault content in either input file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import sys
+import tempfile
+import time
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, cast
+
+SCHEMA_VERSION = 1
+_CANDIDATE_DISPLAY = "2.0.0-beta.1"
+_CANDIDATE_PACKAGE = "2.0.0b1"
+_BASELINE_PACKAGE = "2.0.0a5"
+_DISPLAY_VERSION = re.compile(
+    r"^(?P<release>\d+\.\d+\.\d+)(?:-(?P<phase>alpha|beta|rc)\.(?P<serial>\d+))?$"
+)
+_PACKAGE_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b)\d+|rc\d+)?$")
+_PHASE_TO_PACKAGE = {"alpha": "a", "beta": "b", "rc": "rc"}
+_VALID_SEVERITIES = frozenset({"P0", "P1", "P2", "P3"})
+_VALID_STATES = frozenset({"open", "closed"})
+_VALID_DISPOSITION_STATUSES = frozenset({"accepted", "deferred", "fixed", "not_applicable"})
+_REQUIRED_GATES = ("preflight", "issues", "wheel", "soak", "final_code_audit")
+
+
+class EvidenceError(Exception):
+    """A bounded category that is safe to report in generated evidence."""
+
+    def __init__(self, category: str) -> None:
+        self.category = category
+        super().__init__(category)
+
+
+@dataclass(frozen=True)
+class GateRecord:
+    """A resumable gate result without environment-specific input details."""
+
+    gate_id: str
+    input_hash: str
+    status: str
+    details: dict[str, Any]
+
+
+def _canonical_hash(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def validate_output_directory(
+    output: Path,
+    *,
+    repo_root: Path,
+    protected_roots: Sequence[Path],
+) -> Path:
+    """Reject evidence destinations inside repository or supplied vault roots."""
+
+    resolved_output = output.expanduser().resolve(strict=False)
+    protected = [
+        repo_root.expanduser().resolve(strict=False),
+        *(root.expanduser().resolve(strict=False) for root in protected_roots),
+    ]
+    if any(_is_within(resolved_output, root) for root in protected):
+        raise EvidenceError("output_unsafe")
+    return resolved_output
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(temporary)
+        raise
+
+
+def _atomic_write_json(path: Path, value: object) -> None:
+    _atomic_write(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def _append_event(output: Path, event: dict[str, object]) -> None:
+    event["timestamp_utc"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with (output / "events.jsonl").open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(event, sort_keys=True, ensure_ascii=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _load_json(path: Path, *, category: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError(category) from exc
+    if not isinstance(payload, dict):
+        raise EvidenceError(category)
+    return payload
+
+
+def _empty_checkpoint() -> dict[str, Any]:
+    return {"schema_version": SCHEMA_VERSION, "gates": {}, "metadata": {}}
+
+
+def _load_checkpoint(output: Path) -> dict[str, Any]:
+    path = output / "checkpoint.json"
+    if not path.exists():
+        return _empty_checkpoint()
+    checkpoint = _load_json(path, category="checkpoint_invalid")
+    if (
+        checkpoint.get("schema_version") != SCHEMA_VERSION
+        or not isinstance(checkpoint.get("gates"), dict)
+        or not isinstance(checkpoint.get("metadata"), dict)
+    ):
+        raise EvidenceError("checkpoint_invalid")
+    return checkpoint
+
+
+def _load_evidence(output: Path) -> dict[str, Any]:
+    path = output / "evidence.json"
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "gates": {}, "metadata": {}}
+    evidence = _load_json(path, category="evidence_invalid")
+    if evidence.get("schema_version") != SCHEMA_VERSION or not isinstance(
+        evidence.get("gates"), dict
+    ):
+        raise EvidenceError("evidence_invalid")
+    return evidence
+
+
+def _record_gate(
+    output: Path,
+    record: GateRecord,
+    *,
+    metadata: dict[str, object] | None = None,
+) -> GateRecord:
+    checkpoint = _load_checkpoint(output)
+    evidence = _load_evidence(output)
+    existing = checkpoint["gates"].get(record.gate_id)
+    if isinstance(existing, dict) and existing.get("input_hash") == record.input_hash:
+        persisted = evidence["gates"].get(record.gate_id)
+        expected = asdict(record)
+        if not isinstance(persisted, dict) or existing != expected or persisted != expected:
+            raise EvidenceError("evidence_invalid")
+        _append_event(
+            output, {"event": "gate_resumed", "gate_id": record.gate_id, "status": record.status}
+        )
+        return record
+
+    output.mkdir(parents=True, exist_ok=True)
+    checkpoint["gates"][record.gate_id] = asdict(record)
+    if metadata:
+        checkpoint["metadata"].update(metadata)
+    _atomic_write_json(output / "checkpoint.json", checkpoint)
+
+    evidence["gates"][record.gate_id] = asdict(record)
+    if metadata:
+        evidence.setdefault("metadata", {}).update(metadata)
+    _atomic_write_json(output / "evidence.json", evidence)
+    _append_event(
+        output, {"event": "gate_recorded", "gate_id": record.gate_id, "status": record.status}
+    )
+    return record
+
+
+def display_to_package_version(display: str) -> str:
+    """Normalize a SemVer display prerelease to its Python package version."""
+
+    match = _DISPLAY_VERSION.fullmatch(display)
+    if not match:
+        raise EvidenceError("candidate_display_invalid")
+    phase = match.group("phase")
+    if phase is None:
+        return match.group("release")
+    return f"{match.group('release')}{_PHASE_TO_PACKAGE[phase]}{match.group('serial')}"
+
+
+def _validate_package_version(value: str, *, category: str) -> str:
+    if not _PACKAGE_VERSION.fullmatch(value):
+        raise EvidenceError(category)
+    return value
+
+
+def collect_preflight(
+    output: Path,
+    *,
+    candidate_display: str,
+    candidate_package: str,
+    baseline_package: str,
+) -> GateRecord:
+    """Record release naming and sanitized host facts for a candidate release."""
+
+    expected_package = display_to_package_version(candidate_display)
+    _validate_package_version(candidate_package, category="candidate_package_invalid")
+    _validate_package_version(baseline_package, category="baseline_package_invalid")
+    status = (
+        "PASS"
+        if (
+            candidate_display == _CANDIDATE_DISPLAY
+            and candidate_package == _CANDIDATE_PACKAGE
+            and baseline_package == _BASELINE_PACKAGE
+            and candidate_package == expected_package
+        )
+        else "FAIL"
+    )
+    details = {
+        "candidate_display": candidate_display,
+        "candidate_package": candidate_package,
+        "baseline_package": baseline_package,
+        "candidate_matches_release": candidate_display == _CANDIDATE_DISPLAY,
+        "package_matches_release": candidate_package == _CANDIDATE_PACKAGE,
+        "baseline_matches_release": baseline_package == _BASELINE_PACKAGE,
+        "formats_match": status == "PASS",
+        "python": {
+            "major": sys.version_info.major,
+            "minor": sys.version_info.minor,
+            "micro": sys.version_info.micro,
+        },
+        "platform": {"system": platform.system().lower(), "machine": platform.machine().lower()},
+    }
+    return _record_gate(
+        output,
+        GateRecord("preflight", _canonical_hash(details), status, details),
+        metadata={
+            "candidate_display": candidate_display,
+            "candidate_package": candidate_package,
+            "baseline_package": baseline_package,
+        },
+    )
+
+
+def _parse_issues(payload: dict[str, Any]) -> list[dict[str, object]]:
+    if (
+        set(payload) != {"schema_version", "issues"}
+        or payload.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise EvidenceError("issues_input_invalid")
+    issues = payload.get("issues")
+    if not isinstance(issues, list):
+        raise EvidenceError("issues_input_invalid")
+    normalized: list[dict[str, object]] = []
+    seen: set[int] = set()
+    for issue in issues:
+        if not isinstance(issue, dict) or set(issue) != {"number", "severity", "state", "in_scope"}:
+            raise EvidenceError("issues_input_invalid")
+        number, severity, state, in_scope = (
+            issue.get("number"),
+            issue.get("severity"),
+            issue.get("state"),
+            issue.get("in_scope"),
+        )
+        if (
+            not isinstance(number, int)
+            or isinstance(number, bool)
+            or number <= 0
+            or number in seen
+            or severity not in _VALID_SEVERITIES
+            or state not in _VALID_STATES
+            or not isinstance(in_scope, bool)
+        ):
+            raise EvidenceError("issues_input_invalid")
+        seen.add(number)
+        normalized.append(
+            {"number": number, "severity": severity, "state": state, "in_scope": in_scope}
+        )
+    return sorted(normalized, key=lambda item: cast(int, item["number"]))
+
+
+def _parse_dispositions(payload: dict[str, Any]) -> dict[int, str]:
+    if (
+        set(payload) != {"schema_version", "dispositions"}
+        or payload.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise EvidenceError("dispositions_input_invalid")
+    dispositions = payload.get("dispositions")
+    if not isinstance(dispositions, list):
+        raise EvidenceError("dispositions_input_invalid")
+    result: dict[int, str] = {}
+    for disposition in dispositions:
+        if not isinstance(disposition, dict) or set(disposition) != {"number", "status"}:
+            raise EvidenceError("dispositions_input_invalid")
+        number, status = disposition.get("number"), disposition.get("status")
+        if (
+            not isinstance(number, int)
+            or isinstance(number, bool)
+            or number <= 0
+            or number in result
+            or not isinstance(status, str)
+            or status not in _VALID_DISPOSITION_STATUSES
+        ):
+            raise EvidenceError("dispositions_input_invalid")
+        result[number] = status
+    return result
+
+
+def collect_issues(output: Path, *, issues_path: Path, dispositions_path: Path) -> GateRecord:
+    """Fail closed on in-scope open P0/P1 or P2 without controlled disposition."""
+
+    raw_issues = _load_json(issues_path, category="issues_input_unavailable")
+    raw_dispositions = _load_json(dispositions_path, category="dispositions_input_unavailable")
+    issues = _parse_issues(raw_issues)
+    dispositions = _parse_dispositions(raw_dispositions)
+    summaries: list[dict[str, object]] = []
+    failed = False
+    for issue in issues:
+        number = cast(int, issue["number"])
+        severity = str(issue["severity"])
+        state = str(issue["state"])
+        in_scope = bool(issue["in_scope"])
+        disposition_status = dispositions.get(number) if severity == "P2" else None
+        if in_scope and state == "open" and severity in {"P0", "P1"}:
+            failed = True
+        if in_scope and state == "open" and severity == "P2" and disposition_status is None:
+            failed = True
+        summaries.append(
+            {
+                "number": number,
+                "severity": severity,
+                "state": state,
+                "in_scope": in_scope,
+                "disposition_status": disposition_status,
+            }
+        )
+    details = {"issues": summaries}
+    return _record_gate(
+        output,
+        GateRecord(
+            "issues",
+            _canonical_hash({"issues": issues, "dispositions": dispositions}),
+            "FAIL" if failed else "PASS",
+            details,
+        ),
+    )
+
+
+def _validate_gate_records(gates: dict[str, Any]) -> None:
+    for gate_id, record in gates.items():
+        if (
+            not isinstance(gate_id, str)
+            or not isinstance(record, dict)
+            or record.get("gate_id") != gate_id
+            or not isinstance(record.get("input_hash"), str)
+            or re.fullmatch(r"[0-9a-f]{64}", record["input_hash"]) is None
+            or record.get("status") not in {"PASS", "FAIL"}
+            or not isinstance(record.get("details"), dict)
+        ):
+            raise EvidenceError("evidence_invalid")
+
+
+def render_summary(evidence: dict[str, Any]) -> str:
+    """Render a path-free beta readiness summary from recorded gate evidence."""
+
+    gates = evidence.get("gates", {})
+    rows: list[tuple[str, str]] = []
+    statuses: list[str] = []
+    for gate_id in _REQUIRED_GATES:
+        record = gates.get(gate_id)
+        status = str(record.get("status")) if isinstance(record, dict) else "PENDING"
+        rows.append((gate_id, status))
+        statuses.append(status)
+    readiness = (
+        "READY" if statuses and all(status == "PASS" for status in statuses) else "NOT READY"
+    )
+    metadata = evidence.get("metadata", {})
+    lines = [
+        "# Beta readiness evidence",
+        "",
+        f"Schema version: {SCHEMA_VERSION}",
+        f"Candidate display: {metadata.get('candidate_display', 'PENDING')}",
+        f"Candidate package: {metadata.get('candidate_package', 'PENDING')}",
+        f"Baseline package: {metadata.get('baseline_package', 'PENDING')}",
+        "",
+        "| Gate | Status |",
+        "|---|---|",
+        *(f"| {gate_id} | {status} |" for gate_id, status in rows),
+        "",
+        f"## Verdict: {readiness}",
+        "",
+        "Wheel installation, soak evidence, and final code audit remain pending "
+        "until collected by dedicated commands.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def collect_report(output: Path) -> GateRecord:
+    """Generate a summary; uncollected wheel, soak and code-audit gates remain pending."""
+
+    checkpoint = _load_checkpoint(output)
+    evidence = _load_evidence(output)
+    checkpoint_gates = checkpoint["gates"]
+    evidence_gates = evidence["gates"]
+    _validate_gate_records(checkpoint_gates)
+    _validate_gate_records(evidence_gates)
+    if checkpoint_gates != evidence_gates:
+        raise EvidenceError("evidence_invalid")
+    summary = render_summary(evidence)
+    _atomic_write(output / "summary.md", summary)
+    details = {"required_gates": list(_REQUIRED_GATES), "ready": "## Verdict: READY" in summary}
+    record = _record_gate(
+        output, GateRecord("report", _canonical_hash(evidence.get("gates", {})), "PASS", details)
+    )
+    # The report record is not needed for its own rendering, but publishing it keeps the
+    # evidence and checkpoint internally consistent for a later resume.
+    _atomic_write(output / "summary.md", render_summary(_load_evidence(output)))
+    return record
+
+
+def _protected_roots(args: argparse.Namespace) -> list[Path]:
+    roots: list[Path] = []
+    for name in ("vault_root", "source_root"):
+        value = getattr(args, name, None)
+        if value is not None:
+            roots.append(Path(value))
+    return roots
+
+
+def _prepare_output(args: argparse.Namespace) -> Path:
+    return validate_output_directory(
+        Path(args.output),
+        repo_root=_repo_root_from_script(),
+        protected_roots=_protected_roots(args),
+    )
+
+
+def _run_preflight(args: argparse.Namespace, output: Path) -> GateRecord:
+    return collect_preflight(
+        output,
+        candidate_display=args.candidate_display,
+        candidate_package=args.candidate_package,
+        baseline_package=args.baseline_package,
+    )
+
+
+def _require_success(record: GateRecord) -> None:
+    if record.status != "PASS":
+        raise EvidenceError("gate_failed")
+
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Explicit evidence directory outside repository and vault roots.",
+    )
+    parser.add_argument("--vault-root", help="Protected vault root; output may not be inside it.")
+    parser.add_argument(
+        "--source-root", help="Protected source-copy root; output may not be inside it."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser for the bounded evidence harness."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subcommands.add_parser(
+        "preflight", help="Record release naming and sanitized host evidence."
+    )
+    _add_output_arguments(preflight)
+    preflight.add_argument(
+        "--candidate-display", required=True, help="SemVer display version, e.g. 2.0.0-beta.1."
+    )
+    preflight.add_argument(
+        "--candidate-package", required=True, help="Python package version, e.g. 2.0.0b1."
+    )
+    preflight.add_argument(
+        "--baseline-package",
+        required=True,
+        help="Installed baseline package version, e.g. 2.0.0a5.",
+    )
+
+    issues = subcommands.add_parser(
+        "issues", help="Evaluate sanitized issue severity and disposition input."
+    )
+    _add_output_arguments(issues)
+    issues.add_argument(
+        "--issues-json", required=True, help="Path to the documented schema-version 1 issue input."
+    )
+    issues.add_argument(
+        "--p2-dispositions",
+        required=True,
+        help="Path to the documented schema-version 1 P2 disposition input.",
+    )
+
+    report = subcommands.add_parser(
+        "report", help="Generate a path-free summary from collected evidence."
+    )
+    _add_output_arguments(report)
+
+    run = subcommands.add_parser(
+        "run", help="Run preflight, issue evaluation, and report in order."
+    )
+    _add_output_arguments(run)
+    run.add_argument(
+        "--candidate-display", required=True, help="SemVer display version, e.g. 2.0.0-beta.1."
+    )
+    run.add_argument(
+        "--candidate-package", required=True, help="Python package version, e.g. 2.0.0b1."
+    )
+    run.add_argument(
+        "--baseline-package",
+        required=True,
+        help="Installed baseline package version, e.g. 2.0.0a5.",
+    )
+    run.add_argument(
+        "--issues-json", required=True, help="Path to the documented schema-version 1 issue input."
+    )
+    run.add_argument(
+        "--p2-dispositions",
+        required=True,
+        help="Path to the documented schema-version 1 P2 disposition input.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI and return a stable, privacy-safe exit status."""
+
+    args = build_parser().parse_args(argv)
+    try:
+        output = _prepare_output(args)
+        if args.command == "preflight":
+            _require_success(_run_preflight(args, output))
+        elif args.command == "issues":
+            _require_success(
+                collect_issues(
+                    output,
+                    issues_path=Path(args.issues_json),
+                    dispositions_path=Path(args.p2_dispositions),
+                )
+            )
+        elif args.command == "report":
+            collect_report(output)
+        elif args.command == "run":
+            preflight = _run_preflight(args, output)
+            issues = collect_issues(
+                output,
+                issues_path=Path(args.issues_json),
+                dispositions_path=Path(args.p2_dispositions),
+            )
+            report = collect_report(output)
+            _require_success(preflight)
+            _require_success(issues)
+            if report.details.get("ready") is not True:
+                raise EvidenceError("readiness_incomplete")
+        else:  # pragma: no cover - argparse enforces subcommands.
+            raise EvidenceError("command_invalid")
+    except EvidenceError as exc:
+        print(f"beta evidence: {exc.category}", file=sys.stderr)
+        return 2
+    except OSError:
+        print("beta evidence: storage_error", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -1,0 +1,345 @@
+"""Contract tests for the local, privacy-safe beta evidence harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "beta_readiness_evidence.py"
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("beta_readiness_evidence", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _inputs(
+    tmp_path: Path, *, issues: list[dict[str, object]], dispositions: list[dict[str, object]]
+) -> tuple[Path, Path]:
+    issues_path = tmp_path / "issues.json"
+    dispositions_path = tmp_path / "dispositions.json"
+    _write_json(issues_path, {"schema_version": 1, "issues": issues})
+    _write_json(dispositions_path, {"schema_version": 1, "dispositions": dispositions})
+    return issues_path, dispositions_path
+
+
+def _run(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *arguments], check=False, text=True, capture_output=True
+    )
+
+
+def test_output_rejects_repo_and_vault_containment(tmp_path: Path) -> None:
+    module = _module()
+    repo = tmp_path / "repo"
+    vault = tmp_path / "vault"
+    repo.mkdir()
+    vault.mkdir()
+    with pytest.raises(module.EvidenceError, match="output_unsafe"):
+        module.validate_output_directory(repo / "evidence", repo_root=repo, protected_roots=[vault])
+    with pytest.raises(module.EvidenceError, match="output_unsafe"):
+        module.validate_output_directory(
+            vault / "evidence", repo_root=repo, protected_roots=[vault]
+        )
+    assert module.validate_output_directory(
+        tmp_path / "outside", repo_root=repo, protected_roots=[vault]
+    ) == (tmp_path / "outside")
+
+
+@pytest.mark.parametrize(
+    ("display", "package"),
+    [("2.0.0-beta.1", "2.0.0b1"), ("2.0.0-alpha.5", "2.0.0a5"), ("2.0.0-rc.2", "2.0.0rc2")],
+)
+def test_display_versions_normalize_to_python_packages(display: str, package: str) -> None:
+    assert _module().display_to_package_version(display) == package
+
+
+def test_atomic_resume_is_idempotent(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    first = module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    checkpoint_before = (output / "checkpoint.json").read_text(encoding="utf-8")
+    second = module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    assert first == second
+    assert (output / "checkpoint.json").read_text(encoding="utf-8") == checkpoint_before
+    assert "gate_resumed" in (output / "events.jsonl").read_text(encoding="utf-8")
+
+
+def test_preflight_requires_the_explicit_beta_candidate(tmp_path: Path) -> None:
+    record = _module().collect_preflight(
+        tmp_path / "evidence",
+        candidate_display="2.0.0-alpha.5",
+        candidate_package="2.0.0a5",
+        baseline_package="2.0.0a5",
+    )
+    assert record.status == "FAIL"
+    assert record.details["candidate_matches_release"] is False
+
+
+def test_corrupted_checkpoint_fails_closed(tmp_path: Path) -> None:
+    output = tmp_path / "evidence"
+    output.mkdir()
+    (output / "checkpoint.json").write_text("not-json", encoding="utf-8")
+    result = _run(
+        "preflight",
+        "--output",
+        str(output),
+        "--candidate-display",
+        "2.0.0-beta.1",
+        "--candidate-package",
+        "2.0.0b1",
+        "--baseline-package",
+        "2.0.0a5",
+    )
+    assert result.returncode == 2
+    assert result.stderr.strip() == "beta evidence: checkpoint_invalid"
+
+
+def test_corrupted_evidence_fails_closed_on_resume(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    (output / "evidence.json").write_text("not-json", encoding="utf-8")
+    with pytest.raises(module.EvidenceError, match="evidence_invalid"):
+        module.collect_preflight(
+            output,
+            candidate_display="2.0.0-beta.1",
+            candidate_package="2.0.0b1",
+            baseline_package="2.0.0a5",
+        )
+
+
+def test_tampered_checkpoint_fails_closed_on_resume(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    checkpoint = json.loads((output / "checkpoint.json").read_text(encoding="utf-8"))
+    checkpoint["gates"]["preflight"]["details"]["platform"]["system"] = "untrusted"
+    _write_json(output / "checkpoint.json", checkpoint)
+    with pytest.raises(module.EvidenceError, match="evidence_invalid"):
+        module.collect_preflight(
+            output,
+            candidate_display="2.0.0-beta.1",
+            candidate_package="2.0.0b1",
+            baseline_package="2.0.0a5",
+        )
+
+
+def test_open_p0_or_p1_fails_gate(tmp_path: Path) -> None:
+    module = _module()
+    issues_path, dispositions_path = _inputs(
+        tmp_path,
+        issues=[{"number": 1, "severity": "P1", "state": "open", "in_scope": True}],
+        dispositions=[],
+    )
+    record = module.collect_issues(
+        tmp_path / "evidence", issues_path=issues_path, dispositions_path=dispositions_path
+    )
+    assert record.status == "FAIL"
+
+
+def test_open_p2_needs_disposition_and_then_passes(tmp_path: Path) -> None:
+    module = _module()
+    issues = [{"number": 2, "severity": "P2", "state": "open", "in_scope": True}]
+    missing, empty = _inputs(tmp_path / "missing", issues=issues, dispositions=[])
+    missing_record = module.collect_issues(
+        tmp_path / "missing-evidence", issues_path=missing, dispositions_path=empty
+    )
+    assert missing_record.status == "FAIL"
+    issue_path, disposition_path = _inputs(
+        tmp_path / "accepted", issues=issues, dispositions=[{"number": 2, "status": "accepted"}]
+    )
+    accepted = module.collect_issues(
+        tmp_path / "accepted-evidence", issues_path=issue_path, dispositions_path=disposition_path
+    )
+    assert accepted.status == "PASS"
+    stored = json.loads(
+        (tmp_path / "accepted-evidence" / "evidence.json").read_text(encoding="utf-8")
+    )
+    assert stored["gates"]["issues"]["details"]["issues"] == [
+        {
+            "number": 2,
+            "severity": "P2",
+            "state": "open",
+            "in_scope": True,
+            "disposition_status": "accepted",
+        }
+    ]
+
+
+def test_report_stays_not_ready_without_wheel_soak_and_final_audit(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    issue_path, disposition_path = _inputs(tmp_path, issues=[], dispositions=[])
+    module.collect_issues(output, issues_path=issue_path, dispositions_path=disposition_path)
+    module.collect_report(output)
+    summary = (output / "summary.md").read_text(encoding="utf-8")
+    assert "| wheel | PENDING |" in summary
+    assert "| soak | PENDING |" in summary
+    assert "| final_code_audit | PENDING |" in summary
+    assert "## Verdict: NOT READY" in summary
+
+
+def test_report_rejects_pass_gates_injected_only_into_evidence(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    issue_path, disposition_path = _inputs(tmp_path, issues=[], dispositions=[])
+    module.collect_issues(output, issues_path=issue_path, dispositions_path=disposition_path)
+    module.collect_report(output)
+    evidence_path = output / "evidence.json"
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    for gate_id in ("wheel", "soak", "final_code_audit"):
+        evidence["gates"][gate_id] = {
+            "gate_id": gate_id,
+            "input_hash": "0" * 64,
+            "status": "PASS",
+            "details": {},
+        }
+    _write_json(evidence_path, evidence)
+    with pytest.raises(module.EvidenceError, match="evidence_invalid"):
+        module.collect_report(output)
+    assert "## Verdict: READY" not in (output / "summary.md").read_text(encoding="utf-8")
+
+
+def test_cli_storage_error_for_non_directory_output(tmp_path: Path) -> None:
+    output_file = tmp_path / "not-a-directory"
+    output_file.write_text("x", encoding="utf-8")
+    result = _run("report", "--output", str(output_file))
+    assert result.returncode == 2
+    assert result.stderr.strip() == "beta evidence: storage_error"
+
+
+def test_publishable_artifacts_contain_no_absolute_paths(tmp_path: Path) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    issue_path, disposition_path = _inputs(tmp_path, issues=[], dispositions=[])
+    assert (
+        module.main(
+            [
+                "run",
+                "--output",
+                str(output),
+                "--candidate-display",
+                "2.0.0-beta.1",
+                "--candidate-package",
+                "2.0.0b1",
+                "--baseline-package",
+                "2.0.0a5",
+                "--issues-json",
+                str(issue_path),
+                "--p2-dispositions",
+                str(disposition_path),
+            ]
+        )
+        == 2
+    )
+    forbidden = {str(tmp_path), str(output), str(issue_path), str(disposition_path)}
+    for artifact in ("evidence.json", "checkpoint.json", "events.jsonl", "summary.md"):
+        text = (output / artifact).read_text(encoding="utf-8")
+        assert not any(value in text for value in forbidden)
+
+
+def test_cli_exit_codes_for_success_and_failed_issues(tmp_path: Path) -> None:
+    issue_path, disposition_path = _inputs(
+        tmp_path,
+        issues=[{"number": 3, "severity": "P0", "state": "open", "in_scope": True}],
+        dispositions=[],
+    )
+    failed = _run(
+        "run",
+        "--output",
+        str(tmp_path / "failed"),
+        "--candidate-display",
+        "2.0.0-beta.1",
+        "--candidate-package",
+        "2.0.0b1",
+        "--baseline-package",
+        "2.0.0a5",
+        "--issues-json",
+        str(issue_path),
+        "--p2-dispositions",
+        str(disposition_path),
+    )
+    assert failed.returncode == 2
+    assert failed.stderr.strip() == "beta evidence: gate_failed"
+    assert (tmp_path / "failed" / "summary.md").exists()
+    _write_json(issue_path, {"schema_version": 1, "issues": []})
+    passed = _run(
+        "run",
+        "--output",
+        str(tmp_path / "passed"),
+        "--candidate-display",
+        "2.0.0-beta.1",
+        "--candidate-package",
+        "2.0.0b1",
+        "--baseline-package",
+        "2.0.0a5",
+        "--issues-json",
+        str(issue_path),
+        "--p2-dispositions",
+        str(disposition_path),
+    )
+    assert passed.returncode == 2
+    assert passed.stderr.strip() == "beta evidence: readiness_incomplete"
+    assert "## Verdict: NOT READY" in (tmp_path / "passed" / "summary.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_cli_rejects_repo_root_override(tmp_path: Path) -> None:
+    result = _run(
+        "report",
+        "--output",
+        str(tmp_path / "evidence"),
+        "--repo-root",
+        str(tmp_path),
+    )
+    assert result.returncode == 2
+    assert "unrecognized arguments: --repo-root" in result.stderr


### PR DESCRIPTION
## Summary
- add a deterministic, resumable beta-readiness evidence CLI
- validate the `2.0.0-beta.1` / `2.0.0b1` / `2.0.0a5` version contract
- evaluate sanitized, explicit P0–P2 issue and disposition input without network access
- emit atomic schema-versioned evidence/checkpoints, append-only events, and a path-free Markdown summary
- fail closed on corrupted or inconsistent evidence and remain `NOT READY` until wheel, soak, and final code-audit gates are present

## Privacy and safety
- output must be explicit and outside the repository and supplied vault/source roots
- repository containment cannot be overridden from the CLI
- artifacts contain no issue titles, bodies, URLs, vault content, UUIDs, or absolute paths
- malformed input, storage errors, checkpoint tampering, and incomplete readiness use bounded error categories
- the harness never merges, tags, publishes, or mutates a vault

## Current scope

This is the evidence foundation. `preflight`, `issues`, `report`, and `run` are implemented. Installed-wheel and resumable soak collectors remain deliberately pending and cannot be fabricated through the report path.

## Test plan
- [x] 17 focused harness tests
- [x] manual sanitized CLI smoke: `readiness_incomplete`, `NOT READY`, no absolute paths
- [x] Ruff format/lint and mypy
- [x] full `make ci` — 1394 passed, 2 skipped, 1 xfailed
- [x] coverage 82.80%
- [x] code audit — LOW, zero runtime flows

Refs #20
Refs #297
