### PR TITLE
fix(quality): validate beta wheel provenance against venv prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- **Beta wheel provenance with symlinked interpreters** — validate installed-module provenance against the active virtual-environment prefix instead of the resolved interpreter target, preventing false evidence failures when the venv executable links to a managed Python installation.
 - **Distribution archive hygiene** — release builds exclude Python bytecode and cache directories from wheel and source distributions; CI rejects any that remain.
 - **Catalog merge-save corruption guard (#198)** — `MasterCatalog.save(replace=False)` now aborts after quarantining unreadable or non-object `master_catalog.json` state instead of merging a stale in-memory snapshot with an empty fallback and overwriting unseen catalog rows; explicit `replace=True` remains available for deliberate rebuilds.
 - **Dependency security advisories (Dependabot #28–#31)** — require MCP Python SDK `>=1.28.1` to include task/session isolation and WebSocket transport fixes, and refresh the frontend lock to patched `brace-expansion>=5.0.7`. Matryca's MCP entrypoint remains stdio-only; no HTTP, WebSocket, or experimental task transport is enabled.

--- a/scripts/beta_evidence/wheel.py
+++ b/scripts/beta_evidence/wheel.py
@@ -91,6 +91,17 @@ def _markdown_fingerprint(root: Path) -> str:
     return digest.hexdigest()
 
 
+def _is_imported_from_venv_site_packages(imported: Path, venv_prefix: Path) -> bool:
+    """Require the candidate module to resolve under this virtual environment."""
+    try:
+        module_path = imported.resolve(strict=True)
+        virtual_environment = venv_prefix.resolve(strict=True)
+        relative_module = module_path.relative_to(virtual_environment)
+    except (OSError, ValueError):
+        return False
+    return "site-packages" in relative_module.parts
+
+
 def _safe_environment(
     graph_root: Path, *, enabled: bool, page_parse_timeout_seconds: int
 ) -> dict[str, str]:
@@ -479,12 +490,9 @@ def wheel_probe_main(vault: Path, phase: str) -> int:
         candidate["metadata_version_ok"] = version("matryca-plumber") == _WHEEL_CANDIDATE
         import src as installed_src
 
-        imported, venv_root = (
-            Path(installed_src.__file__ or "").resolve(),
-            Path(sys.executable).resolve().parents[1],
-        )
-        candidate["import_from_site_packages"] = (
-            _is_within(imported, venv_root) and "site-packages" in imported.parts
+        candidate["import_from_site_packages"] = _is_imported_from_venv_site_packages(
+            Path(installed_src.__file__ or ""),
+            Path(sys.prefix),
         )
         candidate["warm_ready"], candidate["generation_preserved"] = (
             resolve_shadow_health(graph) is ShadowHealthState.READY,

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -436,6 +436,28 @@ def test_safe_environment_uses_allowlist(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert set(environment).isdisjoint({"LLM_API_KEY", "GITHUB_TOKEN", "PYTHONPATH"})
 
 
+def test_wheel_provenance_uses_venv_prefix_when_interpreter_is_symlinked(
+    tmp_path: Path,
+) -> None:
+    wheel_module = importlib.import_module("beta_evidence.wheel")
+    base_python = tmp_path / "uv-managed" / "bin" / "python"
+    imported = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "src" / "__init__.py"
+    base_python.parent.mkdir(parents=True)
+    imported.parent.mkdir(parents=True)
+    base_python.touch()
+    imported.touch()
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir()
+    try:
+        venv_python.symlink_to(base_python)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    old_root = venv_python.resolve().parents[1]
+    assert not wheel_module._is_within(imported.resolve(), old_root)
+    assert wheel_module._is_imported_from_venv_site_packages(imported, tmp_path / "venv")
+
+
 def test_wheel_records_only_sanitized_pass_and_keeps_source_untouched(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, wheel = _wheel_source(tmp_path)


### PR DESCRIPTION
## Summary
- validate the installed candidate module against the active virtual-environment prefix
- avoid false provenance failures when a venv interpreter is a symlink to a managed Python installation
- keep provenance validation fail-closed and cover the symlinked-interpreter regression

## Code audit impact
- LOW symbol blast radius: one direct caller in the beta-evidence CLI
- diff-level analysis conservatively includes the existing wheel-probe flows; no daemon, MCP, or user-vault runtime path changes

## Test plan
- [x] focused beta-evidence suite (45 passed)
- [x] Ruff format and lint
- [x] mypy
- [x] `make ci` (1423 passed, 2 skipped, 1 expected xfail; 82.68% coverage)

Refs #20