### PR TITLE
fix(release): mark prerelease tags correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,16 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" dist/* --notes-file release_notes.md
+        run: |
+          release_args=()
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create \
+            "${GITHUB_REF_NAME}" \
+            dist/* \
+            --notes-file release_notes.md \
+            "${release_args[@]}"
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Prerelease publication metadata** — release tags containing a SemVer prerelease suffix now create GitHub prereleases instead of stable releases while preserving the curated changelog notes and PyPI trusted-publishing flow.
+
 ## [2.0.0-beta.1] - 2026-07-30
 
 **v2.0.0-beta.1** — first public beta of the opt-in Shadow DB read path. `MATRYCA_SHADOW_DB_ENABLED` remains default-off, Logseq Markdown remains the system of record, and Markdown/BM25 fallback remains mandatory. Operators who do not set the flag get exactly the established behaviour.


### PR DESCRIPTION
## Summary
- mark SemVer prerelease tags as GitHub prereleases during the automated publication flow
- preserve stable-release behavior for tags without a prerelease suffix
- document the publication metadata fix under `Unreleased`

## Test plan
- [x] parse `.github/workflows/release.yml` as YAML
- [x] extract curated notes for `v2.0.0-beta.1`
- [x] `make docs-check`
- [x] `make agents-check`
- [x] `make check-system-prompt`
- [x] `git diff --check`

Refs #20
