### PR TITLE
feat(safety): define strict read-only write policy (#347)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,6 +195,17 @@ MATRYCA_ALLOW_FLOCK_DEGRADATION=false
 # Range / notes: MCP host has full graph R/W — trust the host process
 MATRYCA_MCP_ENABLED=false
 
+# Strict graph-root write policy. src/graph/safety/write_policy.py
+# Default (code): false
+# Template: false
+# MATRYCA_CACHE_PATH is an external cache root and must always resolve outside LOGSEQ_GRAPH_PATH.
+MATRYCA_READ_ONLY=false
+
+# Optional external cache root. src/graph/safety/write_policy.py
+# Default (code): empty (no external cache)
+# Template: empty
+MATRYCA_CACHE_PATH=
+
 # --- Hermes Agent (~/.hermes/config.yaml → mcp_servers.matryca-plumber.env) ---
 # Hermes is a supported MCP host alongside Claude Desktop / Cursor.
 # Install the host MCP client: cd ~/.hermes/hermes-agent && uv pip install -e ".[mcp]"
@@ -531,4 +542,3 @@ MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S=10
 # Template: 120
 # Range / notes: clamped [1, 600]; full rebuild may scan large vaults at daemon bootstrap
 MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S=120
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The soak ran 24 hours of accumulated exercise across 144 cycles and 288 attempts
 ### Security
 
 - **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.
+- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement.
 
 ### Added
 

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -79,6 +79,8 @@ or `memory_path` in `matryca-wiki.yml`. Bootstrap will create that path and seed
 
 **Rationale:** Cache and templates must exist before the first catalog save or template read; creating them at startup avoids racey `mkdir` scattered through writers.
 
+`MATRYCA_CACHE_PATH` is always an external cache root. The policy canonicalizes graph and cache roots and rejects relative, unresolved, or symlink-alias paths that cannot be proven outside the graph root.
+
 ### 4. Wiki orchestration file (when missing)
 
 | File | Behavior |

--- a/docs/openspec/security-sandbox.md
+++ b/docs/openspec/security-sandbox.md
@@ -27,6 +27,19 @@ All candidate paths under `LOGSEQ_GRAPH_PATH` are resolved with `Path.resolve()`
 
 ---
 
+## Runtime write policy
+
+`RuntimeWritePolicy` in [`src/graph/safety/write_policy.py`](../../src/graph/safety/write_policy.py) is the fail-closed contract for graph-root mutations.
+
+| Variable | Behavior |
+|----------|----------|
+| `MATRYCA_READ_ONLY` | Default `false`. When `true`, any candidate write path whose canonical resolution lies under the canonical graph root raises `GraphReadOnlyError(code="graph_read_only")`. |
+| `MATRYCA_CACHE_PATH` | Optional external cache root. The path is canonicalized before use; symlink aliases, relative targets, and unresolved targets fail closed. The resolved cache root must stay outside the graph root or the policy rejects it. |
+
+The policy resolves both graph and cache roots canonically, so symlink aliases into the graph are treated the same as direct descendants. `MATRYCA_CACHE_PATH` is always treated as an external cache root, not a graph-local working directory. This contract exists before enforcement at callers, CLI, MCP, Shadow, or daemon entry points.
+
+---
+
 ## Bounded JSON checkpoints
 
 Graph-local JSON files (catalog, link registry, daemon state, semantic cache, block vectors) load through **`read_bounded_json()`** with env **`MATRYCA_JSON_MAX_BYTES`** (default **64 MiB**). Oversized files fail fast instead of causing local memory DoS.

--- a/src/graph/safety/write_policy.py
+++ b/src/graph/safety/write_policy.py
@@ -1,0 +1,131 @@
+"""Fail-closed runtime graph write policy and cache configuration."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+from ..path_sandbox import resolved_graph_root
+
+_BOOL_TRUE_TOKENS = frozenset({"1", "true", "yes", "on"})
+_BOOL_FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
+MATRYCA_READ_ONLY_ENV = "MATRYCA_READ_ONLY"
+MATRYCA_CACHE_PATH_ENV = "MATRYCA_CACHE_PATH"
+
+
+class GraphReadOnlyError(PermissionError):
+    """Blocked graph write operation under strict read-only policy."""
+
+    code: ClassVar[str] = "graph_read_only"
+
+    def __init__(
+        self,
+        operation: str,
+        *,
+        path: str | Path | None = None,
+        reason: str,
+    ) -> None:
+        self.operation = operation
+        self.path = None if path is None else str(path)
+        self.reason = reason
+        super().__init__(f"{operation} blocked by graph read-only policy ({reason})")
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeWritePolicy:
+    """Typed runtime contract for graph-root write decisions."""
+
+    graph_root: Path
+    read_only: bool = False
+    cache_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        try:
+            graph_root = resolved_graph_root(self.graph_root)
+        except (OSError, RuntimeError) as exc:
+            raise GraphReadOnlyError(
+                "graph_root",
+                path=self.graph_root,
+                reason="graph_root_unresolvable",
+            ) from exc
+        object.__setattr__(self, "graph_root", graph_root)
+
+        if self.cache_path is None:
+            return
+
+        expanded_cache = Path(self.cache_path).expanduser()
+        if not expanded_cache.is_absolute():
+            raise GraphReadOnlyError(
+                "cache_path",
+                path=self.cache_path,
+                reason="cache_path_not_absolute",
+            )
+
+        resolved_cache = self._resolve_canonical_path(
+            expanded_cache,
+            operation="cache_path",
+            reason="cache_path_unresolvable",
+        )
+        if resolved_cache.is_relative_to(graph_root):
+            raise GraphReadOnlyError(
+                "cache_path",
+                path=resolved_cache,
+                reason="cache_path_inside_graph",
+            )
+        object.__setattr__(self, "cache_path", resolved_cache)
+
+    @classmethod
+    def from_env(
+        cls,
+        graph_root: str | Path,
+        env: Mapping[str, str] | None = None,
+    ) -> RuntimeWritePolicy:
+        """Build the policy from environment-backed configuration."""
+
+        if env is None:
+            read_only = _mapping_bool(os.environ, MATRYCA_READ_ONLY_ENV, default=False)
+            cache_raw = os.environ.get(MATRYCA_CACHE_PATH_ENV, "").strip()
+        else:
+            read_only = _mapping_bool(env, MATRYCA_READ_ONLY_ENV, default=False)
+            cache_raw = env.get(MATRYCA_CACHE_PATH_ENV, "").strip()
+
+        cache_path = None if not cache_raw else Path(cache_raw)
+        return cls(graph_root=Path(graph_root), read_only=read_only, cache_path=cache_path)
+
+    def ensure_write_allowed(self, path: str | Path, *, operation: str = "write") -> Path:
+        """Return the canonical target path or fail closed under read-only mode."""
+
+        resolved = self._resolve_canonical_path(
+            path, operation=operation, reason="path_unresolvable"
+        )
+        if self.read_only and resolved.is_relative_to(self.graph_root):
+            raise GraphReadOnlyError(
+                operation,
+                path=resolved,
+                reason="graph_root_mutation_blocked",
+            )
+        return resolved
+
+    @staticmethod
+    def _resolve_canonical_path(path: str | Path, *, operation: str, reason: str) -> Path:
+        try:
+            return Path(path).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            raise GraphReadOnlyError(operation, path=path, reason=reason) from exc
+
+
+def _mapping_bool(env: Mapping[str, str], key: str, *, default: bool) -> bool:
+    raw = env.get(key, "").strip().lower()
+    if not raw:
+        return default
+    if raw in _BOOL_TRUE_TOKENS:
+        return True
+    if raw in _BOOL_FALSE_TOKENS:
+        return False
+    raise ValueError(f"invalid boolean token for {key}: {env.get(key)!r}")
+
+
+__all__ = ["GraphReadOnlyError", "RuntimeWritePolicy"]

--- a/tests/test_runtime_write_policy.py
+++ b/tests/test_runtime_write_policy.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from src.graph.safety.write_policy import GraphReadOnlyError, RuntimeWritePolicy
+
+
+def _graph_root(tmp_path: Path) -> Path:
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    return graph
+
+
+def _symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+
+@pytest.mark.parametrize(
+    "env",
+    [{}, {"MATRYCA_CACHE_PATH": "   "}, {"MATRYCA_READ_ONLY": "   "}],
+)
+def test_runtime_write_policy_defaults_and_blank_inputs(
+    tmp_path: Path, env: dict[str, str]
+) -> None:
+    graph = _graph_root(tmp_path)
+    policy = RuntimeWritePolicy.from_env(graph, env=env)
+
+    assert policy.graph_root == graph.resolve(strict=False)
+    assert policy.read_only is False
+    assert policy.cache_path is None
+
+    nested = graph / "pages" / ".." / "pages" / "note.md"
+    assert policy.ensure_write_allowed(nested) == nested.resolve(strict=False)
+
+
+@pytest.mark.parametrize("token", ["1", "true", "yes", "on"])
+def test_runtime_write_policy_parses_truthy_tokens(tmp_path: Path, token: str) -> None:
+    graph = _graph_root(tmp_path)
+    policy = RuntimeWritePolicy.from_env(graph, env={"MATRYCA_READ_ONLY": token})
+
+    assert policy.read_only is True
+
+
+@pytest.mark.parametrize("token", ["0", "false", "no", "off"])
+def test_runtime_write_policy_parses_false_tokens(tmp_path: Path, token: str) -> None:
+    graph = _graph_root(tmp_path)
+    policy = RuntimeWritePolicy.from_env(graph, env={"MATRYCA_READ_ONLY": token})
+
+    assert policy.read_only is False
+
+
+def test_runtime_write_policy_rejects_invalid_read_only_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph = _graph_root(tmp_path)
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "maybe")
+    monkeypatch.delenv("MATRYCA_CACHE_PATH", raising=False)
+
+    with pytest.raises(ValueError, match="MATRYCA_READ_ONLY"):
+        RuntimeWritePolicy.from_env(graph)
+
+
+def test_runtime_write_policy_rejects_relative_cache_path(tmp_path: Path) -> None:
+    graph = _graph_root(tmp_path)
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        RuntimeWritePolicy.from_env(graph, env={"MATRYCA_CACHE_PATH": "cache"})
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "cache_path_not_absolute"
+
+
+def test_runtime_write_policy_accepts_tilde_expanded_external_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    graph = _graph_root(tmp_path)
+    home = tmp_path / "home"
+    external_cache = home / "external-cache"
+    external_cache.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    policy = RuntimeWritePolicy.from_env(graph, env={"MATRYCA_CACHE_PATH": "~/external-cache"})
+
+    assert policy.cache_path == external_cache.resolve(strict=False)
+
+
+def test_runtime_write_policy_canonicalizes_graph_root_alias_and_external_cache(
+    tmp_path: Path,
+) -> None:
+    graph = _graph_root(tmp_path)
+    graph_alias = tmp_path / "graph-alias"
+    _symlink(graph, graph_alias, target_is_directory=True)
+    external_cache = tmp_path / "external-cache"
+    external_cache.mkdir()
+    cache_alias = tmp_path / "cache-alias"
+    _symlink(external_cache, cache_alias, target_is_directory=True)
+
+    policy = RuntimeWritePolicy.from_env(
+        graph_alias,
+        env={
+            "MATRYCA_READ_ONLY": "true",
+            "MATRYCA_CACHE_PATH": str(cache_alias),
+        },
+    )
+
+    assert policy.graph_root == graph.resolve(strict=False)
+    assert policy.cache_path == external_cache.resolve(strict=False)
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        policy.ensure_write_allowed(graph_alias / "pages" / "note.md")
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "graph_root_mutation_blocked"
+
+
+def test_runtime_write_policy_blocks_nested_graph_path_when_read_only(tmp_path: Path) -> None:
+    graph = _graph_root(tmp_path)
+    policy = RuntimeWritePolicy(graph_root=graph, read_only=True)
+    nested = graph / "pages" / ".." / "pages" / "note.md"
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        policy.ensure_write_allowed(nested, operation="write note")
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "graph_root_mutation_blocked"
+
+
+def test_runtime_write_policy_blocks_symlink_alias_into_graph(tmp_path: Path) -> None:
+    graph = _graph_root(tmp_path)
+    target = graph / "pages" / "note.md"
+    target.write_text("note", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    alias = outside / "note.md"
+    _symlink(target, alias)
+
+    policy = RuntimeWritePolicy(graph_root=graph, read_only=True)
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        policy.ensure_write_allowed(alias)
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "graph_root_mutation_blocked"
+
+
+@pytest.mark.parametrize("read_only", [False, True])
+def test_runtime_write_policy_rejects_cache_path_inside_graph_for_any_read_only_value(
+    tmp_path: Path, read_only: bool
+) -> None:
+    graph = _graph_root(tmp_path)
+    cache_root = graph / ".matryca_semantic_cache"
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        RuntimeWritePolicy(graph_root=graph, read_only=read_only, cache_path=cache_root)
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "cache_path_inside_graph"
+
+
+def test_runtime_write_policy_rejects_cache_symlink_alias_into_graph(tmp_path: Path) -> None:
+    graph = _graph_root(tmp_path)
+    target_cache_root = graph / "externalized-cache"
+    target_cache_root.mkdir()
+    cache_alias = tmp_path / "cache-alias"
+    _symlink(target_cache_root, cache_alias, target_is_directory=True)
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        RuntimeWritePolicy.from_env(
+            graph,
+            env={
+                "MATRYCA_CACHE_PATH": str(cache_alias),
+            },
+        )
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "cache_path_inside_graph"
+
+
+def test_runtime_write_policy_fails_closed_on_unresolvable_cache_path(tmp_path: Path) -> None:
+    graph = _graph_root(tmp_path)
+    cache_loop = tmp_path / "cache-loop"
+    _symlink(cache_loop, cache_loop)
+
+    with pytest.raises(GraphReadOnlyError) as exc_info:
+        RuntimeWritePolicy.from_env(
+            graph,
+            env={
+                "MATRYCA_READ_ONLY": "true",
+                "MATRYCA_CACHE_PATH": str(cache_loop),
+            },
+        )
+
+    assert exc_info.value.code == "graph_read_only"
+    assert exc_info.value.reason == "cache_path_unresolvable"


### PR DESCRIPTION
## Summary

- define a typed `RuntimeWritePolicy` for strict graph-root write decisions
- add `GraphReadOnlyError` with stable `graph_read_only` code and structured reasons
- parse `MATRYCA_READ_ONLY` strictly and reject ambiguous or unsafe external cache paths
- enforce canonical, symlink-aware containment for graph and cache roots
- synchronize `.env.example`, OpenSpec documentation, tests, and the Unreleased changelog

This PR defines the policy and configuration contract only. CLI, MCP, daemon, Shadow DB, and filesystem caller enforcement remain in the linked follow-up slices.

## Test plan

- [x] `make check`
- [x] 1497 tests passed, 2 skipped, 1 expected failure
- [x] Ruff, mypy, graph read-sandbox, version consistency, agent coherence, and system-prompt checks passed
- [x] focused canonical-path, symlink, invalid-boolean, and external-cache tests passed

Closes #347
Refs #20
Refs #346
