### PR TITLE
fix(quality): record bounded parse deadline in beta evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Explicit beta-evidence parse deadline** — `wheel` and `soak` now require a sanitized, bounded 2–120 second child-only page-parse deadline, record it in resumable evidence, and reject a resume when it changes; this harness setting does not alter the product default of 15 seconds.
 - **Final beta code audit gate** — add a fail-closed `code-audit` evidence command that records only sanitized candidate diff, build, CI, scope, and finding summaries after matching the verified candidate wheel.
 
 ### Security

--- a/docs/quality/issue-bodies/v2-beta-readiness.md
+++ b/docs/quality/issue-bodies/v2-beta-readiness.md
@@ -6,6 +6,8 @@
 
 The beta scope is limited to the existing Shadow read path: bootstrap and reconciliation, FTS5 BM25, recursive CTE subtree reads, health-gated routing, and their Markdown/BM25 fallbacks. Logseq Markdown remains the system of record. Biological memory and Logseq DB Safe-Sync are Phase 4 work and are excluded from beta. `MATRYCA_SHADOW_DB_ENABLED` remains opt-in and default-off.
 
+The product's `MATRYCA_PAGE_PARSE_TIMEOUT_S` default remains **15 seconds**. A timeout must make health non-ready and route reads to the established Markdown/BM25 fallback. The private beta-evidence `wheel` and `soak` commands require an explicit bounded deadline (2–120 seconds) for their child probes; **60 seconds** is allowed for evidence collection only and does not demonstrate readiness at the 15-second product default.
+
 ## Proposed Architectural Solution
 
 Use this record as the release decision gate for `v2.0.0-beta.1`. A gate is complete only when its evidence is sanitized and reproducible; a green unit test alone does not replace an installed-wheel or real-vault check.

--- a/scripts/beta_evidence/cli.py
+++ b/scripts/beta_evidence/cli.py
@@ -126,6 +126,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=_WHEEL_TIMEOUT_SECONDS,
         help="Per-subprocess timeout, bounded to 1-600 seconds.",
     )
+    wheel.add_argument(
+        "--page-parse-timeout-seconds",
+        required=True,
+        type=int,
+        help="Required child page-parse deadline, bounded to 2-120 seconds.",
+    )
     soak = subcommands.add_parser(
         "soak", help="Collect resumable, sanitized Shadow DB evidence from a durable vault copy."
     )
@@ -163,6 +169,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=_DEFAULT_INTERVAL_SECONDS,
         help="Delay between cycles, default 600 seconds.",
+    )
+    soak.add_argument(
+        "--page-parse-timeout-seconds",
+        required=True,
+        type=int,
+        help="Required child page-parse deadline, bounded to 2-120 seconds.",
     )
     code_audit = subcommands.add_parser(
         "code-audit", help="Record sanitized final code audit evidence for the candidate wheel."
@@ -234,6 +246,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     wheel_path=Path(args.wheel),
                     source_vault=Path(args.source_vault),
                     expected_source_file=Path(args.expected_source_realpath_file),
+                    page_parse_timeout_seconds=args.page_parse_timeout_seconds,
                     timeout_seconds=args.timeout_seconds,
                 )
             )
@@ -248,6 +261,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     duration_seconds=args.duration_seconds,
                     max_cycles=args.max_cycles,
                     interval_seconds=args.interval_seconds,
+                    page_parse_timeout_seconds=args.page_parse_timeout_seconds,
                 )
             )
         elif args.command == "code-audit":

--- a/scripts/beta_evidence/core.py
+++ b/scripts/beta_evidence/core.py
@@ -187,6 +187,14 @@ def _record_gate(
     return record
 
 
+def _require_matching_gate_input(output: Path, *, gate_id: str, input_hash: str) -> None:
+    """Reject attempts to resume a recorded gate with different sanitized inputs."""
+
+    existing = _load_checkpoint(output)["gates"].get(gate_id)
+    if isinstance(existing, dict) and existing.get("input_hash") != input_hash:
+        raise EvidenceError("gate_resume_mismatch")
+
+
 def display_to_package_version(display: str) -> str:
     """Normalize a SemVer display prerelease to its Python package version."""
 

--- a/scripts/beta_evidence/soak.py
+++ b/scripts/beta_evidence/soak.py
@@ -22,6 +22,7 @@ from .core import (
     _is_within,
     _record_gate,
     _repo_root_from_script,
+    _require_matching_gate_input,
     validate_output_directory,
 )
 from .wheel import (
@@ -45,7 +46,7 @@ _HEARTBEAT_FILE = "soak-heartbeat.json"
 _RESULT_FILE = "soak-result.json"
 _SUMMARY_FILE = "soak-summary.md"
 
-type ProbeRunner = Callable[[Path, Path, int, int], dict[str, object]]
+type ProbeRunner = Callable[[Path, Path, int, int, int], dict[str, object]]
 type Clock = Callable[[], float]
 type Sleeper = Callable[[float], None]
 type Copier = Callable[[Path, Path], None]
@@ -274,9 +275,12 @@ def _load_state(output: Path) -> dict[str, Any] | None:
         and isinstance(state.get("elapsed_seconds"), (int, float))
         and not isinstance(state.get("elapsed_seconds"), bool)
         and isinstance(state.get("target_duration_seconds"), int)
+        and isinstance(state.get("page_parse_timeout_seconds"), int)
     ):
         raise EvidenceError("soak_state_invalid")
     if state["completed_cycles"] < 0 or state["status"] not in {"RUNNING", "PASS", "FAIL"}:
+        raise EvidenceError("soak_state_invalid")
+    if not 2 <= state["page_parse_timeout_seconds"] <= 120:
         raise EvidenceError("soak_state_invalid")
     if not all(isinstance(item, dict) for item in state["trends"]):
         raise EvidenceError("soak_state_invalid")
@@ -350,9 +354,20 @@ def _resolve_working_root(working_root: Path, *, source: Path, output: Path) -> 
 
 
 def _run_process(
-    python: Path, graph: Path, code: str, *, cycle: int, enabled: bool, timeout_seconds: int
+    python: Path,
+    graph: Path,
+    code: str,
+    *,
+    cycle: int,
+    enabled: bool,
+    timeout_seconds: int,
+    page_parse_timeout_seconds: int,
 ) -> dict[str, object]:
-    environment = _safe_environment(graph, enabled=enabled)
+    environment = _safe_environment(
+        graph,
+        enabled=enabled,
+        page_parse_timeout_seconds=page_parse_timeout_seconds,
+    )
     environment["MATRYCA_SOAK_CYCLE"] = str(cycle)
     try:
         completed = subprocess.run(
@@ -412,7 +427,11 @@ def _nonnegative_number(payload: Mapping[str, object], name: str) -> float | int
 
 
 def _run_soak_probe(
-    candidate_python: Path, working_root: Path, timeout_seconds: int, cycle: int
+    candidate_python: Path,
+    working_root: Path,
+    timeout_seconds: int,
+    page_parse_timeout_seconds: int,
+    cycle: int,
 ) -> dict[str, object]:
     started = time.monotonic()
     on = _run_process(
@@ -422,6 +441,7 @@ def _run_soak_probe(
         cycle=cycle,
         enabled=True,
         timeout_seconds=timeout_seconds,
+        page_parse_timeout_seconds=page_parse_timeout_seconds,
     )
     off = _run_process(
         candidate_python,
@@ -430,6 +450,7 @@ def _run_soak_probe(
         cycle=cycle,
         enabled=False,
         timeout_seconds=timeout_seconds,
+        page_parse_timeout_seconds=page_parse_timeout_seconds,
     )
     payload = {**off, **on, "elapsed_ms": round((time.monotonic() - started) * 1000, 3)}
     validated = _validate_probe_payload(payload)
@@ -465,6 +486,7 @@ def _summary_details(state: Mapping[str, Any]) -> dict[str, object]:
         "source_unchanged_during_copy": state["source_unchanged_during_copy"],
         "observed_duration_seconds": round(float(state["elapsed_seconds"]), 3),
         "target_duration_seconds": state["target_duration_seconds"],
+        "page_parse_timeout_seconds": state["page_parse_timeout_seconds"],
         "duration_target_reached": state["elapsed_seconds"] >= state["target_duration_seconds"],
         "beta_qualified": (
             state["elapsed_seconds"] >= _DEFAULT_DURATION_SECONDS
@@ -492,6 +514,7 @@ def _render_summary(result: Mapping[str, object]) -> str:
         f"Status: {result['status']}",
         f"Cycles completed: {result['cycles_completed']}",
         f"Observed duration seconds: {result['observed_duration_seconds']}",
+        f"Page parse timeout seconds: {result['page_parse_timeout_seconds']}",
         f"Beta-qualified duration: {result['beta_qualified']}",
         f"Source unchanged during copy: {result['source_unchanged_during_copy']}",
         f"FTS/subtree checks: {result['subtree_checks']} pass, {result['subtree_skipped']} skipped",
@@ -534,6 +557,7 @@ def collect_soak(
     source_vault: Path,
     expected_source_file: Path,
     working_root: Path,
+    page_parse_timeout_seconds: int,
     duration_seconds: int = _DEFAULT_DURATION_SECONDS,
     max_cycles: int = _DEFAULT_MAX_CYCLES,
     interval_seconds: int = _DEFAULT_INTERVAL_SECONDS,
@@ -550,6 +574,8 @@ def collect_soak(
     )
     if not 1 <= probe_timeout_seconds <= _PROBE_TIMEOUT_SECONDS:
         raise EvidenceError("timeout_invalid")
+    if not 2 <= page_parse_timeout_seconds <= 120:
+        raise EvidenceError("page_parse_timeout_invalid")
     source = _resolve_source_vault(source_vault, expected_source_file)
     candidate = _resolve_candidate_python(candidate_python)
     candidate_digest = candidate_verifier(candidate)
@@ -567,7 +593,13 @@ def collect_soak(
             "duration_seconds": duration_seconds,
             "max_cycles": max_cycles,
             "interval_seconds": interval_seconds,
+            "page_parse_timeout_seconds": page_parse_timeout_seconds,
         }
+    )
+    _require_matching_gate_input(
+        resolved_output,
+        gate_id="soak",
+        input_hash=input_hash,
     )
     resolved_output.mkdir(parents=True, exist_ok=True)
     state = _load_state(resolved_output)
@@ -596,6 +628,7 @@ def collect_soak(
             "candidate_provenance_digest": candidate_digest,
             "elapsed_seconds": 0.0,
             "target_duration_seconds": duration_seconds,
+            "page_parse_timeout_seconds": page_parse_timeout_seconds,
             "started_at": _now(),
             "updated_at": _now(),
         }
@@ -605,6 +638,7 @@ def collect_soak(
         or state["status"] != "RUNNING"
         or state["target_duration_seconds"] != duration_seconds
         or state["candidate_provenance_digest"] != candidate_digest
+        or state["page_parse_timeout_seconds"] != page_parse_timeout_seconds
     ):
         raise EvidenceError("soak_resume_mismatch")
     elif not work.is_dir():
@@ -620,7 +654,13 @@ def collect_soak(
             state["completed_cycles"] < max_cycles and state["elapsed_seconds"] < duration_seconds
         ):
             payload = _validate_probe_payload(
-                probe_runner(candidate, work, probe_timeout_seconds, state["completed_cycles"])
+                probe_runner(
+                    candidate,
+                    work,
+                    probe_timeout_seconds,
+                    page_parse_timeout_seconds,
+                    state["completed_cycles"],
+                )
             )
             if _markdown_fingerprint(work) != state["working_markdown_fingerprint"]:
                 raise EvidenceError("working_copy_changed")

--- a/scripts/beta_evidence/wheel.py
+++ b/scripts/beta_evidence/wheel.py
@@ -23,6 +23,7 @@ from .core import (
     _is_within,
     _record_gate,
     _repo_root_from_script,
+    _require_matching_gate_input,
     validate_output_directory,
 )
 
@@ -65,7 +66,13 @@ class CommandRunner(Protocol):
 
 class WheelProbeRunner(Protocol):
     def __call__(
-        self, python: Path, graph_root: Path, *, phase: str, timeout_seconds: int
+        self,
+        python: Path,
+        graph_root: Path,
+        *,
+        phase: str,
+        timeout_seconds: int,
+        page_parse_timeout_seconds: int,
     ) -> dict[str, Any]: ...
 
 
@@ -84,12 +91,15 @@ def _markdown_fingerprint(root: Path) -> str:
     return digest.hexdigest()
 
 
-def _safe_environment(graph_root: Path, *, enabled: bool) -> dict[str, str]:
+def _safe_environment(
+    graph_root: Path, *, enabled: bool, page_parse_timeout_seconds: int
+) -> dict[str, str]:
     environment = {
         name: value for name, value in os.environ.items() if name in _PROCESS_ENV_ALLOWLIST
     }
     environment["LOGSEQ_GRAPH_PATH"] = str(graph_root)
     environment["MATRYCA_SHADOW_DB_ENABLED"] = "1" if enabled else "0"
+    environment["MATRYCA_PAGE_PARSE_TIMEOUT_S"] = str(page_parse_timeout_seconds)
     return environment
 
 
@@ -222,13 +232,22 @@ def _validate_probe_payload(payload: object) -> dict[str, Any]:
 
 
 def _run_wheel_probe(
-    python: Path, graph_root: Path, *, phase: str, timeout_seconds: int
+    python: Path,
+    graph_root: Path,
+    *,
+    phase: str,
+    timeout_seconds: int,
+    page_parse_timeout_seconds: int,
 ) -> dict[str, Any]:
     wrapper = Path(__file__).resolve().parents[1] / "beta_readiness_evidence.py"
     result = _run_command(
         [str(python), str(wrapper), "_wheel-probe", "--vault", str(graph_root), "--phase", phase],
         cwd=Path(tempfile.gettempdir()),
-        environment=_safe_environment(graph_root, enabled=True),
+        environment=_safe_environment(
+            graph_root,
+            enabled=True,
+            page_parse_timeout_seconds=page_parse_timeout_seconds,
+        ),
         timeout_seconds=timeout_seconds,
     )
     _require_command_success(result)
@@ -246,6 +265,7 @@ def _wheel_details(
     source_after: str,
     baseline: dict[str, Any],
     candidate: dict[str, Any],
+    page_parse_timeout_seconds: int,
 ) -> dict[str, Any]:
     return {
         "wheel_sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
@@ -253,6 +273,7 @@ def _wheel_details(
         "source_markdown_count": sum(
             1 for path in source.rglob("*.md") if ".matryca_semantic_cache" not in path.parts
         ),
+        "page_parse_timeout_seconds": page_parse_timeout_seconds,
         "baseline": baseline,
         "candidate": candidate,
     }
@@ -264,6 +285,7 @@ def collect_wheel(
     wheel_path: Path,
     source_vault: Path,
     expected_source_file: Path,
+    page_parse_timeout_seconds: int,
     timeout_seconds: int = _WHEEL_TIMEOUT_SECONDS,
     command_runner: CommandRunner = _run_command,
     probe_runner: WheelProbeRunner = _run_wheel_probe,
@@ -272,6 +294,8 @@ def collect_wheel(
     """Collect isolated baseline-to-wheel evidence without writing the source vault."""
     if not 1 <= timeout_seconds <= 600:
         raise EvidenceError("timeout_invalid")
+    if not 2 <= page_parse_timeout_seconds <= 120:
+        raise EvidenceError("page_parse_timeout_invalid")
     source = _resolve_source_vault(source_vault, expected_source_file)
     wheel = _resolve_candidate_wheel(wheel_path, source)
     resolved_output = validate_output_directory(
@@ -288,7 +312,13 @@ def collect_wheel(
         ).hexdigest(),
         "baseline": _WHEEL_BASELINE,
         "candidate": _WHEEL_CANDIDATE,
+        "page_parse_timeout_seconds": page_parse_timeout_seconds,
     }
+    _require_matching_gate_input(
+        resolved_output,
+        gate_id="wheel",
+        input_hash=_canonical_hash(fingerprint_input),
+    )
     temporary_root: Path | None = None
     try:
         resolved_output.mkdir(parents=True, exist_ok=True)
@@ -300,7 +330,11 @@ def collect_wheel(
         _add_synthetic_probe_pages(working_vault)
         working_before, python = _markdown_fingerprint(working_vault), venv / "bin" / "python"
         environment, cwd = (
-            _safe_environment(working_vault, enabled=True),
+            _safe_environment(
+                working_vault,
+                enabled=True,
+                page_parse_timeout_seconds=page_parse_timeout_seconds,
+            ),
             Path(tempfile.gettempdir()),
         )
         for command in (
@@ -320,7 +354,13 @@ def collect_wheel(
                 )
             )
         baseline = _validate_probe_payload(
-            probe_runner(python, working_vault, phase="baseline", timeout_seconds=timeout_seconds)
+            probe_runner(
+                python,
+                working_vault,
+                phase="baseline",
+                timeout_seconds=timeout_seconds,
+                page_parse_timeout_seconds=page_parse_timeout_seconds,
+            )
         )["baseline"]
         _require_command_success(
             command_runner(
@@ -331,7 +371,13 @@ def collect_wheel(
             )
         )
         candidate = _validate_probe_payload(
-            probe_runner(python, working_vault, phase="candidate", timeout_seconds=timeout_seconds)
+            probe_runner(
+                python,
+                working_vault,
+                phase="candidate",
+                timeout_seconds=timeout_seconds,
+                page_parse_timeout_seconds=page_parse_timeout_seconds,
+            )
         )["candidate"]
         candidate["working_markdown_unchanged"] = (
             candidate["working_markdown_unchanged"]
@@ -344,6 +390,7 @@ def collect_wheel(
             source_after=_markdown_fingerprint(source),
             baseline=baseline,
             candidate=candidate,
+            page_parse_timeout_seconds=page_parse_timeout_seconds,
         )
         checks = [
             details["source_unchanged"],
@@ -364,6 +411,7 @@ def collect_wheel(
         failure = {
             "wheel_sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
             "source_unchanged": source_before == _markdown_fingerprint(source),
+            "page_parse_timeout_seconds": page_parse_timeout_seconds,
             "failure_category": exc.category,
         }
         return _record_gate(

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -394,6 +394,7 @@ def test_wheel_requires_exact_daily_source_fingerprint(tmp_path: Path) -> None:
             wheel_path=wheel,
             source_vault=source,
             expected_source_file=fingerprint,
+            page_parse_timeout_seconds=60,
         )
 
 
@@ -412,6 +413,7 @@ def test_wheel_rejects_source_symlinks(tmp_path: Path) -> None:
             wheel_path=wheel,
             source_vault=source,
             expected_source_file=fingerprint,
+            page_parse_timeout_seconds=60,
         )
 
 
@@ -421,10 +423,13 @@ def test_safe_environment_uses_allowlist(monkeypatch: pytest.MonkeyPatch, tmp_pa
     monkeypatch.setenv("LLM_API_KEY", "secret")
     monkeypatch.setenv("GITHUB_TOKEN", "secret")
     monkeypatch.setenv("PYTHONPATH", "/unsafe/import")
-    environment = wheel_module._safe_environment(tmp_path, enabled=True)
+    environment = wheel_module._safe_environment(
+        tmp_path, enabled=True, page_parse_timeout_seconds=60
+    )
     assert environment["PATH"] == "/safe/bin"
     assert environment["LOGSEQ_GRAPH_PATH"] == str(tmp_path)
     assert environment["MATRYCA_SHADOW_DB_ENABLED"] == "1"
+    assert environment["MATRYCA_PAGE_PARSE_TIMEOUT_S"] == "60"
     assert "LLM_API_KEY" not in environment
     assert "GITHUB_TOKEN" not in environment
     assert "PYTHONPATH" not in environment
@@ -440,6 +445,7 @@ def test_wheel_records_only_sanitized_pass_and_keeps_source_untouched(tmp_path: 
         wheel_path=wheel,
         source_vault=source,
         expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
         command_runner=_successful_command,
         probe_runner=lambda *_args, **_kwargs: _probe_payload(),
     )
@@ -473,6 +479,7 @@ def _code_audit_prerequisites(
         wheel_path=wheel,
         source_vault=source,
         expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
         command_runner=_successful_command,
         probe_runner=lambda *_args, **_kwargs: _probe_payload(),
     )
@@ -562,6 +569,7 @@ def test_report_is_ready_after_collected_code_audit_and_soak(tmp_path: Path) -> 
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "soak-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=1,
             max_cycles=1,
             interval_seconds=0,
@@ -590,15 +598,18 @@ def test_wheel_timeout_and_malformed_probe_record_safe_failures(tmp_path: Path) 
         wheel_path=wheel,
         source_vault=source,
         expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
         command_runner=timeout,
     )
     assert timed_out.status == "FAIL"
     assert timed_out.details["failure_category"] == "command_timeout"
+    assert timed_out.details["page_parse_timeout_seconds"] == 60
     malformed = module.collect_wheel(
         tmp_path / "malformed",
         wheel_path=wheel,
         source_vault=source,
         expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
         command_runner=_successful_command,
         probe_runner=lambda *_args, **_kwargs: {"schema_version": 1},
     )
@@ -622,9 +633,48 @@ def test_wheel_cli_fails_closed_on_source_mismatch(tmp_path: Path) -> None:
         str(source),
         "--expected-source-realpath-file",
         str(fingerprint),
+        "--page-parse-timeout-seconds",
+        "60",
     )
     assert result.returncode == 2
     assert result.stderr.strip() == "beta evidence: source_fingerprint_mismatch"
+
+
+def test_wheel_cli_requires_an_explicit_page_parse_deadline(tmp_path: Path) -> None:
+    source, fingerprint, wheel = _wheel_source(tmp_path)
+    result = _run(
+        "wheel",
+        "--output",
+        str(tmp_path / "evidence"),
+        "--wheel",
+        str(wheel),
+        "--source-vault",
+        str(source),
+        "--expected-source-realpath-file",
+        str(fingerprint),
+    )
+    assert result.returncode == 2
+    assert "--page-parse-timeout-seconds" in result.stderr
+
+
+def test_soak_cli_requires_an_explicit_page_parse_deadline() -> None:
+    cli = importlib.import_module("beta_evidence.cli")
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(
+            [
+                "soak",
+                "--output",
+                "/evidence",
+                "--candidate-python",
+                "/candidate/python",
+                "--source-vault",
+                "/source",
+                "--expected-source-realpath-file",
+                "/source.realpath",
+                "--working-root",
+                "/working",
+            ]
+        )
 
 
 def _soak_payload() -> dict[str, object]:
@@ -654,6 +704,7 @@ def test_soak_persists_only_sanitized_trends_after_explicit_short_duration(tmp_p
         source_vault=source,
         expected_source_file=fingerprint,
         working_root=tmp_path / "durable-copy",
+        page_parse_timeout_seconds=60,
         duration_seconds=1,
         max_cycles=2,
         interval_seconds=0,
@@ -669,6 +720,7 @@ def test_soak_persists_only_sanitized_trends_after_explicit_short_duration(tmp_p
     assert [trend["elapsed_ms"] for trend in state["trends"]] == [12.5, 12.5]
     assert state["source_copy_snapshot_fingerprint"] == source_before
     assert state["source_unchanged_during_copy"] is True
+    assert state["page_parse_timeout_seconds"] == 60
     for artifact in (
         "checkpoint.json",
         "evidence.json",
@@ -685,6 +737,12 @@ def test_soak_persists_only_sanitized_trends_after_explicit_short_duration(tmp_p
         encoding="utf-8"
     )
     assert record.details["beta_qualified"] is False
+    assert record.details["page_parse_timeout_seconds"] == 60
+    result = json.loads((tmp_path / "evidence" / "soak-result.json").read_text(encoding="utf-8"))
+    assert result["page_parse_timeout_seconds"] == 60
+    assert "Page parse timeout seconds: 60" in (
+        tmp_path / "evidence" / "soak-summary.md"
+    ).read_text(encoding="utf-8")
 
 
 def test_soak_rejects_source_symlinks_and_never_creates_working_copy(tmp_path: Path) -> None:
@@ -701,6 +759,7 @@ def test_soak_rejects_source_symlinks_and_never_creates_working_copy(tmp_path: P
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=work,
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=1,
             interval_seconds=0,
@@ -723,6 +782,7 @@ def test_soak_accepts_source_change_between_interrupted_runs(tmp_path: Path) -> 
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=1,
             max_cycles=2,
             interval_seconds=1,
@@ -738,6 +798,7 @@ def test_soak_accepts_source_change_between_interrupted_runs(tmp_path: Path) -> 
         source_vault=source,
         expected_source_file=fingerprint,
         working_root=tmp_path / "durable-copy",
+        page_parse_timeout_seconds=60,
         duration_seconds=1,
         max_cycles=2,
         interval_seconds=1,
@@ -773,6 +834,7 @@ def test_soak_rejects_source_change_during_copy_before_probe(tmp_path: Path) -> 
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=1,
             max_cycles=1,
             interval_seconds=0,
@@ -787,7 +849,9 @@ def test_soak_rejects_working_copy_drift_after_probe(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, _wheel = _wheel_source(tmp_path)
 
-    def mutate_work(_python: Path, work: Path, _timeout: int, _cycle: int) -> dict[str, object]:
+    def mutate_work(
+        _python: Path, work: Path, _timeout: int, _page_parse_timeout: int, _cycle: int
+    ) -> dict[str, object]:
         (work / "pages" / "daily.md").write_text("- leaked fixture\n", encoding="utf-8")
         return _soak_payload()
 
@@ -798,6 +862,7 @@ def test_soak_rejects_working_copy_drift_after_probe(tmp_path: Path) -> None:
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=1,
             interval_seconds=0,
@@ -821,6 +886,7 @@ def test_soak_rejects_candidate_version_mismatch_before_copy(tmp_path: Path) -> 
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=work,
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=1,
             interval_seconds=0,
@@ -843,6 +909,7 @@ def test_soak_rejects_candidate_provenance_change_on_resume(tmp_path: Path) -> N
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=2,
             interval_seconds=1,
@@ -858,6 +925,7 @@ def test_soak_rejects_candidate_provenance_change_on_resume(tmp_path: Path) -> N
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=2,
             interval_seconds=1,
@@ -875,6 +943,7 @@ def test_soak_does_not_pass_before_configured_duration(tmp_path: Path) -> None:
             source_vault=source,
             expected_source_file=fingerprint,
             working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
             duration_seconds=60,
             max_cycles=1,
             interval_seconds=0,
@@ -899,14 +968,139 @@ def test_soak_runs_flag_on_before_non_vacuous_flag_off(monkeypatch: pytest.Monke
         cycle: int,
         enabled: bool,
         timeout_seconds: int,
+        page_parse_timeout_seconds: int,
     ) -> dict[str, object]:
         assert cycle == 0
         assert timeout_seconds == 1
+        assert page_parse_timeout_seconds == 60
         calls.append(enabled)
         if enabled:
             return _soak_payload()
         return {"flag_off": True, "rss_kib": 1}
 
     monkeypatch.setattr(soak, "_run_process", fake_process)
-    soak._run_soak_probe(Path(sys.executable), Path("/unused"), 1, 0)
+    soak._run_soak_probe(Path(sys.executable), Path("/unused"), 1, 60, 0)
     assert calls == [True, False]
+
+
+def test_wheel_deadline_is_hashed_recorded_and_cannot_change_on_resume(tmp_path: Path) -> None:
+    module = _module()
+    source, fingerprint, wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+    record = module.collect_wheel(
+        output,
+        wheel_path=wheel,
+        source_vault=source,
+        expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
+        command_runner=_successful_command,
+        probe_runner=lambda *_args, **_kwargs: _probe_payload(),
+    )
+    assert record.details["page_parse_timeout_seconds"] == 60
+    with pytest.raises(module.EvidenceError, match="gate_resume_mismatch"):
+        module.collect_wheel(
+            output,
+            wheel_path=wheel,
+            source_vault=source,
+            expected_source_file=fingerprint,
+            page_parse_timeout_seconds=61,
+            command_runner=_successful_command,
+            probe_runner=lambda *_args, **_kwargs: _probe_payload(),
+        )
+
+
+def test_wheel_keeps_page_parse_and_subprocess_deadlines_distinct(tmp_path: Path) -> None:
+    module = _module()
+    source, fingerprint, wheel = _wheel_source(tmp_path)
+    command_timeouts: list[int] = []
+    probe_deadlines: list[tuple[int, int]] = []
+
+    def command(
+        *_args: object, timeout_seconds: int, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        command_timeouts.append(timeout_seconds)
+        return _successful_command()
+
+    def probe(
+        *_args: object,
+        timeout_seconds: int,
+        page_parse_timeout_seconds: int,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        probe_deadlines.append((timeout_seconds, page_parse_timeout_seconds))
+        return _probe_payload()
+
+    record = module.collect_wheel(
+        tmp_path / "evidence",
+        wheel_path=wheel,
+        source_vault=source,
+        expected_source_file=fingerprint,
+        page_parse_timeout_seconds=60,
+        timeout_seconds=19,
+        command_runner=command,
+        probe_runner=probe,
+    )
+    assert record.status == "PASS"
+    assert command_timeouts == [19, 19, 19]
+    assert probe_deadlines == [(19, 60), (19, 60)]
+
+
+@pytest.mark.parametrize("value", (1, 121))
+def test_collectors_reject_page_parse_deadlines_outside_bounds(tmp_path: Path, value: int) -> None:
+    module = _module()
+    source, fingerprint, wheel = _wheel_source(tmp_path)
+    with pytest.raises(module.EvidenceError, match="page_parse_timeout_invalid"):
+        module.collect_wheel(
+            tmp_path / "wheel-evidence",
+            wheel_path=wheel,
+            source_vault=source,
+            expected_source_file=fingerprint,
+            page_parse_timeout_seconds=value,
+        )
+    with pytest.raises(module.EvidenceError, match="page_parse_timeout_invalid"):
+        module.collect_soak(
+            tmp_path / "soak-evidence",
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=value,
+        )
+
+
+def test_soak_deadline_change_rejects_an_interrupted_resume(tmp_path: Path) -> None:
+    module = _module()
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+
+    def interrupt(_seconds: float) -> None:
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        module.collect_soak(
+            tmp_path / "evidence",
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
+            duration_seconds=60,
+            max_cycles=2,
+            interval_seconds=1,
+            probe_runner=lambda *_args: _soak_payload(),
+            candidate_verifier=lambda _python: "candidate-digest",
+            clock=iter((0.0, 0.1)).__next__,
+            sleeper=interrupt,
+        )
+    with pytest.raises(module.EvidenceError, match="soak_resume_mismatch"):
+        module.collect_soak(
+            tmp_path / "evidence",
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=61,
+            duration_seconds=60,
+            max_cycles=2,
+            interval_seconds=1,
+            candidate_verifier=lambda _python: "candidate-digest",
+        )


### PR DESCRIPTION
## Summary
- require an explicit 2–120 second page-parse deadline for beta wheel and soak child probes
- inject the selected deadline only into sanitized child environments
- bind it to wheel input hashes and soak state, results, summaries, and resume validation
- retain the 15-second product default and mandatory Markdown/BM25 fallback
- document that a 60-second maintainer evidence deadline does not prove default-15 readiness

## Test plan
- [x] beta-evidence suite (44 passed)
- [x] Ruff and mypy
- [x] `make docs-check`
- [x] `make ci`
- [x] `git diff --check`

## Code audit impact
- HIGH reported by coarse shared-CLI entrypoint attribution and reviewed
- direct impact on `collect_wheel` and `collect_soak` is LOW: one expected caller (`cli.main`) each
- no product runtime/default or vault write-path change

## Known limitation
Some unusually complex pages can exceed the standard deadline. Containment keeps Shadow non-ready and routes reads through the established fallback. Beta evidence will separately record the bounded maintainer deadline used for the real-vault qualification.

Refs #20
Refs #297