### PR TITLE
fix(quality): run and diagnose beta soak flag-off probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- **Beta soak flag-off probe import and failure hygiene** — resolve the Shadow DB path from its connection module so both embedded probes run, while child failures persist only a stable flag-stage category without subprocess diagnostics.
 - **Beta soak candidate interpreter provenance** — preserve the requested virtual-environment Python invocation path when it symlinks to a managed interpreter, so soak verification retains the venv's installed site-packages while rejecting non-executable candidates.
 - **Beta wheel provenance with symlinked interpreters** — validate installed-module provenance against the active virtual-environment prefix instead of the resolved interpreter target, preventing false evidence failures when the venv executable links to a managed Python installation.
 - **Distribution archive hygiene** — release builds exclude Python bytecode and cache directories from wheel and source distributions; CI rejects any that remain.

--- a/scripts/beta_evidence/soak.py
+++ b/scripts/beta_evidence/soak.py
@@ -86,7 +86,8 @@ import sys
 from pathlib import Path
 
 from src.shadow.bootstrap import rebuild_shadow_from_graph
-from src.shadow.config import shadow_db_enabled, shadow_db_path
+from src.shadow.config import shadow_db_enabled
+from src.shadow.connection import shadow_db_path
 from src.shadow.health import ShadowHealthState, resolve_shadow_health
 
 graph = Path(os.environ["LOGSEQ_GRAPH_PATH"])
@@ -384,7 +385,7 @@ def _run_process(
     except OSError as exc:
         raise EvidenceError("probe_launch_failed") from exc
     if completed.returncode != 0:
-        raise EvidenceError("probe_failed")
+        raise EvidenceError("probe_flag_on_failed" if enabled else "probe_flag_off_failed")
     try:
         payload = json.loads(completed.stdout.strip())
     except json.JSONDecodeError as exc:
@@ -701,6 +702,7 @@ def collect_soak(
                 failure_category=exc.category,
             )
         state["status"] = "FAIL"
+        state["last_failure_category"] = exc.category
         state["updated_at"] = _now()
         _write_state(resolved_output, state)
         _write_heartbeat(resolved_output, state)

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -10,6 +10,7 @@ import sys
 import venv
 from pathlib import Path
 from types import ModuleType
+from typing import cast
 
 import pytest
 
@@ -1111,14 +1112,17 @@ def test_soak_process_failure_persists_only_sanitized_probe_stage(tmp_path: Path
         page_parse_timeout_seconds: int,
         cycle: int,
     ) -> dict[str, object]:
-        return soak._run_process(
-            candidate,
-            graph,
-            code,
-            cycle=cycle,
-            enabled=False,
-            timeout_seconds=timeout_seconds,
-            page_parse_timeout_seconds=page_parse_timeout_seconds,
+        return cast(
+            dict[str, object],
+            soak._run_process(
+                candidate,
+                graph,
+                code,
+                cycle=cycle,
+                enabled=False,
+                timeout_seconds=timeout_seconds,
+                page_parse_timeout_seconds=page_parse_timeout_seconds,
+            ),
         )
 
     with pytest.raises(soak.EvidenceError, match="^probe_flag_off_failed$") as raised:

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -1057,6 +1057,97 @@ def test_soak_runs_flag_on_before_non_vacuous_flag_off(monkeypatch: pytest.Monke
     assert calls == [True, False]
 
 
+def test_soak_embedded_probes_run_against_synthetic_graph(tmp_path: Path) -> None:
+    soak = importlib.import_module("beta_evidence.soak")
+    graph = tmp_path / "synthetic-graph"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    (pages / "daily.md").write_text("- synthetic soak graph\n", encoding="utf-8")
+
+    payload = soak._run_soak_probe(Path(sys.executable), graph, 60, 60, 0)
+
+    assert payload["flag_off"] is True
+    assert payload["flag_on"] is True
+    assert payload["restart_health"] is True
+    assert payload["fts"] is True
+    assert payload["subtree"] == "PASS"
+    assert payload["synthetic_crud"] == "PASS"
+    assert payload["recovery"] is True
+
+
+def test_soak_process_failure_persists_only_sanitized_probe_stage(tmp_path: Path) -> None:
+    soak = importlib.import_module("beta_evidence.soak")
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+    raw_secret = "do-not-persist-child-secret"
+    raw_path = "/private/do-not-persist/child-path"
+    raw_message = "do-not-persist-child-message"
+    code = (
+        "import sys; "
+        f"print({raw_secret!r}); "
+        f"print({raw_path!r}, file=sys.stderr); "
+        f"raise RuntimeError({raw_message!r})"
+    )
+
+    with pytest.raises(soak.EvidenceError, match="^probe_flag_on_failed$") as on_raised:
+        soak._run_process(
+            Path(sys.executable),
+            tmp_path,
+            code,
+            cycle=0,
+            enabled=True,
+            timeout_seconds=1,
+            page_parse_timeout_seconds=60,
+        )
+    assert str(on_raised.value) == "probe_flag_on_failed"
+    assert raw_secret not in str(on_raised.value)
+    assert raw_path not in str(on_raised.value)
+    assert raw_message not in str(on_raised.value)
+
+    def failing_probe(
+        candidate: Path,
+        graph: Path,
+        timeout_seconds: int,
+        page_parse_timeout_seconds: int,
+        cycle: int,
+    ) -> dict[str, object]:
+        return soak._run_process(
+            candidate,
+            graph,
+            code,
+            cycle=cycle,
+            enabled=False,
+            timeout_seconds=timeout_seconds,
+            page_parse_timeout_seconds=page_parse_timeout_seconds,
+        )
+
+    with pytest.raises(soak.EvidenceError, match="^probe_flag_off_failed$") as raised:
+        soak.collect_soak(
+            output,
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "durable-copy",
+            page_parse_timeout_seconds=60,
+            duration_seconds=1,
+            max_cycles=1,
+            interval_seconds=0,
+            probe_runner=failing_probe,
+            candidate_verifier=lambda _python: "candidate-digest",
+            clock=lambda: 0.0,
+        )
+
+    assert str(raised.value) == "probe_flag_off_failed"
+    state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "FAIL"
+    assert state["last_failure_category"] == "probe_flag_off_failed"
+    for artifact in ("soak-state.json", "soak-heartbeat.json"):
+        evidence = (output / artifact).read_text(encoding="utf-8")
+        assert raw_secret not in evidence
+        assert raw_path not in evidence
+        assert raw_message not in evidence
+
+
 def test_wheel_deadline_is_hashed_recorded_and_cannot_change_on_resume(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, wheel = _wheel_source(tmp_path)


### PR DESCRIPTION
## Summary

- import the Shadow database path from its owning connection module in the embedded flag-off probe
- classify nonzero child exits by flag-on/flag-off stage without persisting subprocess output
- persist a stable failure category even when the first cycle fails
- execute both real embedded probes on a synthetic graph in tests

## Root cause

The flag-on phase completed, but the following flag-off child imported `shadow_db_path` from the configuration module instead of the connection module. The collector then collapsed the resulting import failure into a generic category, obscuring the phase that failed.

## Test plan

- [x] `uv run --extra dev pytest --no-cov tests/test_beta_readiness_evidence.py -q` (49 passed)
- [x] ruff check and format check
- [x] mypy on `scripts/beta_evidence/soak.py`
- [x] privacy assertions prove child output, paths, and messages are not persisted
- [x] code audit: expected evidence-collector scope; one affected collection flow

Refs #20