### PR TITLE
fix(quality): bind beta soak to verified wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - **Explicit beta-evidence parse deadline** — `wheel` and `soak` now require a sanitized, bounded 2–120 second child-only page-parse deadline, record it in resumable evidence, and reject a resume when it changes; this harness setting does not alter the product default of 15 seconds.
-- **Final beta code audit gate** — add a fail-closed `code-audit` evidence command that records only sanitized candidate diff, build, CI, scope, and finding summaries after matching the verified candidate wheel.
+- **Final beta code audit gate** — add a fail-closed `code-audit` evidence command that records only sanitized candidate diff, build, CI, scope, and finding summaries after matching the verified candidate wheel; wheel and soak evidence now share a canonical SHA-256 provenance binding, so absent, malformed, or mismatched bindings cannot become release-ready.
 
 ### Security
 

--- a/scripts/beta_evidence/core.py
+++ b/scripts/beta_evidence/core.py
@@ -195,6 +195,83 @@ def _require_matching_gate_input(output: Path, *, gate_id: str, input_hash: str)
         raise EvidenceError("gate_resume_mismatch")
 
 
+def _candidate_wheel_binding_digest(
+    wheel_sha256: object, candidate_provenance_digest: object
+) -> str:
+    """Return the canonical, privacy-safe binding for a verified candidate wheel."""
+
+    if not (
+        isinstance(wheel_sha256, str)
+        and _SHA256.fullmatch(wheel_sha256) is not None
+        and isinstance(candidate_provenance_digest, str)
+        and _SHA256.fullmatch(candidate_provenance_digest) is not None
+    ):
+        raise EvidenceError("candidate_wheel_binding_invalid")
+    return _canonical_hash(
+        {
+            "candidate_provenance_digest": candidate_provenance_digest,
+            "wheel_sha256": wheel_sha256,
+        }
+    )
+
+
+def _require_bound_wheel(output: Path, candidate_provenance_digest: object) -> str:
+    """Require a passed wheel gate bound to the live candidate provenance digest."""
+
+    checkpoint, evidence = _load_checkpoint(output), _load_evidence(output)
+    checkpoint_gates, evidence_gates = checkpoint["gates"], evidence["gates"]
+    _validate_gate_records(checkpoint_gates)
+    _validate_gate_records(evidence_gates)
+    if checkpoint_gates != evidence_gates:
+        raise EvidenceError("evidence_invalid")
+    wheel = checkpoint_gates.get("wheel")
+    if not isinstance(wheel, dict) or wheel.get("status") != "PASS":
+        raise EvidenceError("soak_wheel_binding_missing")
+    details = wheel.get("details")
+    if not isinstance(details, dict):
+        raise EvidenceError("soak_wheel_binding_invalid")
+    try:
+        expected = _candidate_wheel_binding_digest(
+            details.get("wheel_sha256"), details.get("candidate_provenance_digest")
+        )
+    except EvidenceError as exc:
+        raise EvidenceError("soak_wheel_binding_invalid") from exc
+    if details.get("candidate_wheel_binding_digest") != expected:
+        raise EvidenceError("soak_wheel_binding_invalid")
+    if details.get("candidate_provenance_digest") != candidate_provenance_digest:
+        raise EvidenceError("soak_candidate_provenance_mismatch")
+    return expected
+
+
+def _has_valid_bound_wheel_soak(gates: dict[str, Any]) -> bool:
+    """Return whether passed wheel and soak gates refer to the same candidate wheel."""
+
+    wheel, soak = gates.get("wheel"), gates.get("soak")
+    if not (
+        isinstance(wheel, dict)
+        and isinstance(soak, dict)
+        and wheel.get("status") == "PASS"
+        and soak.get("status") == "PASS"
+        and isinstance(wheel.get("details"), dict)
+        and isinstance(soak.get("details"), dict)
+    ):
+        return False
+    wheel_details = cast(dict[str, Any], wheel["details"])
+    soak_details = cast(dict[str, Any], soak["details"])
+    try:
+        binding = _candidate_wheel_binding_digest(
+            wheel_details.get("wheel_sha256"), wheel_details.get("candidate_provenance_digest")
+        )
+    except EvidenceError:
+        return False
+    return (
+        wheel_details.get("candidate_wheel_binding_digest") == binding
+        and soak_details.get("candidate_wheel_binding_digest") == binding
+        and soak_details.get("candidate_provenance_digest")
+        == wheel_details.get("candidate_provenance_digest")
+    )
+
+
 def display_to_package_version(display: str) -> str:
     """Normalize a SemVer display prerelease to its Python package version."""
 
@@ -506,7 +583,11 @@ def render_summary(evidence: dict[str, Any]) -> str:
         rows.append((gate_id, status))
         statuses.append(status)
     readiness = (
-        "READY" if statuses and all(status == "PASS" for status in statuses) else "NOT READY"
+        "READY"
+        if statuses
+        and all(status == "PASS" for status in statuses)
+        and _has_valid_bound_wheel_soak(gates)
+        else "NOT READY"
     )
     metadata = evidence.get("metadata", {})
     lines = [

--- a/scripts/beta_evidence/soak.py
+++ b/scripts/beta_evidence/soak.py
@@ -23,15 +23,16 @@ from .core import (
     _is_within,
     _record_gate,
     _repo_root_from_script,
+    _require_bound_wheel,
     _require_matching_gate_input,
     validate_output_directory,
 )
 from .wheel import (
-    _WHEEL_CANDIDATE,
     _copy_vault_without_cache,
     _markdown_fingerprint,
     _resolve_source_vault,
     _safe_environment,
+    _verify_candidate_python,
 )
 
 _SOAK_SCHEMA_VERSION = 2
@@ -74,31 +75,6 @@ _LEGACY_TREND_FIELDS = (
     "subtree",
     "synthetic_crud",
 )
-
-_CANDIDATE_PROBE = f"""
-import hashlib
-from importlib.metadata import distribution, version
-from pathlib import Path
-import sys
-
-import src
-
-origin = Path(src.__file__).resolve()
-prefix = Path(sys.prefix).resolve()
-assert origin.is_relative_to(prefix)
-assert any(part in ("site-packages", "dist-packages") for part in origin.parts)
-assert version("matryca-plumber") == {_WHEEL_CANDIDATE!r}
-installed = distribution("matryca-plumber")
-files = installed.files or ()
-artifacts = sorted(
-    file for file in files if str(file).endswith((".dist-info/METADATA", ".dist-info/RECORD"))
-)
-assert len(artifacts) == 2
-digest = hashlib.sha256()
-for artifact in artifacts:
-    digest.update(installed.locate_file(artifact).read_bytes())
-print(digest.hexdigest())
-"""
 
 _OFF_PROBE = r"""
 import json
@@ -298,6 +274,8 @@ def _load_state(output: Path) -> dict[str, Any] | None:
         and state.get("source_unchanged_during_copy") is True
         and isinstance(state.get("working_markdown_fingerprint"), str)
         and isinstance(state.get("candidate_provenance_digest"), str)
+        and isinstance(state.get("candidate_wheel_binding_digest"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", state["candidate_wheel_binding_digest"]) is not None
         and isinstance(state.get("elapsed_seconds"), (int, float))
         and not isinstance(state.get("elapsed_seconds"), bool)
         and isinstance(state.get("target_duration_seconds"), int)
@@ -464,27 +442,6 @@ def _resolve_candidate_python(candidate_python: Path) -> Path:
     if not candidate.is_file() or not os.access(candidate, os.X_OK):
         raise EvidenceError("candidate_python_invalid")
     return candidate
-
-
-def _verify_candidate_python(candidate_python: Path) -> str:
-    try:
-        completed = subprocess.run(
-            [str(candidate_python), "-c", _CANDIDATE_PROBE],
-            cwd=tempfile.gettempdir(),
-            env={"PATH": os.environ.get("PATH", ""), "PYTHONNOUSERSITE": "1"},
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise EvidenceError("candidate_python_invalid") from exc
-    if completed.returncode != 0:
-        raise EvidenceError("candidate_version_mismatch")
-    digest = completed.stdout.strip()
-    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
-        raise EvidenceError("candidate_provenance_invalid")
-    return digest
 
 
 def _resolve_working_root(working_root: Path, *, source: Path, output: Path) -> Path:
@@ -707,6 +664,8 @@ def _summary_details(state: Mapping[str, Any]) -> dict[str, object]:
             state["elapsed_seconds"] >= _DEFAULT_DURATION_SECONDS
             and state["target_duration_seconds"] >= _DEFAULT_DURATION_SECONDS
         ),
+        "candidate_provenance_digest": state["candidate_provenance_digest"],
+        "candidate_wheel_binding_digest": state["candidate_wheel_binding_digest"],
         "subtree_checks": sum(item["subtree"] == "PASS" for item in trends),
         "subtree_skipped": sum(item["subtree"] == "SKIPPED" for item in trends),
         "synthetic_crud_checks": sum(item["synthetic_crud"] == "PASS" for item in trends),
@@ -804,17 +763,17 @@ def collect_soak(
     source = _resolve_source_vault(source_vault, expected_source_file)
     candidate = _resolve_candidate_python(candidate_python)
     candidate_digest = candidate_verifier(candidate)
-    if not candidate_digest:
-        raise EvidenceError("candidate_provenance_invalid")
     resolved_output = validate_output_directory(
         output, repo_root=_repo_root_from_script(), protected_roots=[source]
     )
+    candidate_wheel_binding_digest = _require_bound_wheel(resolved_output, candidate_digest)
     work = _resolve_working_root(working_root, source=source, output=resolved_output)
     input_hash = _canonical_hash(
         {
             "source_realpath_sha256": hashlib.sha256(str(source).encode()).hexdigest(),
             "expected_source_sha256": hashlib.sha256(expected_source_file.read_bytes()).hexdigest(),
             "candidate_provenance_digest": candidate_digest,
+            "candidate_wheel_binding_digest": candidate_wheel_binding_digest,
             "duration_seconds": duration_seconds,
             "max_cycles": max_cycles,
             "interval_seconds": interval_seconds,
@@ -854,6 +813,7 @@ def collect_soak(
             "source_unchanged_during_copy": True,
             "working_markdown_fingerprint": working_snapshot,
             "candidate_provenance_digest": candidate_digest,
+            "candidate_wheel_binding_digest": candidate_wheel_binding_digest,
             "elapsed_seconds": 0.0,
             "target_duration_seconds": duration_seconds,
             "page_parse_timeout_seconds": page_parse_timeout_seconds,
@@ -866,6 +826,7 @@ def collect_soak(
         or state["status"] not in {"RUNNING", "READY"}
         or state["target_duration_seconds"] != duration_seconds
         or state["candidate_provenance_digest"] != candidate_digest
+        or state["candidate_wheel_binding_digest"] != candidate_wheel_binding_digest
         or state["page_parse_timeout_seconds"] != page_parse_timeout_seconds
     ):
         raise EvidenceError("soak_resume_mismatch")

--- a/scripts/beta_evidence/wheel.py
+++ b/scripts/beta_evidence/wheel.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Protocol, cast
@@ -19,6 +19,7 @@ from typing import Any, Protocol, cast
 from .core import (
     EvidenceError,
     GateRecord,
+    _candidate_wheel_binding_digest,
     _canonical_hash,
     _is_within,
     _record_gate,
@@ -52,6 +53,31 @@ _PROCESS_ENV_ALLOWLIST = frozenset(
     }
 )
 
+_CANDIDATE_PROBE = f"""
+import hashlib
+from importlib.metadata import distribution, version
+from pathlib import Path
+import sys
+
+import src
+
+origin = Path(src.__file__).resolve()
+prefix = Path(sys.prefix).resolve()
+assert origin.is_relative_to(prefix)
+assert any(part in ("site-packages", "dist-packages") for part in origin.parts)
+assert version("matryca-plumber") == {_WHEEL_CANDIDATE!r}
+installed = distribution("matryca-plumber")
+files = installed.files or ()
+artifacts = sorted(
+    file for file in files if str(file).endswith((".dist-info/METADATA", ".dist-info/RECORD"))
+)
+assert len(artifacts) == 2
+digest = hashlib.sha256()
+for artifact in artifacts:
+    digest.update(installed.locate_file(artifact).read_bytes())
+print(digest.hexdigest())
+"""
+
 
 class CommandRunner(Protocol):
     def __call__(
@@ -78,6 +104,9 @@ class WheelProbeRunner(Protocol):
 
 class VaultCopier(Protocol):
     def __call__(self, source: Path, destination: Path) -> None: ...
+
+
+type CandidateVerifier = Callable[[Path], str]
 
 
 def _markdown_fingerprint(root: Path) -> str:
@@ -268,6 +297,29 @@ def _run_wheel_probe(
         raise EvidenceError("probe_invalid") from exc
 
 
+def _verify_candidate_python(candidate_python: Path) -> str:
+    """Verify the installed candidate and return its sanitized provenance digest."""
+
+    try:
+        completed = subprocess.run(
+            [str(candidate_python), "-c", _CANDIDATE_PROBE],
+            cwd=tempfile.gettempdir(),
+            env={"PATH": os.environ.get("PATH", ""), "PYTHONNOUSERSITE": "1"},
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EvidenceError("candidate_python_invalid") from exc
+    if completed.returncode != 0:
+        raise EvidenceError("candidate_version_mismatch")
+    digest = completed.stdout.strip()
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise EvidenceError("candidate_provenance_invalid")
+    return digest
+
+
 def _wheel_details(
     *,
     wheel: Path,
@@ -276,10 +328,14 @@ def _wheel_details(
     source_after: str,
     baseline: dict[str, Any],
     candidate: dict[str, Any],
+    candidate_provenance_digest: str,
+    candidate_wheel_binding_digest: str,
     page_parse_timeout_seconds: int,
 ) -> dict[str, Any]:
     return {
         "wheel_sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        "candidate_provenance_digest": candidate_provenance_digest,
+        "candidate_wheel_binding_digest": candidate_wheel_binding_digest,
         "source_unchanged": source_before == source_after,
         "source_markdown_count": sum(
             1 for path in source.rglob("*.md") if ".matryca_semantic_cache" not in path.parts
@@ -301,6 +357,7 @@ def collect_wheel(
     command_runner: CommandRunner = _run_command,
     probe_runner: WheelProbeRunner = _run_wheel_probe,
     copier: VaultCopier = _copy_vault_without_cache,
+    candidate_verifier: CandidateVerifier | None = None,
 ) -> GateRecord:
     """Collect isolated baseline-to-wheel evidence without writing the source vault."""
     if not 1 <= timeout_seconds <= 600:
@@ -309,6 +366,7 @@ def collect_wheel(
         raise EvidenceError("page_parse_timeout_invalid")
     source = _resolve_source_vault(source_vault, expected_source_file)
     wheel = _resolve_candidate_wheel(wheel_path, source)
+    verifier = _verify_candidate_python if candidate_verifier is None else candidate_verifier
     resolved_output = validate_output_directory(
         output, repo_root=_repo_root_from_script(), protected_roots=[source]
     )
@@ -394,6 +452,10 @@ def collect_wheel(
             candidate["working_markdown_unchanged"]
             and _markdown_fingerprint(working_vault) == working_before
         )
+        candidate_provenance_digest = verifier(python)
+        candidate_wheel_binding_digest = _candidate_wheel_binding_digest(
+            hashlib.sha256(wheel.read_bytes()).hexdigest(), candidate_provenance_digest
+        )
         details = _wheel_details(
             wheel=wheel,
             source=source,
@@ -401,6 +463,8 @@ def collect_wheel(
             source_after=_markdown_fingerprint(source),
             baseline=baseline,
             candidate=candidate,
+            candidate_provenance_digest=candidate_provenance_digest,
+            candidate_wheel_binding_digest=candidate_wheel_binding_digest,
             page_parse_timeout_seconds=page_parse_timeout_seconds,
         )
         checks = [

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -385,6 +385,32 @@ def _successful_command(*_: object, **__: object) -> subprocess.CompletedProcess
     return subprocess.CompletedProcess([], 0, stdout="", stderr="")
 
 
+_TEST_CANDIDATE_DIGEST = "c" * 64
+
+
+@pytest.fixture(autouse=True)
+def _isolated_provenance_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep legacy collector tests focused on their own injected process behavior."""
+
+    wheel = importlib.import_module("beta_evidence.wheel")
+    soak = importlib.import_module("beta_evidence.soak")
+    core = importlib.import_module("beta_evidence.core")
+    monkeypatch.setattr(wheel, "_verify_candidate_python", lambda _python: _TEST_CANDIDATE_DIGEST)
+
+    def binding(output: Path, candidate_digest: object) -> str:
+        checkpoint = core._load_checkpoint(output)
+        wheel_record = checkpoint["gates"].get("wheel")
+        if isinstance(wheel_record, dict) and isinstance(wheel_record.get("details"), dict):
+            details = wheel_record["details"]
+            return cast(
+                str,
+                core._candidate_wheel_binding_digest(details.get("wheel_sha256"), candidate_digest),
+            )
+        return "b" * 64
+
+    monkeypatch.setattr(soak, "_require_bound_wheel", binding)
+
+
 def test_wheel_requires_exact_daily_source_fingerprint(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, wheel = _wheel_source(tmp_path)
@@ -648,7 +674,7 @@ def test_report_is_ready_after_collected_code_audit_and_soak(tmp_path: Path) -> 
             duration_seconds=1,
             max_cycles=1,
             interval_seconds=0,
-            candidate_verifier=lambda _: "e" * 64,
+            candidate_verifier=lambda _: _TEST_CANDIDATE_DIGEST,
             probe_runner=lambda *_args: _soak_payload(),
             clock=lambda: next(ticks),
             sleeper=lambda _: None,
@@ -659,6 +685,148 @@ def test_report_is_ready_after_collected_code_audit_and_soak(tmp_path: Path) -> 
     module.collect_issues(output, issues_path=issue_path, dispositions_path=disposition_path)
     module.collect_report(output)
     assert "## Verdict: READY" in (output / "summary.md").read_text(encoding="utf-8")
+
+
+def _record_bound_wheel(
+    module: ModuleType,
+    output: Path,
+    *,
+    provenance_digest: str = _TEST_CANDIDATE_DIGEST,
+    status: str = "PASS",
+) -> str:
+    core = importlib.import_module("beta_evidence.core")
+    wheel_sha256 = "a" * 64
+    binding = core._candidate_wheel_binding_digest(wheel_sha256, provenance_digest)
+    core._record_gate(
+        output,
+        module.GateRecord(
+            "wheel",
+            "f" * 64,
+            status,
+            {
+                "wheel_sha256": wheel_sha256,
+                "candidate_provenance_digest": provenance_digest,
+                "candidate_wheel_binding_digest": binding,
+            },
+        ),
+    )
+    return cast(str, binding)
+
+
+def test_soak_requires_a_passing_bound_wheel_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak = importlib.import_module("beta_evidence.soak")
+    core = importlib.import_module("beta_evidence.core")
+    monkeypatch.setattr(soak, "_require_bound_wheel", core._require_bound_wheel)
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+    arguments = {
+        "candidate_python": Path(sys.executable),
+        "source_vault": source,
+        "expected_source_file": fingerprint,
+        "working_root": tmp_path / "soak-copy",
+        "page_parse_timeout_seconds": 60,
+        "duration_seconds": 1,
+        "max_cycles": 1,
+        "interval_seconds": 0,
+        "candidate_verifier": lambda _python: _TEST_CANDIDATE_DIGEST,
+    }
+    with pytest.raises(module.EvidenceError, match="^soak_wheel_binding_missing$"):
+        module.collect_soak(output, **arguments)
+    _record_bound_wheel(module, output, status="FAIL")
+    with pytest.raises(module.EvidenceError, match="^soak_wheel_binding_missing$"):
+        module.collect_soak(output, **arguments)
+    malformed_output = tmp_path / "malformed-evidence"
+    core._record_gate(
+        malformed_output,
+        module.GateRecord(
+            "wheel",
+            "e" * 64,
+            "PASS",
+            {
+                "wheel_sha256": "a" * 64,
+                "candidate_provenance_digest": _TEST_CANDIDATE_DIGEST,
+                "candidate_wheel_binding_digest": "malformed",
+            },
+        ),
+    )
+    with pytest.raises(module.EvidenceError, match="^soak_wheel_binding_invalid$"):
+        module.collect_soak(malformed_output, **arguments)
+
+
+def test_bound_soak_matches_live_candidate_and_persists_only_sanitized_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    soak = importlib.import_module("beta_evidence.soak")
+    core = importlib.import_module("beta_evidence.core")
+    monkeypatch.setattr(soak, "_require_bound_wheel", core._require_bound_wheel)
+    source, fingerprint, _wheel = _wheel_source(tmp_path)
+    output = tmp_path / "evidence"
+    binding = _record_bound_wheel(module, output)
+    with pytest.raises(module.EvidenceError, match="^soak_candidate_provenance_mismatch$"):
+        module.collect_soak(
+            output,
+            candidate_python=Path(sys.executable),
+            source_vault=source,
+            expected_source_file=fingerprint,
+            working_root=tmp_path / "mismatch-copy",
+            page_parse_timeout_seconds=60,
+            duration_seconds=1,
+            max_cycles=1,
+            interval_seconds=0,
+            candidate_verifier=lambda _python: "d" * 64,
+        )
+    record = module.collect_soak(
+        output,
+        candidate_python=Path(sys.executable),
+        source_vault=source,
+        expected_source_file=fingerprint,
+        working_root=tmp_path / "bound-copy",
+        page_parse_timeout_seconds=60,
+        duration_seconds=1,
+        max_cycles=1,
+        interval_seconds=0,
+        candidate_verifier=lambda _python: _TEST_CANDIDATE_DIGEST,
+        probe_runner=lambda *_args: _soak_payload(),
+        clock=iter((0.0, 1.0)).__next__,
+        sleeper=lambda _seconds: None,
+    )
+    assert record.status == "PASS"
+    assert record.details["candidate_wheel_binding_digest"] == binding
+    assert record.details["candidate_provenance_digest"] == _TEST_CANDIDATE_DIGEST
+    for artifact in ("checkpoint.json", "evidence.json", "soak-state.json", "soak-result.json"):
+        content = (output / artifact).read_text(encoding="utf-8")
+        assert str(source) not in content
+        assert str(Path(sys.executable)) not in content
+        assert "daily note" not in content
+
+
+def test_report_rejects_legacy_or_malformed_wheel_soak_bindings() -> None:
+    core = importlib.import_module("beta_evidence.core")
+    wheel_sha256 = "a" * 64
+    binding = core._candidate_wheel_binding_digest(wheel_sha256, _TEST_CANDIDATE_DIGEST)
+    gates = {gate_id: {"status": "PASS", "details": {}} for gate_id in core._REQUIRED_GATES}
+    gates["wheel"] = {
+        "status": "PASS",
+        "details": {
+            "wheel_sha256": wheel_sha256,
+            "candidate_provenance_digest": _TEST_CANDIDATE_DIGEST,
+            "candidate_wheel_binding_digest": binding,
+        },
+    }
+    gates["soak"] = {"status": "PASS", "details": {}}
+    assert "## Verdict: NOT READY" in core.render_summary({"gates": gates})
+    gates["soak"] = {
+        "status": "PASS",
+        "details": {
+            "candidate_provenance_digest": _TEST_CANDIDATE_DIGEST,
+            "candidate_wheel_binding_digest": "not-a-sha256",
+        },
+    }
+    assert "## Verdict: NOT READY" in core.render_summary({"gates": gates})
 
 
 def test_wheel_timeout_and_malformed_probe_record_safe_failures(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- record the built wheel SHA-256, installed candidate provenance digest, and their canonical binding
- require a passing, structurally valid wheel gate before a soak can start
- reject an installed candidate whose provenance does not match the wheel gate
- include the binding in soak identity, state, and final gate details
- keep the final report `NOT READY` unless the wheel and soak share the same valid binding

## Privacy and failure behavior

Only fixed-length digests are persisted. No wheel path, environment path, vault content, command output, or subprocess diagnostics enter the evidence artifacts. Missing, legacy, malformed, non-passing, or mismatched bindings fail closed.

## Test plan

- [x] beta-evidence suite (57 passed)
- [x] Ruff lint and format
- [x] strict mypy
- [x] `git diff --check`
- [x] matching binding
- [x] missing and non-passing wheel gate
- [x] malformed and legacy binding
- [x] candidate provenance mismatch
- [x] report readiness and privacy boundaries

## Code audit impact

Pre-edit impact was low for the wheel collector, soak collector, and report verdict. The final linked-worktree index over-attributed adjacent symbols; the authoritative Git diff contains only the five collector, report, test, and changelog files listed above.

## Dependency

This PR is stacked on #323, which is itself stacked on #319. Retarget to `main` after those two PRs merge without broadening scope.

Refs #20
