### PR TITLE
feat(quality): add fail-closed beta code audit gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- **Final beta code audit gate** — add a fail-closed `code-audit` evidence command that records only sanitized candidate diff, build, CI, scope, and finding summaries after matching the verified candidate wheel.
+
 ### Security
 
 - **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.

--- a/scripts/beta_evidence/__init__.py
+++ b/scripts/beta_evidence/__init__.py
@@ -4,6 +4,7 @@ from .cli import main
 from .core import (
     EvidenceError,
     GateRecord,
+    collect_final_code_audit,
     collect_issues,
     collect_preflight,
     collect_report,
@@ -16,6 +17,7 @@ from .wheel import _markdown_fingerprint, collect_wheel
 __all__ = [
     "EvidenceError",
     "GateRecord",
+    "collect_final_code_audit",
     "collect_issues",
     "collect_preflight",
     "collect_report",

--- a/scripts/beta_evidence/cli.py
+++ b/scripts/beta_evidence/cli.py
@@ -11,6 +11,7 @@ from .core import (
     EvidenceError,
     GateRecord,
     _repo_root_from_script,
+    collect_final_code_audit,
     collect_issues,
     collect_preflight,
     collect_report,
@@ -163,6 +164,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=_DEFAULT_INTERVAL_SECONDS,
         help="Delay between cycles, default 600 seconds.",
     )
+    code_audit = subcommands.add_parser(
+        "code-audit", help="Record sanitized final code audit evidence for the candidate wheel."
+    )
+    _add_output_arguments(code_audit)
+    code_audit.add_argument(
+        "--audit-json",
+        required=True,
+        help="Path to the documented schema-version 1 code audit input.",
+    )
     run = subcommands.add_parser(
         "run", help="Run preflight, issue evaluation, and report in order."
     )
@@ -240,6 +250,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     interval_seconds=args.interval_seconds,
                 )
             )
+        elif args.command == "code-audit":
+            _require_success(collect_final_code_audit(output, audit_path=Path(args.audit_json)))
         elif args.command == "run":
             preflight = _run_preflight(args, output)
             issues = collect_issues(

--- a/scripts/beta_evidence/core.py
+++ b/scripts/beta_evidence/core.py
@@ -28,6 +28,8 @@ _PHASE_TO_PACKAGE = {"alpha": "a", "beta": "b", "rc": "rc"}
 _VALID_SEVERITIES = frozenset({"P0", "P1", "P2", "P3"})
 _VALID_STATES = frozenset({"open", "closed"})
 _VALID_DISPOSITION_STATUSES = frozenset({"accepted", "deferred", "fixed", "not_applicable"})
+_VALID_AUDIT_STATUSES = frozenset({"PASS", "FAIL"})
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _REQUIRED_GATES = ("preflight", "issues", "wheel", "soak", "final_code_audit")
 
 
@@ -352,6 +354,120 @@ def collect_issues(output: Path, *, issues_path: Path, dispositions_path: Path) 
             _canonical_hash({"issues": issues, "dispositions": dispositions}),
             "FAIL" if failed else "PASS",
             {"issues": summaries},
+        ),
+    )
+
+
+def _parse_final_code_audit(payload: dict[str, Any]) -> dict[str, object]:
+    expected = {
+        "schema_version",
+        "candidate_package",
+        "wheel_sha256",
+        "candidate_diff_sha256",
+        "diff_verified",
+        "build_verified",
+        "ci_verified",
+        "scope_verified",
+        "audit_status",
+        "blocking_findings",
+        "advisory_findings",
+    }
+    if set(payload) != expected or payload.get("schema_version") != SCHEMA_VERSION:
+        raise EvidenceError("code_audit_input_invalid")
+    candidate_package = payload.get("candidate_package")
+    wheel_sha256 = payload.get("wheel_sha256")
+    candidate_diff_sha256 = payload.get("candidate_diff_sha256")
+    audit_status = payload.get("audit_status")
+    boolean_fields = ("diff_verified", "build_verified", "ci_verified", "scope_verified")
+    count_fields = ("blocking_findings", "advisory_findings")
+    if (
+        not isinstance(candidate_package, str)
+        or _PACKAGE_VERSION.fullmatch(candidate_package) is None
+        or not isinstance(wheel_sha256, str)
+        or _SHA256.fullmatch(wheel_sha256) is None
+        or not isinstance(candidate_diff_sha256, str)
+        or _SHA256.fullmatch(candidate_diff_sha256) is None
+        or audit_status not in _VALID_AUDIT_STATUSES
+        or any(not isinstance(payload.get(field), bool) for field in boolean_fields)
+        or any(
+            not isinstance(payload.get(field), int)
+            or isinstance(payload.get(field), bool)
+            or payload[field] < 0
+            for field in count_fields
+        )
+    ):
+        raise EvidenceError("code_audit_input_invalid")
+    return {
+        "candidate_package": candidate_package,
+        "wheel_sha256": wheel_sha256,
+        "candidate_diff_sha256": candidate_diff_sha256,
+        "diff_verified": payload["diff_verified"],
+        "build_verified": payload["build_verified"],
+        "ci_verified": payload["ci_verified"],
+        "scope_verified": payload["scope_verified"],
+        "audit_status": audit_status,
+        "blocking_findings": payload["blocking_findings"],
+        "advisory_findings": payload["advisory_findings"],
+    }
+
+
+def _code_audit_prerequisites(output: Path) -> tuple[str, str]:
+    checkpoint, evidence = _load_checkpoint(output), _load_evidence(output)
+    checkpoint_gates, evidence_gates = checkpoint["gates"], evidence["gates"]
+    _validate_gate_records(checkpoint_gates)
+    _validate_gate_records(evidence_gates)
+    if checkpoint_gates != evidence_gates:
+        raise EvidenceError("evidence_invalid")
+    records = {gate_id: checkpoint_gates.get(gate_id) for gate_id in ("preflight", "wheel")}
+    if any(
+        not isinstance(record, dict) or record.get("status") != "PASS"
+        for record in records.values()
+    ):
+        raise EvidenceError("code_audit_prerequisite_missing")
+    preflight_details = cast(dict[str, Any], records["preflight"])["details"]
+    wheel_details = cast(dict[str, Any], records["wheel"])["details"]
+    candidate_package = preflight_details.get("candidate_package")
+    wheel_sha256 = wheel_details.get("wheel_sha256")
+    if (
+        not isinstance(candidate_package, str)
+        or _PACKAGE_VERSION.fullmatch(candidate_package) is None
+        or not isinstance(wheel_sha256, str)
+        or _SHA256.fullmatch(wheel_sha256) is None
+    ):
+        raise EvidenceError("code_audit_prerequisite_invalid")
+    return candidate_package, wheel_sha256
+
+
+def collect_final_code_audit(output: Path, *, audit_path: Path) -> GateRecord:
+    """Record a sanitized, fail-closed code audit for the candidate wheel."""
+
+    audit = _parse_final_code_audit(_load_json(audit_path, category="code_audit_input_unavailable"))
+    candidate_package, wheel_sha256 = _code_audit_prerequisites(output)
+    failure_reasons: list[str] = []
+    if audit["candidate_package"] != candidate_package:
+        failure_reasons.append("candidate_package_mismatch")
+    if audit["wheel_sha256"] != wheel_sha256:
+        failure_reasons.append("wheel_sha256_mismatch")
+    if audit["diff_verified"] is not True:
+        failure_reasons.append("diff_unverified")
+    if audit["build_verified"] is not True:
+        failure_reasons.append("build_unverified")
+    if audit["ci_verified"] is not True:
+        failure_reasons.append("ci_unverified")
+    if audit["scope_verified"] is not True:
+        failure_reasons.append("scope_unverified")
+    if audit["audit_status"] != "PASS":
+        failure_reasons.append("audit_not_passed")
+    if audit["blocking_findings"] != 0:
+        failure_reasons.append("blocking_findings_present")
+    details = {**audit, "failure_reasons": failure_reasons}
+    return _record_gate(
+        output,
+        GateRecord(
+            "final_code_audit",
+            _canonical_hash(audit),
+            "FAIL" if failure_reasons else "PASS",
+            details,
         ),
     )
 

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -456,6 +456,128 @@ def test_wheel_records_only_sanitized_pass_and_keeps_source_untouched(tmp_path: 
     )
 
 
+def _code_audit_prerequisites(
+    tmp_path: Path,
+) -> tuple[ModuleType, Path, Path, Path, str]:
+    module = _module()
+    output = tmp_path / "evidence"
+    module.collect_preflight(
+        output,
+        candidate_display="2.0.0-beta.1",
+        candidate_package="2.0.0b1",
+        baseline_package="2.0.0a5",
+    )
+    source, fingerprint, wheel = _wheel_source(tmp_path)
+    record = module.collect_wheel(
+        output,
+        wheel_path=wheel,
+        source_vault=source,
+        expected_source_file=fingerprint,
+        command_runner=_successful_command,
+        probe_runner=lambda *_args, **_kwargs: _probe_payload(),
+    )
+    assert record.status == "PASS"
+    evidence = json.loads((output / "evidence.json").read_text(encoding="utf-8"))
+    wheel_sha256 = evidence["gates"]["wheel"]["details"]["wheel_sha256"]
+    return module, output, source, fingerprint, wheel_sha256
+
+
+def _code_audit_payload(wheel_sha256: str, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "candidate_package": "2.0.0b1",
+        "wheel_sha256": wheel_sha256,
+        "candidate_diff_sha256": "d" * 64,
+        "diff_verified": True,
+        "build_verified": True,
+        "ci_verified": True,
+        "scope_verified": True,
+        "audit_status": "PASS",
+        "blocking_findings": 0,
+        "advisory_findings": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_code_audit_requires_valid_preflight_and_wheel_evidence(tmp_path: Path) -> None:
+    module = _module()
+    audit_path = tmp_path / "audit.json"
+    _write_json(audit_path, _code_audit_payload("a" * 64))
+    with pytest.raises(module.EvidenceError, match="code_audit_prerequisite_missing"):
+        module.collect_final_code_audit(tmp_path / "evidence", audit_path=audit_path)
+
+
+def test_code_audit_rejects_malformed_input(tmp_path: Path) -> None:
+    module, output, _source, _fingerprint, wheel_sha256 = _code_audit_prerequisites(tmp_path)
+    audit_path = tmp_path / "audit.json"
+    malformed = _code_audit_payload(wheel_sha256)
+    del malformed["ci_verified"]
+    _write_json(audit_path, malformed)
+    with pytest.raises(module.EvidenceError, match="code_audit_input_invalid"):
+        module.collect_final_code_audit(output, audit_path=audit_path)
+
+
+def test_code_audit_records_sanitized_pass_and_resumes(tmp_path: Path) -> None:
+    module, output, _source, _fingerprint, wheel_sha256 = _code_audit_prerequisites(tmp_path)
+    audit_path = tmp_path / "audit.json"
+    payload = _code_audit_payload(wheel_sha256)
+    _write_json(audit_path, payload)
+    first = module.collect_final_code_audit(output, audit_path=audit_path)
+    checkpoint_before = (output / "checkpoint.json").read_text(encoding="utf-8")
+    second = module.collect_final_code_audit(output, audit_path=audit_path)
+    expected = {key: value for key, value in payload.items() if key != "schema_version"}
+    assert first.status == "PASS"
+    assert first == second
+    assert first.details == {**expected, "failure_reasons": []}
+    assert (output / "checkpoint.json").read_text(encoding="utf-8") == checkpoint_before
+    evidence = (output / "evidence.json").read_text(encoding="utf-8")
+    assert str(tmp_path) not in evidence
+    assert "audit.json" not in evidence
+    assert "gate_resumed" in (output / "events.jsonl").read_text(encoding="utf-8")
+
+
+def test_code_audit_records_mismatch_as_failed_gate_and_cli_fails(tmp_path: Path) -> None:
+    module, output, _source, _fingerprint, wheel_sha256 = _code_audit_prerequisites(tmp_path)
+    audit_path = tmp_path / "audit.json"
+    _write_json(audit_path, _code_audit_payload(wheel_sha256, build_verified=False))
+    record = module.collect_final_code_audit(output, audit_path=audit_path)
+    assert record.status == "FAIL"
+    assert record.details["failure_reasons"] == ["build_unverified"]
+    assert (
+        module.main(["code-audit", "--output", str(output), "--audit-json", str(audit_path)]) == 2
+    )
+
+
+def test_report_is_ready_after_collected_code_audit_and_soak(tmp_path: Path) -> None:
+    module, output, source, fingerprint, wheel_sha256 = _code_audit_prerequisites(tmp_path)
+    audit_path = tmp_path / "audit.json"
+    _write_json(audit_path, _code_audit_payload(wheel_sha256))
+    assert module.collect_final_code_audit(output, audit_path=audit_path).status == "PASS"
+    ticks = iter((0.0, 1.0))
+    assert (
+        module.collect_soak(
+            output,
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "soak-copy",
+            duration_seconds=1,
+            max_cycles=1,
+            interval_seconds=0,
+            candidate_verifier=lambda _: "e" * 64,
+            probe_runner=lambda *_args: _soak_payload(),
+            clock=lambda: next(ticks),
+            sleeper=lambda _: None,
+        ).status
+        == "PASS"
+    )
+    issue_path, disposition_path = _inputs(tmp_path, issues=[], dispositions=[])
+    module.collect_issues(output, issues_path=issue_path, dispositions_path=disposition_path)
+    module.collect_report(output)
+    assert "## Verdict: READY" in (output / "summary.md").read_text(encoding="utf-8")
+
+
 def test_wheel_timeout_and_malformed_probe_record_safe_failures(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, wheel = _wheel_source(tmp_path)


### PR DESCRIPTION
## Summary
- add a strict schema-v1 `code-audit` evidence command for the beta candidate
- bind audit evidence to matching preflight metadata and the verified candidate wheel hash
- persist only bounded, sanitized pass/fail fields and fail closed on malformed or inconsistent prerequisites
- keep the combined readiness report unavailable until every required gate passes

## Test plan
- [x] `uv run pytest -q --no-cov tests/test_beta_readiness_evidence.py` (37 passed)
- [x] Ruff check and format
- [x] mypy on the four implementation/test paths
- [x] `git diff --check`

## Code audit impact
- LOW: limited to the private beta-evidence CLI and its single collector path; no product runtime or vault mutation path changes

Refs #20