### PR TITLE
fix(quality): make beta soak failures resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Fixed
 
-- **Beta soak flag-off probe import and failure hygiene** — resolve the Shadow DB path from its connection module so both embedded probes run, while child failures persist only a stable flag-stage category without subprocess diagnostics.
+- **Beta soak flag-off probe import and failure hygiene** — resolve the Shadow DB path from its connection module so both embedded probes run; persist only stable phase categories without subprocess diagnostics; and resume recoverable ON/OFF probe failures from integrity-checked, corruption-detecting sanitized state without treating a partial pair as a completed trend.
 - **Beta soak candidate interpreter provenance** — preserve the requested virtual-environment Python invocation path when it symlinks to a managed interpreter, so soak verification retains the venv's installed site-packages while rejecting non-executable candidates.
 - **Beta wheel provenance with symlinked interpreters** — validate installed-module provenance against the active virtual-environment prefix instead of the resolved interpreter target, preventing false evidence failures when the venv executable links to a managed Python installation.
 - **Distribution archive hygiene** — release builds exclude Python bytecode and cache directories from wheel and source distributions; CI rejects any that remain.

--- a/scripts/beta_evidence/soak.py
+++ b/scripts/beta_evidence/soak.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -33,7 +34,7 @@ from .wheel import (
     _safe_environment,
 )
 
-_SOAK_SCHEMA_VERSION = 1
+_SOAK_SCHEMA_VERSION = 2
 _DEFAULT_DURATION_SECONDS = 24 * 60 * 60
 _DEFAULT_MAX_CYCLES = 145
 _DEFAULT_INTERVAL_SECONDS = 10 * 60
@@ -41,6 +42,7 @@ _MAX_DURATION_SECONDS = 7 * 24 * 60 * 60
 _MAX_CYCLES = 10_080
 _MAX_INTERVAL_SECONDS = 60 * 60
 _PROBE_TIMEOUT_SECONDS = 900
+_ATTEMPT_HISTORY_LIMIT = 2 * _MAX_CYCLES + 2
 _STATE_FILE = "soak-state.json"
 _HEARTBEAT_FILE = "soak-heartbeat.json"
 _RESULT_FILE = "soak-result.json"
@@ -51,6 +53,27 @@ type Clock = Callable[[], float]
 type Sleeper = Callable[[float], None]
 type Copier = Callable[[Path, Path], None]
 type CandidateVerifier = Callable[[Path], str]
+
+_PHASES = ("ON", "OFF")
+_RECOVERABLE_FAILURE_CATEGORIES = frozenset(
+    {
+        "probe_timeout",
+        "probe_launch_failed",
+        "probe_flag_on_failed",
+        "probe_flag_off_failed",
+        "probe_payload_invalid",
+        "probe_invalid",
+    }
+)
+_SAFE_CATEGORY = re.compile(r"[a-z0-9_]{1,80}")
+_LEGACY_TREND_FIELDS = (
+    "source_count",
+    "indexed_count",
+    "rss_kib",
+    "elapsed_ms",
+    "subtree",
+    "synthetic_crud",
+)
 
 _CANDIDATE_PROBE = f"""
 import hashlib
@@ -262,6 +285,8 @@ def _load_state(output: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     state = _load_json(path, category="soak_state_invalid")
+    if state.get("schema_version") == 1:
+        return _migrate_v1_running_state(state)
     if state.get("schema_version") != _SOAK_SCHEMA_VERSION:
         raise EvidenceError("soak_state_invalid")
     if not (
@@ -277,15 +302,131 @@ def _load_state(output: Path) -> dict[str, Any] | None:
         and not isinstance(state.get("elapsed_seconds"), bool)
         and isinstance(state.get("target_duration_seconds"), int)
         and isinstance(state.get("page_parse_timeout_seconds"), int)
+        and state.get("next_phase") in _PHASES
+        and isinstance(state.get("attempt_history"), list)
+        and isinstance(state.get("attempt_cursor"), str)
     ):
         raise EvidenceError("soak_state_invalid")
-    if state["completed_cycles"] < 0 or state["status"] not in {"RUNNING", "PASS", "FAIL"}:
+    if state["completed_cycles"] < 0 or state["status"] not in {"RUNNING", "READY", "PASS", "FAIL"}:
         raise EvidenceError("soak_state_invalid")
     if not 2 <= state["page_parse_timeout_seconds"] <= 120:
         raise EvidenceError("soak_state_invalid")
     if not all(isinstance(item, dict) for item in state["trends"]):
         raise EvidenceError("soak_state_invalid")
+    _validate_attempt_history(state)
     return state
+
+
+def _attempt_digest(previous_digest: str, attempt: Mapping[str, object]) -> str:
+    return _canonical_hash({"previous_digest": previous_digest, **attempt})
+
+
+def _append_attempt(
+    state: dict[str, Any],
+    *,
+    phase: str,
+    outcome: str,
+    category: str | None = None,
+) -> None:
+    if len(state["attempt_history"]) >= _ATTEMPT_HISTORY_LIMIT:
+        raise EvidenceError("soak_attempt_limit")
+    if phase not in (*_PHASES, "legacy_combined") or outcome not in {"PASS", "FAIL"}:
+        raise EvidenceError("soak_state_invalid")
+    if category is not None and _SAFE_CATEGORY.fullmatch(category) is None:
+        raise EvidenceError("soak_state_invalid")
+    previous_digest = str(state["attempt_cursor"])
+    attempt: dict[str, object] = {
+        "sequence": len(state["attempt_history"]),
+        "cycle": state["completed_cycles"],
+        "phase": phase,
+        "outcome": outcome,
+    }
+    if category is not None:
+        attempt["category"] = category
+    attempt["previous_digest"] = previous_digest
+    attempt["digest"] = _attempt_digest(previous_digest, attempt)
+    state["attempt_history"].append(attempt)
+    state["attempt_cursor"] = str(attempt["digest"])
+
+
+def _validate_attempt_history(state: Mapping[str, Any]) -> None:
+    if len(state["attempt_history"]) > _ATTEMPT_HISTORY_LIMIT:
+        raise EvidenceError("soak_state_invalid")
+    cursor = ""
+    for sequence, attempt in enumerate(state["attempt_history"]):
+        if not isinstance(attempt, dict):
+            raise EvidenceError("soak_state_invalid")
+        allowed = {"sequence", "cycle", "phase", "outcome", "previous_digest", "digest"}
+        if "category" in attempt:
+            allowed.add("category")
+        if set(attempt) != allowed:
+            raise EvidenceError("soak_state_invalid")
+        if (
+            attempt.get("sequence") != sequence
+            or not isinstance(attempt.get("cycle"), int)
+            or attempt["cycle"] < 0
+            or attempt.get("phase") not in (*_PHASES, "legacy_combined")
+            or attempt.get("outcome") not in {"PASS", "FAIL"}
+            or attempt.get("previous_digest") != cursor
+            or not isinstance(attempt.get("digest"), str)
+            or (
+                "category" in attempt
+                and (
+                    not isinstance(attempt["category"], str)
+                    or _SAFE_CATEGORY.fullmatch(attempt["category"]) is None
+                )
+            )
+        ):
+            raise EvidenceError("soak_state_invalid")
+        unsigned_attempt = {key: value for key, value in attempt.items() if key != "digest"}
+        expected = _attempt_digest(cursor, unsigned_attempt)
+        if attempt["digest"] != expected:
+            raise EvidenceError("soak_state_invalid")
+        cursor = attempt["digest"]
+    if state["attempt_cursor"] != cursor:
+        raise EvidenceError("soak_state_invalid")
+
+
+def _migrate_v1_running_state(state: dict[str, Any]) -> dict[str, Any]:
+    if (
+        state.get("status") != "RUNNING"
+        or not isinstance(state.get("completed_cycles"), int)
+        or isinstance(state.get("completed_cycles"), bool)
+        or not isinstance(state.get("trends"), list)
+        or state["completed_cycles"] != len(state["trends"])
+    ):
+        raise EvidenceError("soak_state_invalid")
+    migrated = dict(state)
+    migrated["schema_version"] = _SOAK_SCHEMA_VERSION
+    migrated["next_phase"] = "ON"
+    migrated["attempt_history"] = []
+    migrated["attempt_cursor"] = ""
+    legacy_trends: list[dict[str, object]] = []
+    for index, trend in enumerate(migrated["trends"]):
+        if not isinstance(trend, dict) or set(trend) != set(_LEGACY_TREND_FIELDS):
+            raise EvidenceError("soak_state_invalid")
+        if trend["subtree"] not in {"PASS", "SKIPPED"} or trend["synthetic_crud"] not in {
+            "PASS",
+            "SKIPPED",
+        }:
+            raise EvidenceError("soak_state_invalid")
+        legacy_trends.append(
+            {
+                "phase": "legacy_combined",
+                "source_count": _nonnegative_int(trend, "source_count"),
+                "indexed_count": _nonnegative_int(trend, "indexed_count"),
+                "rss_kib": _nonnegative_int(trend, "rss_kib"),
+                "elapsed_ms": _nonnegative_number(trend, "elapsed_ms"),
+                "subtree": trend["subtree"],
+                "synthetic_crud": trend["synthetic_crud"],
+            }
+        )
+        migrated["completed_cycles"] = index
+        _append_attempt(migrated, phase="legacy_combined", outcome="PASS")
+    migrated["trends"] = legacy_trends
+    migrated["completed_cycles"] = len(legacy_trends)
+    _validate_attempt_history(migrated)
+    return migrated
 
 
 def _write_state(output: Path, state: dict[str, Any]) -> None:
@@ -299,6 +440,8 @@ def _write_heartbeat(output: Path, state: Mapping[str, Any]) -> None:
             "schema_version": _SOAK_SCHEMA_VERSION,
             "status": state["status"],
             "completed_cycles": state["completed_cycles"],
+            "next_phase": state["next_phase"],
+            "attempt_cursor": state["attempt_cursor"],
             "updated_at": state["updated_at"],
         },
     )
@@ -427,6 +570,50 @@ def _nonnegative_number(payload: Mapping[str, object], name: str) -> float | int
     return value
 
 
+def _run_soak_phase(
+    candidate_python: Path,
+    working_root: Path,
+    timeout_seconds: int,
+    page_parse_timeout_seconds: int,
+    cycle: int,
+    phase: str,
+) -> dict[str, object]:
+    if phase == "ON":
+        return _run_process(
+            candidate_python,
+            working_root,
+            _ON_PROBE,
+            cycle=cycle,
+            enabled=True,
+            timeout_seconds=timeout_seconds,
+            page_parse_timeout_seconds=page_parse_timeout_seconds,
+        )
+    if phase == "OFF":
+        return _run_process(
+            candidate_python,
+            working_root,
+            _OFF_PROBE,
+            cycle=cycle,
+            enabled=False,
+            timeout_seconds=timeout_seconds,
+            page_parse_timeout_seconds=page_parse_timeout_seconds,
+        )
+    raise EvidenceError("soak_state_invalid")
+
+
+def _validate_phase_payload(phase: str, payload: Mapping[str, object]) -> dict[str, object]:
+    if phase == "ON":
+        validated = _validate_probe_payload({**payload, "flag_off": True, "elapsed_ms": 0.0})
+        return {
+            name: validated[name] for name in validated if name not in {"flag_off", "elapsed_ms"}
+        }
+    if phase == "OFF":
+        if payload.get("flag_off") is not True:
+            raise EvidenceError("probe_invalid")
+        return {"flag_off": True, "rss_kib": _nonnegative_int(payload, "rss_kib")}
+    raise EvidenceError("soak_state_invalid")
+
+
 def _run_soak_probe(
     candidate_python: Path,
     working_root: Path,
@@ -435,23 +622,27 @@ def _run_soak_probe(
     cycle: int,
 ) -> dict[str, object]:
     started = time.monotonic()
-    on = _run_process(
-        candidate_python,
-        working_root,
-        _ON_PROBE,
-        cycle=cycle,
-        enabled=True,
-        timeout_seconds=timeout_seconds,
-        page_parse_timeout_seconds=page_parse_timeout_seconds,
+    on = _validate_phase_payload(
+        "ON",
+        _run_soak_phase(
+            candidate_python,
+            working_root,
+            timeout_seconds,
+            page_parse_timeout_seconds,
+            cycle,
+            "ON",
+        ),
     )
-    off = _run_process(
-        candidate_python,
-        working_root,
-        _OFF_PROBE,
-        cycle=cycle,
-        enabled=False,
-        timeout_seconds=timeout_seconds,
-        page_parse_timeout_seconds=page_parse_timeout_seconds,
+    off = _validate_phase_payload(
+        "OFF",
+        _run_soak_phase(
+            candidate_python,
+            working_root,
+            timeout_seconds,
+            page_parse_timeout_seconds,
+            cycle,
+            "OFF",
+        ),
     )
     payload = {**off, **on, "elapsed_ms": round((time.monotonic() - started) * 1000, 3)}
     validated = _validate_probe_payload(payload)
@@ -463,23 +654,46 @@ def _run_soak_probe(
     return validated
 
 
+def _checkpoint_phase(
+    output: Path,
+    state: dict[str, Any],
+    *,
+    phase: str,
+    outcome: str,
+    next_phase: str,
+    category: str | None = None,
+) -> None:
+    _append_attempt(state, phase=phase, outcome=outcome, category=category)
+    state["next_phase"] = next_phase
+    state["updated_at"] = _now()
+    _write_state(output, state)
+    _write_heartbeat(output, state)
+
+
+def _working_copy_is_intact(work: Path, state: Mapping[str, Any]) -> bool:
+    return work.is_dir() and _markdown_fingerprint(work) == state["working_markdown_fingerprint"]
+
+
 def _trend(payload: Mapping[str, object]) -> dict[str, object]:
     return {
-        name: payload[name]
-        for name in (
-            "source_count",
-            "indexed_count",
-            "rss_kib",
-            "elapsed_ms",
-            "subtree",
-            "synthetic_crud",
-        )
+        "phase": "combined",
+        **{
+            name: payload[name]
+            for name in (
+                "source_count",
+                "indexed_count",
+                "rss_kib",
+                "elapsed_ms",
+                "subtree",
+                "synthetic_crud",
+            )
+        },
     }
 
 
 def _summary_details(state: Mapping[str, Any]) -> dict[str, object]:
     trends = state["trends"]
-    if not isinstance(trends, list) or not trends:
+    if not isinstance(trends, list):
         raise EvidenceError("soak_state_invalid")
     numeric = ("source_count", "indexed_count", "rss_kib", "elapsed_ms")
     details: dict[str, object] = {
@@ -496,9 +710,14 @@ def _summary_details(state: Mapping[str, Any]) -> dict[str, object]:
         "subtree_checks": sum(item["subtree"] == "PASS" for item in trends),
         "subtree_skipped": sum(item["subtree"] == "SKIPPED" for item in trends),
         "synthetic_crud_checks": sum(item["synthetic_crud"] == "PASS" for item in trends),
+        "attempts_recorded": len(state["attempt_history"]),
     }
     for name in numeric:
         values = [item[name] for item in trends]
+        if not values:
+            details[f"{name}_min"] = None
+            details[f"{name}_max"] = None
+            continue
         if not all(
             isinstance(value, (int, float)) and not isinstance(value, bool) for value in values
         ):
@@ -520,8 +739,13 @@ def _render_summary(result: Mapping[str, object]) -> str:
         f"Source unchanged during copy: {result['source_unchanged_during_copy']}",
         f"FTS/subtree checks: {result['subtree_checks']} pass, {result['subtree_skipped']} skipped",
         f"Synthetic CRUD checks: {result['synthetic_crud_checks']} pass",
-        f"RSS KiB range: {result['rss_kib_min']}–{result['rss_kib_max']}",
-        f"Probe timing ms range: {result['elapsed_ms_min']}–{result['elapsed_ms_max']}",
+        f"Attempts recorded: {result['attempts_recorded']}",
+        "RSS KiB range: "
+        f"{result['rss_kib_min'] if result['rss_kib_min'] is not None else 'not observed'}–"
+        f"{result['rss_kib_max'] if result['rss_kib_max'] is not None else 'not observed'}",
+        "Probe timing ms range: "
+        f"{result['elapsed_ms_min'] if result['elapsed_ms_min'] is not None else 'not observed'}–"
+        f"{result['elapsed_ms_max'] if result['elapsed_ms_max'] is not None else 'not observed'}",
         "",
     ]
     return "\n".join(lines)
@@ -623,6 +847,9 @@ def collect_soak(
             "status": "RUNNING",
             "completed_cycles": 0,
             "trends": [],
+            "next_phase": "ON",
+            "attempt_history": [],
+            "attempt_cursor": "",
             "source_copy_snapshot_fingerprint": source_before,
             "source_unchanged_during_copy": True,
             "working_markdown_fingerprint": working_snapshot,
@@ -636,35 +863,108 @@ def collect_soak(
         _write_state(resolved_output, state)
     elif (
         state["input_hash"] != input_hash
-        or state["status"] != "RUNNING"
+        or state["status"] not in {"RUNNING", "READY"}
         or state["target_duration_seconds"] != duration_seconds
         or state["candidate_provenance_digest"] != candidate_digest
         or state["page_parse_timeout_seconds"] != page_parse_timeout_seconds
     ):
         raise EvidenceError("soak_resume_mismatch")
-    elif not work.is_dir():
-        raise EvidenceError("working_copy_missing")
-    elif _markdown_fingerprint(work) != state["working_markdown_fingerprint"]:
-        raise EvidenceError("working_copy_changed")
+    elif not _working_copy_is_intact(work, state):
+        return _finish(
+            resolved_output,
+            state,
+            status="FAIL",
+            failure_category=(
+                "working_copy_missing" if not work.is_dir() else "working_copy_changed"
+            ),
+        )
+    if len(state["attempt_history"]) >= _ATTEMPT_HISTORY_LIMIT:
+        return _finish(
+            resolved_output,
+            state,
+            status="FAIL",
+            failure_category="soak_attempt_limit",
+        )
 
     started = clock()
     checkpoint_clock = started
+    state["status"] = "RUNNING"
+    if state["next_phase"] == "OFF":
+        # A process may have stopped after the ON checkpoint. A resumed cycle is
+        # deliberately restarted from ON so no partial pair can become a trend.
+        _checkpoint_phase(
+            resolved_output,
+            state,
+            phase="OFF",
+            outcome="FAIL",
+            category="probe_interrupted",
+            next_phase="ON",
+        )
     _write_heartbeat(resolved_output, state)
-    try:
-        while (
-            state["completed_cycles"] < max_cycles and state["elapsed_seconds"] < duration_seconds
-        ):
-            payload = _validate_probe_payload(
+    legacy_pair: dict[str, object] | None = None
+
+    def run_phase(phase: str) -> dict[str, object]:
+        nonlocal legacy_pair
+        cycle = int(state["completed_cycles"])
+        if probe_runner is _run_soak_probe:
+            return _validate_phase_payload(
+                phase,
+                _run_soak_phase(
+                    candidate,
+                    work,
+                    probe_timeout_seconds,
+                    page_parse_timeout_seconds,
+                    cycle,
+                    phase,
+                ),
+            )
+        if legacy_pair is None:
+            legacy_pair = _validate_probe_payload(
                 probe_runner(
                     candidate,
                     work,
                     probe_timeout_seconds,
                     page_parse_timeout_seconds,
-                    state["completed_cycles"],
+                    cycle,
                 )
             )
-            if _markdown_fingerprint(work) != state["working_markdown_fingerprint"]:
+        return _validate_phase_payload(phase, legacy_pair)
+
+    try:
+        while (
+            state["completed_cycles"] < max_cycles and state["elapsed_seconds"] < duration_seconds
+        ):
+            legacy_pair = None
+            pair_started = time.monotonic()
+            on = run_phase("ON")
+            if not _working_copy_is_intact(work, state):
                 raise EvidenceError("working_copy_changed")
+            _checkpoint_phase(
+                resolved_output,
+                state,
+                phase="ON",
+                outcome="PASS",
+                next_phase="OFF",
+            )
+            off = run_phase("OFF")
+            if not _working_copy_is_intact(work, state):
+                raise EvidenceError("working_copy_changed")
+            _checkpoint_phase(
+                resolved_output,
+                state,
+                phase="OFF",
+                outcome="PASS",
+                next_phase="ON",
+            )
+            elapsed_ms = (
+                legacy_pair["elapsed_ms"]
+                if legacy_pair is not None
+                else round((time.monotonic() - pair_started) * 1000, 3)
+            )
+            payload = _validate_probe_payload({**off, **on, "elapsed_ms": elapsed_ms})
+            payload["rss_kib"] = max(
+                _nonnegative_int(on, "rss_kib"), _nonnegative_int(off, "rss_kib")
+            )
             current_clock = clock()
             state["elapsed_seconds"] += max(0.0, current_clock - checkpoint_clock)
             checkpoint_clock = current_clock
@@ -678,7 +978,7 @@ def collect_soak(
                 and state["elapsed_seconds"] < duration_seconds
             ):
                 sleeper(float(interval_seconds))
-        if _markdown_fingerprint(work) != state["working_markdown_fingerprint"]:
+        if not _working_copy_is_intact(work, state):
             raise EvidenceError("working_copy_changed")
         if state["elapsed_seconds"] < duration_seconds:
             state["last_failure_category"] = "duration_incomplete"
@@ -694,16 +994,25 @@ def collect_soak(
     except EvidenceError as exc:
         if exc.category == "duration_incomplete":
             raise
-        if state["trends"]:
-            return _finish(
+        phase = str(state["next_phase"])
+        if exc.category in _RECOVERABLE_FAILURE_CATEGORIES and _working_copy_is_intact(work, state):
+            _checkpoint_phase(
                 resolved_output,
                 state,
-                status="FAIL",
-                failure_category=exc.category,
+                phase=phase,
+                outcome="FAIL",
+                category=exc.category,
+                next_phase="ON",
             )
-        state["status"] = "FAIL"
-        state["last_failure_category"] = exc.category
-        state["updated_at"] = _now()
-        _write_state(resolved_output, state)
-        _write_heartbeat(resolved_output, state)
-        raise
+            state["status"] = "RUNNING"
+            state["last_failure_category"] = exc.category
+            state["updated_at"] = _now()
+            _write_state(resolved_output, state)
+            _write_heartbeat(resolved_output, state)
+            raise
+        return _finish(
+            resolved_output,
+            state,
+            status="FAIL",
+            failure_category=exc.category,
+        )

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -10,7 +10,7 @@ import sys
 import venv
 from pathlib import Path
 from types import ModuleType
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -768,6 +768,33 @@ def _soak_payload() -> dict[str, object]:
     }
 
 
+def _soak_phase_payload(phase: str) -> dict[str, object]:
+    payload = _soak_payload()
+    if phase == "ON":
+        return {
+            name: value for name, value in payload.items() if name not in {"flag_off", "elapsed_ms"}
+        }
+    return {"flag_off": True, "rss_kib": 64}
+
+
+def _collect_test_soak(
+    module: ModuleType, output: Path, source: Path, fingerprint: Path, **overrides: Any
+) -> Any:
+    arguments: dict[str, Any] = {
+        "candidate_python": Path(sys.executable),
+        "source_vault": source,
+        "expected_source_file": fingerprint,
+        "working_root": output.parent / "durable-copy",
+        "page_parse_timeout_seconds": 60,
+        "duration_seconds": 1,
+        "max_cycles": 1,
+        "interval_seconds": 0,
+        "candidate_verifier": lambda _python: "candidate-digest",
+    }
+    arguments.update(overrides)
+    return module.collect_soak(output, **arguments)
+
+
 def test_soak_persists_only_sanitized_trends_after_explicit_short_duration(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, _wheel = _wheel_source(tmp_path)
@@ -930,20 +957,21 @@ def test_soak_rejects_working_copy_drift_after_probe(tmp_path: Path) -> None:
         (work / "pages" / "daily.md").write_text("- leaked fixture\n", encoding="utf-8")
         return _soak_payload()
 
-    with pytest.raises(module.EvidenceError, match="working_copy_changed"):
-        module.collect_soak(
-            tmp_path / "evidence",
-            candidate_python=Path(sys.executable),
-            source_vault=source,
-            expected_source_file=fingerprint,
-            working_root=tmp_path / "durable-copy",
-            page_parse_timeout_seconds=60,
-            duration_seconds=60,
-            max_cycles=1,
-            interval_seconds=0,
-            probe_runner=mutate_work,
-            candidate_verifier=lambda _python: "candidate-digest",
-        )
+    record = module.collect_soak(
+        tmp_path / "evidence",
+        candidate_python=Path(sys.executable),
+        source_vault=source,
+        expected_source_file=fingerprint,
+        working_root=tmp_path / "durable-copy",
+        page_parse_timeout_seconds=60,
+        duration_seconds=60,
+        max_cycles=1,
+        interval_seconds=0,
+        probe_runner=mutate_work,
+        candidate_verifier=lambda _python: "candidate-digest",
+    )
+    assert record.status == "FAIL"
+    assert record.details["failure_category"] == "working_copy_changed"
 
 
 def test_soak_rejects_candidate_version_mismatch_before_copy(tmp_path: Path) -> None:
@@ -1126,30 +1154,265 @@ def test_soak_process_failure_persists_only_sanitized_probe_stage(tmp_path: Path
         )
 
     with pytest.raises(soak.EvidenceError, match="^probe_flag_off_failed$") as raised:
-        soak.collect_soak(
+        _collect_test_soak(
+            soak,
             output,
-            candidate_python=Path(sys.executable),
-            source_vault=source,
-            expected_source_file=fingerprint,
-            working_root=tmp_path / "durable-copy",
-            page_parse_timeout_seconds=60,
-            duration_seconds=1,
-            max_cycles=1,
-            interval_seconds=0,
+            source,
+            fingerprint,
             probe_runner=failing_probe,
-            candidate_verifier=lambda _python: "candidate-digest",
             clock=lambda: 0.0,
         )
 
     assert str(raised.value) == "probe_flag_off_failed"
     state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
-    assert state["status"] == "FAIL"
+    assert state["status"] == "RUNNING"
+    assert state["completed_cycles"] == 0
     assert state["last_failure_category"] == "probe_flag_off_failed"
+    assert state["attempt_history"][-1]["category"] == "probe_flag_off_failed"
     for artifact in ("soak-state.json", "soak-heartbeat.json"):
         evidence = (output / artifact).read_text(encoding="utf-8")
         assert raw_secret not in evidence
         assert raw_path not in evidence
         assert raw_message not in evidence
+
+    record = _collect_test_soak(
+        soak,
+        output,
+        source,
+        fingerprint,
+        probe_runner=lambda *_args: _soak_payload(),
+        clock=iter((0.0, 1.0)).__next__,
+    )
+    assert record.status == "PASS"
+    integrity_state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
+    integrity_state["attempt_history"][0]["outcome"] = "PASS"
+    previous_digest = ""
+    for attempt in integrity_state["attempt_history"]:
+        attempt["previous_digest"] = previous_digest
+        attempt["digest"] = soak._attempt_digest(
+            previous_digest, {key: value for key, value in attempt.items() if key != "digest"}
+        )
+        previous_digest = attempt["digest"]
+    integrity_state["attempt_cursor"] = previous_digest
+    (output / "soak-state.json").write_text(json.dumps(integrity_state), encoding="utf-8")
+    assert soak._load_state(output) is not None
+    integrity_state["attempt_history"][0]["outcome"] = "FAIL"
+    (output / "soak-state.json").write_text(json.dumps(integrity_state), encoding="utf-8")
+    with pytest.raises(soak.EvidenceError, match="^soak_state_invalid$"):
+        _collect_test_soak(soak, output, source, fingerprint, clock=lambda: 0.0)
+
+
+def test_soak_attempt_history_limit_finishes_without_unbounded_growth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak = importlib.import_module("beta_evidence.soak")
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+
+    def fail_phase(*_args: object) -> dict[str, object]:
+        raise module.EvidenceError("probe_timeout")
+
+    monkeypatch.setattr(soak, "_ATTEMPT_HISTORY_LIMIT", 2)
+    monkeypatch.setattr(soak, "_run_soak_phase", fail_phase)
+    for _ in range(2):
+        with pytest.raises(module.EvidenceError, match="^probe_timeout$"):
+            _collect_test_soak(module, output, source, fingerprint, clock=lambda: 0.0)
+    record = _collect_test_soak(module, output, source, fingerprint, clock=lambda: 0.0)
+    state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
+    assert record.status == "FAIL"
+    assert record.details["failure_category"] == "soak_attempt_limit"
+    assert len(state["attempt_history"]) == 2
+
+
+def test_soak_interrupt_between_phases_restarts_the_whole_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak_module = importlib.import_module("beta_evidence.soak")
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    calls: list[tuple[int, str]] = []
+    raw_secret = "never-store-phase-payload"
+    interrupted = False
+
+    def phases(
+        _python: Path, _work: Path, _timeout: int, _parse_timeout: int, cycle: int, phase: str
+    ) -> dict[str, object]:
+        nonlocal interrupted
+        calls.append((cycle, phase))
+        if phase == "OFF" and not interrupted:
+            interrupted = True
+            raise KeyboardInterrupt
+        payload = _soak_phase_payload(phase)
+        payload["untrusted_detail"] = raw_secret
+        return payload
+
+    output = tmp_path / "evidence"
+    monkeypatch.setattr(soak_module, "_run_soak_phase", phases)
+    monkeypatch.setattr(soak_module.time, "monotonic", iter((10.0, 20.0, 20.125)).__next__)
+    with pytest.raises(KeyboardInterrupt):
+        _collect_test_soak(
+            module,
+            output,
+            source,
+            fingerprint,
+            clock=lambda: 0.0,
+        )
+    interrupted_state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
+    assert interrupted_state["next_phase"] == "OFF"
+    assert interrupted_state["trends"] == []
+    assert [attempt["phase"] for attempt in interrupted_state["attempt_history"]] == ["ON"]
+
+    record = _collect_test_soak(
+        module,
+        output,
+        source,
+        fingerprint,
+        clock=iter((0.0, 1.0)).__next__,
+    )
+    assert record.status == "PASS"
+    state = json.loads((output / "soak-state.json").read_text(encoding="utf-8"))
+    assert calls == [(0, "ON"), (0, "OFF"), (0, "ON"), (0, "OFF")]
+    assert [attempt["phase"] for attempt in state["attempt_history"]] == ["ON", "OFF", "ON", "OFF"]
+    assert state["attempt_history"][1]["outcome"] == "FAIL"
+    assert state["attempt_history"][1]["category"] == "probe_interrupted"
+    assert len(state["trends"]) == 1
+    assert state["trends"][0]["elapsed_ms"] == 125.0
+    assert raw_secret not in (output / "soak-state.json").read_text(encoding="utf-8")
+
+
+def test_soak_cycle_n_recoverable_failure_preserves_completed_pairs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak_module = importlib.import_module("beta_evidence.soak")
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+
+    def phases(
+        _python: Path, _work: Path, _timeout: int, _parse_timeout: int, cycle: int, phase: str
+    ) -> dict[str, object]:
+        if cycle == 1 and phase == "ON":
+            raise module.EvidenceError("probe_timeout")
+        return _soak_phase_payload(phase)
+
+    monkeypatch.setattr(soak_module, "_run_soak_phase", phases)
+    with pytest.raises(module.EvidenceError, match="^probe_timeout$"):
+        _collect_test_soak(
+            module,
+            tmp_path / "evidence",
+            source,
+            fingerprint,
+            duration_seconds=2,
+            max_cycles=2,
+            clock=iter((0.0, 0.5)).__next__,
+        )
+    state = json.loads((tmp_path / "evidence" / "soak-state.json").read_text(encoding="utf-8"))
+    assert state["status"] == "RUNNING"
+    assert state["completed_cycles"] == 1
+    assert len(state["trends"]) == 1
+    assert state["attempt_history"][-1] == {
+        "sequence": 2,
+        "cycle": 1,
+        "phase": "ON",
+        "outcome": "FAIL",
+        "category": "probe_timeout",
+        "previous_digest": state["attempt_history"][-2]["digest"],
+        "digest": state["attempt_cursor"],
+    }
+
+
+def test_soak_migrates_running_v1_trends_as_legacy_combined(tmp_path: Path) -> None:
+    module = _module()
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+    with pytest.raises(module.EvidenceError, match="^duration_incomplete$"):
+        _collect_test_soak(
+            module,
+            output,
+            source,
+            fingerprint,
+            duration_seconds=60,
+            probe_runner=lambda *_args: _soak_payload(),
+            clock=iter((0.0, 0.1)).__next__,
+        )
+    state_path = output / "soak-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["schema_version"] = 1
+    state["trends"] = [{key: value for key, value in state["trends"][0].items() if key != "phase"}]
+    state.pop("next_phase")
+    state.pop("attempt_history")
+    state.pop("attempt_cursor")
+    raw_legacy_detail = "never-migrate-this-detail"
+    state["trends"][0]["untrusted_detail"] = raw_legacy_detail
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(module.EvidenceError, match="^soak_state_invalid$"):
+        _collect_test_soak(
+            module,
+            output,
+            source,
+            fingerprint,
+            duration_seconds=60,
+            probe_runner=lambda *_args: _soak_payload(),
+            clock=lambda: 0.0,
+        )
+    state["trends"][0].pop("untrusted_detail")
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(module.EvidenceError, match="^duration_incomplete$"):
+        _collect_test_soak(
+            module,
+            output,
+            source,
+            fingerprint,
+            duration_seconds=60,
+            probe_runner=lambda *_args: _soak_payload(),
+            clock=lambda: 0.0,
+        )
+    migrated = json.loads(state_path.read_text(encoding="utf-8"))
+    assert migrated["schema_version"] == 2
+    assert migrated["trends"][0]["phase"] == "legacy_combined"
+    assert migrated["attempt_history"][0]["phase"] == "legacy_combined"
+    assert set(migrated["trends"][0]) == {
+        "phase",
+        "source_count",
+        "indexed_count",
+        "rss_kib",
+        "elapsed_ms",
+        "subtree",
+        "synthetic_crud",
+    }
+    assert raw_legacy_detail not in json.dumps(migrated)
+
+
+def test_soak_terminal_working_integrity_failure_renders_zero_cycle_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak_module = importlib.import_module("beta_evidence.soak")
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+
+    def mutate_work(
+        _python: Path, work: Path, _timeout: int, _parse_timeout: int, _cycle: int, phase: str
+    ) -> dict[str, object]:
+        if phase == "ON":
+            (work / "pages" / "daily.md").write_text("- mutated\n", encoding="utf-8")
+        return _soak_phase_payload(phase)
+
+    output = tmp_path / "evidence"
+    monkeypatch.setattr(soak_module, "_run_soak_phase", mutate_work)
+    record = _collect_test_soak(
+        module,
+        output,
+        source,
+        fingerprint,
+        clock=lambda: 0.0,
+    )
+    result = json.loads((output / "soak-result.json").read_text(encoding="utf-8"))
+    assert record.status == "FAIL"
+    assert result["failure_category"] == "working_copy_changed"
+    assert result["cycles_completed"] == 0
+    assert result["rss_kib_min"] is None
 
 
 def test_wheel_deadline_is_hashed_recorded_and_cannot_change_on_resume(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- persist separate ON and OFF phase outcomes before deriving a completed-cycle trend
- keep recoverable probe failures resumable while preserving terminal handling for working-copy integrity failures
- restart interrupted partial pairs from ON and record a bounded interruption category
- migrate valid v1 running state through a strict allowlist
- detect accidental history corruption, cap attempt history, and render zero-cycle terminal failures safely

## Security and privacy boundary

The phase-history digest chain detects accidental or partial corruption. It is deliberately not described as tamper evidence because its cursor and records share the same mutable evidence boundary. Tests document that a fully recomputed structurally valid chain is accepted.

## Test plan

- [x] beta-evidence suite (54 passed)
- [x] Ruff lint and format
- [x] strict mypy
- [x] Python compilation
- [x] `git diff --check`
- [x] adversarial review of state transitions, privacy, migration, interruption, and bounded growth

## Code audit impact

Medium expected impact, limited to the `collect_soak` evidence-collection flow. No product runtime, Shadow routing, vault-write, or release-publication path is modified.

## Dependency

The prerequisite flag-off probe fix from #319 is now on `main`; this branch has been rebased onto it. The wheel-provenance binding remains isolated in the stacked follow-up #324.

Refs #20