### PR TITLE
build(deps): bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -74,7 +74,7 @@ jobs:
             **/uv.lock
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
## Summary

- upgrade `actions/setup-node` from v6 to v7 in the CI workflow
- keep both release workflow setup steps aligned on v7
- preserve Node.js 22 and existing npm cache behavior

## Scope

Three workflow substitutions only; no product runtime, package lock, or release artifact behavior changes.

## Validation

- applies cleanly to current `main`
- workflow diff reviewed after the release-provenance merge
- fresh CI and CodeQL required before merge

Supersedes #301, whose Dependabot-owned branch could not be reopened after synchronization with current `main`.