### PR TITLE
fix(quality): stabilize installed-wheel provenance (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- **Beta candidate provenance stability** — canonicalize installed wheel `RECORD` evidence and exclude installer-generated entries, so equivalent candidate installs retain the same soak binding while malformed payload evidence fails closed.
 - **Beta soak flag-off probe import and failure hygiene** — resolve the Shadow DB path from its connection module so both embedded probes run; persist only stable phase categories without subprocess diagnostics; and resume recoverable ON/OFF probe failures from integrity-checked, corruption-detecting sanitized state without treating a partial pair as a completed trend.
 - **Beta soak candidate interpreter provenance** — preserve the requested virtual-environment Python invocation path when it symlinks to a managed interpreter, so soak verification retains the venv's installed site-packages while rejecting non-executable candidates.
 - **Beta wheel provenance with symlinked interpreters** — validate installed-module provenance against the active virtual-environment prefix instead of the resolved interpreter target, preventing false evidence failures when the venv executable links to a managed Python installation.

--- a/scripts/beta_evidence/wheel.py
+++ b/scripts/beta_evidence/wheel.py
@@ -54,7 +54,10 @@ _PROCESS_ENV_ALLOWLIST = frozenset(
 )
 
 _CANDIDATE_PROBE = f"""
+import base64
+import csv
 import hashlib
+import hmac
 from importlib.metadata import distribution, version
 from pathlib import Path
 import sys
@@ -68,13 +71,79 @@ assert any(part in ("site-packages", "dist-packages") for part in origin.parts)
 assert version("matryca-plumber") == {_WHEEL_CANDIDATE!r}
 installed = distribution("matryca-plumber")
 files = installed.files or ()
-artifacts = sorted(
-    file for file in files if str(file).endswith((".dist-info/METADATA", ".dist-info/RECORD"))
+record_candidates = sorted(
+    str(file) for file in files if str(file).endswith(".dist-info/RECORD")
 )
-assert len(artifacts) == 2
+assert len(record_candidates) == 1
+record_path = record_candidates[0]
+record_location = Path(installed.locate_file(record_path))
+assert record_location.is_file()
+assert record_location.resolve().is_relative_to(prefix)
+
+generated_dist_info_entries = {{
+    "INSTALLER",
+    "REQUESTED",
+    "direct_url.json",
+    "uv_cache.json",
+    "RECORD",
+}}
+entries = []
+metadata_entries = 0
+payload_entries = 0
+with record_location.open(encoding="utf-8", newline="") as record_file:
+    for row in csv.reader(record_file):
+        assert len(row) == 3
+        raw_path, hash_spec, size = row
+        assert raw_path and not raw_path.startswith(("/", "\\\\"))
+        normalized_path = "/".join(
+            part for part in raw_path.replace("\\\\", "/").split("/") if part
+        )
+        assert normalized_path
+        assert not any(character in normalized_path for character in "\\r\\n\\t")
+        parts = normalized_path.split("/")
+        parent_count = 0
+        while parent_count < len(parts) and parts[parent_count] == "..":
+            parent_count += 1
+        if parent_count:
+            assert (
+                len(parts) == parent_count + 2
+                and parts[parent_count] in {{"bin", "Scripts"}}
+                and parts[-1] not in {{"", ".", ".."}}
+            )
+            continue
+        assert ".." not in parts
+        is_dist_info = len(parts) >= 2 and parts[-2].endswith(".dist-info")
+        if is_dist_info and parts[-1] in generated_dist_info_entries:
+            continue
+        location = Path(installed.locate_file(normalized_path)).resolve()
+        assert location.is_relative_to(prefix)
+        assert hash_spec and size.isdecimal()
+        algorithm, separator, encoded_hash = hash_spec.partition("=")
+        assert separator and algorithm and encoded_hash
+        algorithm = algorithm.lower()
+        assert algorithm in {{"sha256", "sha384", "sha512"}}
+        try:
+            expected_hash = base64.b64decode(
+                encoded_hash + "=" * (-len(encoded_hash) % 4), altchars=b"-_", validate=True
+            )
+        except ValueError:
+            raise AssertionError from None
+        assert location.is_file() and location.stat().st_size == int(size)
+        actual_hash = hashlib.new(algorithm, location.read_bytes()).digest()
+        assert hmac.compare_digest(actual_hash, expected_hash)
+        canonical_hash = base64.urlsafe_b64encode(expected_hash).decode("ascii").rstrip("=")
+        entries.append((normalized_path, f"{{algorithm}}={{canonical_hash}}", str(int(size))))
+        if is_dist_info and parts[-1] == "METADATA":
+            metadata_entries += 1
+        elif not is_dist_info:
+            payload_entries += 1
+
+assert metadata_entries == 1
+assert payload_entries >= 1
 digest = hashlib.sha256()
-for artifact in artifacts:
-    digest.update(installed.locate_file(artifact).read_bytes())
+for entry in sorted(entries):
+    digest.update("\\0".join(entry).encode("utf-8"))
+    digest.update(b"\\n")
 print(digest.hexdigest())
 """
 

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import csv
+import hashlib
 import importlib
 import json
 import os
@@ -16,6 +19,7 @@ import pytest
 
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "beta_readiness_evidence.py"
 _SCRIPTS = _SCRIPT.parent
+type RecordEntry = tuple[str, bytes, str | None, str | None]
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -487,6 +491,148 @@ def test_wheel_provenance_uses_venv_prefix_when_interpreter_is_symlinked(
     assert wheel_module._is_imported_from_venv_site_packages(imported, tmp_path / "venv")
 
 
+def _record_hash(payload: bytes, algorithm: str = "sha256") -> str:
+    digest = hashlib.new(algorithm, payload).digest()
+    encoded = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return f"{algorithm}={encoded}"
+
+
+def _candidate_probe_digest(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    entries: list[RecordEntry],
+) -> str:
+    """Execute the isolated candidate probe against a synthetic installed distribution."""
+
+    wheel_module = importlib.import_module("beta_evidence.wheel")
+    prefix = tmp_path / "venv"
+    site_packages = prefix / "lib" / "python3.12" / "site-packages"
+    record = "matryca_plumber-2.0.0b1.dist-info/RECORD"
+    locations: dict[str, Path] = {}
+    rows: list[list[str]] = []
+    for path, payload, hash_spec, size in entries:
+        location = (
+            tmp_path / "outside" / path.replace("../", "outside/")
+            if path.startswith("../")
+            else site_packages / path
+        )
+        location.parent.mkdir(parents=True, exist_ok=True)
+        location.write_bytes(payload)
+        locations[path] = location
+        rows.append(
+            [
+                path,
+                _record_hash(payload) if hash_spec is None else hash_spec,
+                str(len(payload)) if size is None else size,
+            ]
+        )
+    record_location = site_packages / record
+    record_location.parent.mkdir(parents=True, exist_ok=True)
+    with record_location.open("w", encoding="utf-8", newline="") as output:
+        csv.writer(output).writerows(rows)
+    locations[record] = record_location
+
+    class Distribution:
+        files = (record,)
+
+        @staticmethod
+        def locate_file(path: object) -> Path:
+            return locations[str(path)]
+
+    metadata_module = importlib.import_module("importlib.metadata")
+    src_module = ModuleType("src")
+    src_module.__file__ = str(site_packages / "src" / "__init__.py")
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+    monkeypatch.setattr(metadata_module, "distribution", lambda _name: Distribution())
+    monkeypatch.setattr(metadata_module, "version", lambda _name: "2.0.0b1")
+    monkeypatch.setitem(sys.modules, "src", src_module)
+
+    exec(wheel_module._CANDIDATE_PROBE, {})
+    return capsys.readouterr().out.strip()
+
+
+def test_candidate_provenance_digest_ignores_record_order_and_generated_entries(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    stable: list[RecordEntry] = [
+        ("matryca_plumber-2.0.0b1.dist-info/METADATA", b"Name: matryca-plumber\n", None, None),
+        ("src/__init__.py", b"__version__ = '2.0.0b1'\n", None, None),
+    ]
+    generated: list[RecordEntry] = [
+        ("../../../bin/matryca", b"#!/different/venv/bin/python\n", "", ""),
+        ("matryca_plumber-2.0.0b1.dist-info/INSTALLER", b"uv\n", "", ""),
+        ("matryca_plumber-2.0.0b1.dist-info/REQUESTED", b"", "", ""),
+        ("matryca_plumber-2.0.0b1.dist-info/direct_url.json", b"{}\n", "", ""),
+        ("matryca_plumber-2.0.0b1.dist-info/uv_cache.json", b"{}\n", "", ""),
+        ("matryca_plumber-2.0.0b1.dist-info/RECORD", b"", "", ""),
+    ]
+
+    first = _candidate_probe_digest(monkeypatch, capsys, tmp_path / "first", stable + generated)
+    second = _candidate_probe_digest(
+        monkeypatch,
+        capsys,
+        tmp_path / "second",
+        list(reversed(stable)) + list(reversed(generated)),
+    )
+
+    assert first == second
+    assert len(first) == 64
+
+
+def test_candidate_provenance_digest_tracks_payload_and_record_hashes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    metadata = ("matryca_plumber-2.0.0b1.dist-info/METADATA", b"Name: matryca-plumber\n")
+    payload = ("src/__init__.py", b"__version__ = '2.0.0b1'\n")
+    baseline: list[RecordEntry] = [
+        (metadata[0], metadata[1], None, None),
+        (*payload, None, None),
+    ]
+    first = _candidate_probe_digest(monkeypatch, capsys, tmp_path / "first", baseline)
+    payload_changed = _candidate_probe_digest(
+        monkeypatch,
+        capsys,
+        tmp_path / "payload-changed",
+        [
+            (metadata[0], metadata[1], None, None),
+            (payload[0], b"__version__ = 'changed'\n", None, None),
+        ],
+    )
+    hash_changed = _candidate_probe_digest(
+        monkeypatch,
+        capsys,
+        tmp_path / "hash-changed",
+        [
+            (metadata[0], metadata[1], _record_hash(metadata[1], "sha512"), None),
+            (*payload, None, None),
+        ],
+    )
+
+    assert first != payload_changed
+    assert first != hash_changed
+
+
+def test_candidate_provenance_digest_rejects_missing_stable_entry_evidence(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    with pytest.raises(AssertionError):
+        _candidate_probe_digest(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [
+                (
+                    "matryca_plumber-2.0.0b1.dist-info/METADATA",
+                    b"Name: matryca-plumber\n",
+                    None,
+                    None,
+                ),
+                ("src/__init__.py", b"payload\n", _record_hash(b"payload\n"), ""),
+            ],
+        )
+
+
 def test_soak_candidate_uses_venv_python_symlink_and_its_site_packages(tmp_path: Path) -> None:
     soak_module = importlib.import_module("beta_evidence.soak")
     venv_root = tmp_path / "candidate-venv"
@@ -509,12 +655,11 @@ def test_soak_candidate_uses_venv_python_symlink_and_its_site_packages(tmp_path:
     (site_packages / "src" / "__init__.py").write_text("", encoding="utf-8")
     distribution = site_packages / "matryca_plumber-2.0.0b1.dist-info"
     distribution.mkdir()
-    (distribution / "METADATA").write_text(
-        "Metadata-Version: 2.1\nName: matryca-plumber\nVersion: 2.0.0b1\n",
-        encoding="utf-8",
-    )
+    metadata = b"Metadata-Version: 2.1\nName: matryca-plumber\nVersion: 2.0.0b1\n"
+    (distribution / "METADATA").write_bytes(metadata)
     (distribution / "RECORD").write_text(
-        "matryca_plumber-2.0.0b1.dist-info/METADATA,,\n"
+        f"matryca_plumber-2.0.0b1.dist-info/METADATA,{_record_hash(metadata)},{len(metadata)}\n"
+        f"src/__init__.py,{_record_hash(b'')},0\n"
         "matryca_plumber-2.0.0b1.dist-info/RECORD,,\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary

Fix the beta evidence wheel-to-soak provenance binding so equivalent installations of the exact same wheel produce the same digest.

Installers legitimately rewrite and reorder `RECORD`, add console-script entries, and add installer metadata. Hashing the raw installed `RECORD` bytes therefore made a valid durable candidate venv differ from the temporary wheel-gate venv.

## Fix

- parse installed `RECORD` as CSV;
- exclude only recognized installer-generated scripts and dist-info records;
- require stable payload entries to remain inside the active venv;
- verify declared sizes and SHA-256/SHA-384/SHA-512 hashes against installed files;
- canonicalize and sort stable `(path, hash, size)` tuples before hashing;
- require exactly one `METADATA` record and at least one payload record;
- fail closed on malformed, missing, traversal, outside-prefix, or unsupported evidence.

The separate candidate wheel SHA-256 binding is unchanged.

## Verification

- two real isolated installs of the same `2.0.0b1` wheel produced the same canonical provenance digest;
- focused beta-evidence suite: 60 passed;
- `make ci`: 1445 passed, 2 skipped, 1 expected xfail;
- Ruff, formatting, mypy, and `git diff --check`: passed;
- authoritative diff: three intended files only (`wheel.py`, focused tests, changelog).

The code-audit index was stale and over-attributed already-merged files; the Git diff is authoritative for this PR.

Fixes #327.
