### PR TITLE
fix(packaging): exclude compiled Python artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,44 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
 
+      - name: Verify distribution archives exclude compiled Python artifacts
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import sys
+          import tarfile
+          import zipfile
+
+          dist = Path("dist")
+          wheels = sorted(dist.glob("*.whl"))
+          sdists = sorted(dist.glob("*.tar.gz"))
+          if not wheels or not sdists:
+              sys.exit("Both a wheel and source distribution are required in dist/.")
+          archives = [*wheels, *sdists]
+
+          forbidden = []
+          for archive in archives:
+              if archive.suffix == ".whl":
+                  with zipfile.ZipFile(archive) as bundle:
+                      members = bundle.namelist()
+              else:
+                  with tarfile.open(archive, "r:gz") as bundle:
+                      members = bundle.getnames()
+
+              forbidden.extend(
+                  f"{archive}: {member}"
+                  for member in members
+                  if "__pycache__" in Path(member).parts
+                  or Path(member).suffix in {".pyc", ".pyo", ".pyd"}
+              )
+
+          if forbidden:
+              sys.exit(
+                  "Compiled Python artifacts are not permitted in release archives:\n"
+                  + "\n".join(forbidden)
+              )
+          PY
+
       - name: Extract release notes from CHANGELOG
         run: |
           uv run python scripts/extract_changelog.py "${GITHUB_REF_NAME}" > release_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- **Distribution archive hygiene** — release builds exclude Python bytecode and cache directories from wheel and source distributions; CI rejects any that remain.
 - **Catalog merge-save corruption guard (#198)** — `MasterCatalog.save(replace=False)` now aborts after quarantining unreadable or non-object `master_catalog.json` state instead of merging a stale in-memory snapshot with an empty fallback and overwriting unseen catalog rows; explicit `replace=True` remains available for deliberate rebuilds.
 - **Dependency security advisories (Dependabot #28–#31)** — require MCP Python SDK `>=1.28.1` to include task/session isolation and WebSocket transport fixes, and refresh the frontend lock to patched `brace-expansion>=5.0.7`. Matryca's MCP entrypoint remains stdio-only; no HTTP, WebSocket, or experimental task transport is enabled.
 - **CLI `search bm25` no longer eager-bootstraps AST (#297 / A-CLI-01)** — `matryca search bm25` prepares runtime with `eager_graph=False`, so LogosParser cold load cannot hang BM25 (raw Markdown / Shadow FTS). Other CLI commands keep eager AST warm-up.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include NOTICE
 graft src
 graft frontend/dist
 prune frontend/node_modules
+global-exclude *.py[cod]

--- a/tests/test_packaging_manifest.py
+++ b/tests/test_packaging_manifest.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_manifest_excludes_compiled_python_artifacts() -> None:
+    manifest = Path(__file__).parents[1] / "MANIFEST.in"
+
+    assert "global-exclude *.py[cod]" in manifest.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- exclude Python bytecode and cache directories from wheel and source distributions
- add a deterministic manifest contract test
- make release CI inspect both wheel and sdist and reject compiled Python artifacts
- reduce candidate wheel size and prevent checkout-local caches from contaminating published packages

## Test plan
- [x] packaging manifest test
- [x] Ruff check and format
- [x] `uv build`
- [x] wheel and sdist archive inspection
- [x] workflow YAML parse
- [x] `make ci` (1410 passed, 2 skipped, 1 expected xfail)
- [x] `git diff --check`

## Code audit impact
- LOW: packaging and release automation only; no product runtime execution flow changes

Refs #20