### PR TITLE
fix(quality): preserve beta soak venv interpreter path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- **Beta soak candidate interpreter provenance** — preserve the requested virtual-environment Python invocation path when it symlinks to a managed interpreter, so soak verification retains the venv's installed site-packages while rejecting non-executable candidates.
 - **Beta wheel provenance with symlinked interpreters** — validate installed-module provenance against the active virtual-environment prefix instead of the resolved interpreter target, preventing false evidence failures when the venv executable links to a managed Python installation.
 - **Distribution archive hygiene** — release builds exclude Python bytecode and cache directories from wheel and source distributions; CI rejects any that remain.
 - **Catalog merge-save corruption guard (#198)** — `MasterCatalog.save(replace=False)` now aborts after quarantining unreadable or non-object `master_catalog.json` state instead of merging a stale in-memory snapshot with an empty fallback and overwriting unseen catalog rows; explicit `replace=True` remains available for deliberate rebuilds.

--- a/scripts/beta_evidence/soak.py
+++ b/scripts/beta_evidence/soak.py
@@ -314,12 +314,12 @@ def _validate_limits(*, duration_seconds: int, max_cycles: int, interval_seconds
 
 def _resolve_candidate_python(candidate_python: Path) -> Path:
     try:
-        resolved = candidate_python.expanduser().resolve(strict=True)
+        candidate = candidate_python.expanduser().absolute()
     except OSError as exc:
         raise EvidenceError("candidate_python_invalid") from exc
-    if not resolved.is_file():
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
         raise EvidenceError("candidate_python_invalid")
-    return resolved
+    return candidate
 
 
 def _verify_candidate_python(candidate_python: Path) -> str:

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import subprocess
 import sys
+import venv
 from pathlib import Path
 from types import ModuleType
 
@@ -456,6 +458,56 @@ def test_wheel_provenance_uses_venv_prefix_when_interpreter_is_symlinked(
     old_root = venv_python.resolve().parents[1]
     assert not wheel_module._is_within(imported.resolve(), old_root)
     assert wheel_module._is_imported_from_venv_site_packages(imported, tmp_path / "venv")
+
+
+def test_soak_candidate_uses_venv_python_symlink_and_its_site_packages(tmp_path: Path) -> None:
+    soak_module = importlib.import_module("beta_evidence.soak")
+    venv_root = tmp_path / "candidate-venv"
+    venv.EnvBuilder(with_pip=False, symlinks=True).create(venv_root)
+    executable = "python.exe" if os.name == "nt" else "python"
+    candidate_python = venv_root / ("Scripts" if os.name == "nt" else "bin") / executable
+    if not candidate_python.is_symlink():
+        pytest.skip("venv Python is not symlinked on this platform")
+
+    site_packages_probe = "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+    site_packages = Path(
+        subprocess.run(
+            [str(candidate_python), "-c", site_packages_probe],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    (site_packages / "src").mkdir(parents=True)
+    (site_packages / "src" / "__init__.py").write_text("", encoding="utf-8")
+    distribution = site_packages / "matryca_plumber-2.0.0b1.dist-info"
+    distribution.mkdir()
+    (distribution / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: matryca-plumber\nVersion: 2.0.0b1\n",
+        encoding="utf-8",
+    )
+    (distribution / "RECORD").write_text(
+        "matryca_plumber-2.0.0b1.dist-info/METADATA,,\n"
+        "matryca_plumber-2.0.0b1.dist-info/RECORD,,\n",
+        encoding="utf-8",
+    )
+
+    resolved = soak_module._resolve_candidate_python(candidate_python)
+
+    assert resolved == candidate_python
+    assert resolved != candidate_python.resolve()
+    assert len(soak_module._verify_candidate_python(resolved)) == 64
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable permission contract")
+def test_soak_rejects_non_executable_candidate_python(tmp_path: Path) -> None:
+    soak_module = importlib.import_module("beta_evidence.soak")
+    candidate_python = tmp_path / "python"
+    candidate_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    candidate_python.chmod(0o600)
+
+    with pytest.raises(soak_module.EvidenceError, match="candidate_python_invalid"):
+        soak_module._resolve_candidate_python(candidate_python)
 
 
 def test_wheel_records_only_sanitized_pass_and_keeps_source_untouched(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve the requested candidate virtual-environment Python path instead of resolving its interpreter symlink
- keep candidate verification bound to the wheel installed in that virtual environment
- reject missing, non-file, or non-executable candidate interpreters
- cover the real symlinked-venv and fail-closed contracts

## Code audit impact
- LOW blast radius: one direct caller in the private beta soak collector
- no daemon, MCP, or user-vault runtime execution flow changes

## Test plan
- [x] beta-evidence tests (47 passed)
- [x] Ruff format and lint
- [x] mypy
- [x] `make ci` (1425 passed, 2 skipped, 1 expected xfail; 82.67% coverage)

Refs #20