### PR TITLE
feat(safety): enforce read-only entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The soak ran 24 hours of accumulated exercise across 144 cycles and 288 attempts
 ### Security
 
 - **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.
-- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement.
+- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement at the CLI and MCP mutation entry points.
 
 ### Added
 

--- a/src/agent/mcp_server.py
+++ b/src/agent/mcp_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -10,6 +12,8 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from ..config import MatrycaWikiConfig
+from ..graph.graph_path_validate import validate_logseq_graph_path
+from ..graph.safety.write_policy import ensure_graph_write_allowed, is_graph_read_only
 from .graph_dispatch import (
     dispatch_lint,
     dispatch_mutate,
@@ -64,6 +68,40 @@ def register_mcp_tools(mcp: FastMCP) -> None:
             return mcp.tool(*args, **kwargs)(guard_mcp_tool(fn))
 
         return decorator
+
+    def reject_read_only_mutation(
+        action: str,
+        *,
+        payload: str = "",
+        dry_run: bool | None = None,
+    ) -> None:
+        if dry_run is None:
+            dry_run = _mutation_is_dry_run(action, payload)
+        if dry_run:
+            return
+        if not is_graph_read_only():
+            return
+        raw_graph = os.environ.get("LOGSEQ_GRAPH_PATH", "").strip()
+        if not raw_graph:
+            return
+        graph_root = validate_logseq_graph_path(raw_graph)
+        ensure_graph_write_allowed(graph_root, operation=action)
+
+    def _mutation_is_dry_run(action: str, payload: str) -> bool:
+        if action == "write_outline":
+            return False
+        raw = payload.strip()
+        if not raw:
+            return True
+        if not raw.startswith("{"):
+            return False
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(data, dict):
+            return False
+        return bool(data.get("dry_run", True))
 
     @safe_tool()
     async def read_graph_data(
@@ -211,6 +249,7 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         Writes a Map-of-Content index page listing every page under that namespace.
         """
         _ = ctx
+        reject_read_only_mutation(action, payload=payload)
         return await dispatch_mutate(action, target, payload)
 
     @safe_tool()
@@ -232,6 +271,7 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         ``payload`` = optional JSON ``{"max_cards":30, "dry_run":true}``.
         """
         _ = ctx
+        reject_read_only_mutation(action, payload=payload)
         return await dispatch_refactor(action, target_uuid, payload)
 
     @safe_tool()
@@ -273,6 +313,7 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         remember operator preferences for future MCP and daemon LLM runs.
         """
         _ = ctx
+        reject_read_only_mutation("store_fact", dry_run=False)
         return await dispatch_store_fact(fact)
 
     @safe_tool()
@@ -289,6 +330,7 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         writes and optional robot git commits.
         """
         _ = ctx
+        reject_read_only_mutation("ingest_document", dry_run=False)
         return await dispatch_ingest_document(source_name, raw_text)
 
     @safe_tool()
@@ -305,6 +347,7 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         report without touching disk.
         """
         _ = ctx
+        reject_read_only_mutation("import_tana", dry_run=dry_run)
         return await dispatch_tana_import(export_path, dry_run=dry_run)
 
 

--- a/src/agent/mcp_tool_guard.py
+++ b/src/agent/mcp_tool_guard.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from ..daemon.config_layer import append_identity_to_mcp_payload
 from ..graph.path_sandbox import PathTraversalSecurityError
+from ..graph.safety.write_policy import GraphReadOnlyError
 from .mcp_telemetry import _matryca_debug_enabled
 
 
@@ -26,6 +27,8 @@ def _tool_returns_text(fn: Callable[..., Any]) -> bool:
 def _public_tool_error_message(exc: Exception) -> str:
     """Return a client-safe error string (full detail only when ``MATRYCA_DEBUG=true``)."""
     if _matryca_debug_enabled():
+        return str(exc).strip() or exc.__class__.__name__
+    if isinstance(exc, GraphReadOnlyError):
         return str(exc).strip() or exc.__class__.__name__
     if isinstance(exc, PathTraversalSecurityError):
         return str(exc).strip() or exc.__class__.__name__
@@ -78,6 +81,14 @@ def guard_mcp_tool[F: Callable[..., Awaitable[Any]]](fn: F) -> F:
                 as_text=returns_text,
                 code="security_violation",
                 hint="Stay within LOGSEQ_GRAPH_PATH and retry with a valid page reference.",
+            )
+        except GraphReadOnlyError as exc:
+            logger.bind(tool=fn.__name__).warning("MCP tool read-only error: {}", exc)
+            return format_tool_error(
+                exc,
+                as_text=returns_text,
+                code=exc.code,
+                hint="Unset MATRYCA_READ_ONLY or retry with a dry-run-only action.",
             )
         except ValueError as exc:
             logger.bind(tool=fn.__name__).warning("MCP tool validation error: {}", exc)

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 from typing import Any
 
@@ -36,6 +37,12 @@ from ..agent.maintenance_daemon import (
 )
 from ..agent.tana_import import run_tana_import
 from ..config import load_matryca_wiki_config
+from ..graph.graph_path_validate import validate_logseq_graph_path
+from ..graph.safety.write_policy import (
+    GraphReadOnlyError,
+    ensure_graph_write_allowed,
+    is_graph_read_only,
+)
 from ..graph.service_manager import manage_matryca_service
 from ..utils.runtime_bootstrap import try_prepare_matryca_runtime_from_env
 from ..utils.secret_redaction import redact_secrets_in_text
@@ -278,6 +285,46 @@ def _emit_error(message: str) -> None:
         sys.stderr.write("\n")
 
 
+def _mutation_is_dry_run(action: str, payload: str) -> bool:
+    if action == "write_outline":
+        return False
+    raw = payload.strip()
+    if not raw:
+        return True
+    if not raw.startswith("{"):
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    return bool(data.get("dry_run", True))
+
+
+def _reject_read_only_mutation(action: str, *, payload: str, dry_run: bool | None = None) -> None:
+    if dry_run is None:
+        dry_run = _mutation_is_dry_run(action, payload)
+    if dry_run:
+        return
+    if not is_graph_read_only():
+        return
+    raw_graph = os.environ.get("LOGSEQ_GRAPH_PATH", "").strip()
+    if not raw_graph:
+        return
+    graph_root = validate_logseq_graph_path(raw_graph)
+    ensure_graph_write_allowed(graph_root, operation=action)
+
+
+def _reject_read_only_cli_mutation(args: argparse.Namespace) -> None:
+    """Reject an applying CLI mutation before runtime bootstrap can write locally."""
+
+    if args.command in {"mutate", "refactor"}:
+        _reject_read_only_mutation(args.action, payload=args.payload)
+    elif args.command == "import" and args.import_command == "tana" and args.apply:
+        _reject_read_only_mutation("import_tana", payload="", dry_run=False)
+
+
 async def run_cli(args: argparse.Namespace) -> int:
     """Dispatch parsed CLI arguments to graph handlers."""
     wiki_config = load_matryca_wiki_config()
@@ -306,6 +353,11 @@ async def run_cli(args: argparse.Namespace) -> int:
         return 0
 
     if command == "mutate":
+        try:
+            _reject_read_only_mutation(args.action, payload=args.payload)
+        except GraphReadOnlyError as exc:
+            _emit_error(f"{exc.code}: {exc}")
+            return 1
         mutate_out: dict[str, Any] = await dispatch_mutate(
             args.action,
             args.target,
@@ -317,6 +369,11 @@ async def run_cli(args: argparse.Namespace) -> int:
         return 0
 
     if command == "refactor":
+        try:
+            _reject_read_only_mutation(args.action, payload=args.payload)
+        except GraphReadOnlyError as exc:
+            _emit_error(f"{exc.code}: {exc}")
+            return 1
         refactor_out: dict[str, Any] = await dispatch_refactor(
             args.action,
             args.target_uuid,
@@ -387,6 +444,12 @@ async def run_cli(args: argparse.Namespace) -> int:
                 _emit_error(
                     "DRY-RUN MODE: No files written to disk. Use --apply to commit.\n",
                 )
+            else:
+                try:
+                    _reject_read_only_mutation("import_tana", payload="", dry_run=False)
+                except GraphReadOnlyError as exc:
+                    _emit_error(f"{exc.code}: {exc}")
+                    return 1
             import_result = run_tana_import(args.export_file, apply=args.apply)
             _emit_result(import_result.to_dict(), as_json=True, command="import tana")
             return 0 if import_result.ok else 1
@@ -413,6 +476,11 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     ui_only = args.command == "plumber" and args.plumber_action in {"status", "ui"}
     skip_eager_bootstrap = args.command == "plumber" and args.plumber_action == "start"
+    try:
+        _reject_read_only_cli_mutation(args)
+    except GraphReadOnlyError as exc:
+        _emit_error(f"{exc.code}: {exc}")
+        raise SystemExit(1) from exc
     if not ui_only and not skip_eager_bootstrap:
         try_prepare_matryca_runtime_from_env(eager_graph=_cli_eager_graph(args))
     if ui_only:

--- a/src/graph/safety/write_policy.py
+++ b/src/graph/safety/write_policy.py
@@ -86,7 +86,7 @@ class RuntimeWritePolicy:
         """Build the policy from environment-backed configuration."""
 
         if env is None:
-            read_only = _mapping_bool(os.environ, MATRYCA_READ_ONLY_ENV, default=False)
+            read_only = is_graph_read_only()
             cache_raw = os.environ.get(MATRYCA_CACHE_PATH_ENV, "").strip()
         else:
             read_only = _mapping_bool(env, MATRYCA_READ_ONLY_ENV, default=False)
@@ -128,4 +128,27 @@ def _mapping_bool(env: Mapping[str, str], key: str, *, default: bool) -> bool:
     raise ValueError(f"invalid boolean token for {key}: {env.get(key)!r}")
 
 
-__all__ = ["GraphReadOnlyError", "RuntimeWritePolicy"]
+def is_graph_read_only(env: Mapping[str, str] | None = None) -> bool:
+    """Return the validated runtime read-only setting without touching the graph path."""
+
+    source = os.environ if env is None else env
+    return _mapping_bool(source, MATRYCA_READ_ONLY_ENV, default=False)
+
+
+def ensure_graph_write_allowed(
+    graph_root: str | Path,
+    *,
+    operation: str,
+) -> None:
+    """Apply the environment-backed policy to a graph-root write request."""
+
+    policy = RuntimeWritePolicy.from_env(graph_root)
+    policy.ensure_write_allowed(policy.graph_root, operation=operation)
+
+
+__all__ = [
+    "GraphReadOnlyError",
+    "RuntimeWritePolicy",
+    "ensure_graph_write_allowed",
+    "is_graph_read_only",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from .config import load_matryca_wiki_config
 from .graph.markdown_blocks import sweep_dangling_atomic_tmp_files
 from .graph.page_write_lock import clear_page_write_locks
 from .graph.path_sandbox import resolved_graph_root
+from .graph.safety.write_policy import RuntimeWritePolicy
 from .utils.logging_config import configure_loguru
 from .utils.runtime_bootstrap import prepare_matryca_runtime
 
@@ -41,13 +42,16 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     if graph_path:
         resolved_root = resolved_graph_root(graph_path)
         os.chdir(str(resolved_root))
+    read_only = resolved_root is not None and RuntimeWritePolicy.from_env(resolved_root).read_only
     # Lazy AST: handshake must not block on full-vault parse (Hermes connect_timeout).
-    prepare_matryca_runtime(
-        graph_root=resolved_root,
-        wiki_config=wiki_config,
-        eager_graph=False,
-    )
-    if resolved_root is not None:
+    # In read-only mode this bootstrap would create graph-local cache/template files.
+    if not read_only:
+        prepare_matryca_runtime(
+            graph_root=resolved_root,
+            wiki_config=wiki_config,
+            eager_graph=False,
+        )
+    if resolved_root is not None and not read_only:
         swept = await asyncio.to_thread(sweep_dangling_atomic_tmp_files, str(resolved_root))
         if swept:
             logger.bind(graph=str(resolved_root), removed=swept).info(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,7 +17,9 @@ from src.agent.graph_tool_helpers import (
     read_xray_page_markdown,
 )
 from src.agent.mcp_server import OutlineNode, register_mcp_tools
+from src.agent.mcp_tool_guard import guard_mcp_tool
 from src.agent.outline_models import validate_outline_for_write
+from src.graph.safety.write_policy import GraphReadOnlyError
 
 
 def test_mcp_registers_five_mega_tools() -> None:
@@ -35,6 +37,23 @@ def test_mcp_registers_five_mega_tools() -> None:
         "search_graph",
         "store_fact",
     ]
+
+
+@pytest.mark.asyncio
+async def test_guard_mcp_tool_returns_graph_read_only_error() -> None:
+    @guard_mcp_tool
+    async def sample() -> dict[str, Any]:
+        raise GraphReadOnlyError(
+            "write_outline",
+            path="/tmp/graph/pages/Demo.md",
+            reason="graph_root_mutation_blocked",
+        )
+
+    out = await sample()
+
+    assert out["ok"] is False
+    assert out["code"] == "graph_read_only"
+    assert "graph read-only policy" in out["error"]
 
 
 def test_parse_optional_json_query_accepts_plain_or_json() -> None:

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -56,6 +56,35 @@ def test_cli_main_calls_try_prepare_before_dispatch(monkeypatch: pytest.MonkeyPa
     assert eager_flags == [True]
 
 
+def test_cli_main_rejects_read_only_write_before_prepare(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.cli import main as cli_main
+
+    graph = _minimal_graph(tmp_path)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setattr(
+        "src.cli.try_prepare_matryca_runtime_from_env",
+        lambda **_kwargs: pytest.fail("bootstrap must not run"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(
+            [
+                "mutate",
+                "write_outline",
+                "--target",
+                "parent-uuid",
+                "--payload",
+                '{"text":"x","children":[]}',
+            ],
+        )
+
+    assert exc.value.code == 1
+
+
 def test_cli_eager_graph_route_matrix() -> None:
     from argparse import Namespace
 
@@ -66,6 +95,76 @@ def test_cli_eager_graph_route_matrix() -> None:
     assert _cli_eager_graph(Namespace(command="search", method="semantic")) is True
     assert _cli_eager_graph(Namespace(command="read", method=None)) is True
     assert _cli_eager_graph(Namespace(command="lint", method=None)) is True
+
+
+@pytest.mark.asyncio
+async def test_cli_rejects_read_only_write_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from argparse import Namespace
+
+    from src.cli import run_cli
+
+    graph = _minimal_graph(tmp_path)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    called = {"mutate": False}
+
+    async def _dispatch_mutate(*args: object, **kwargs: object) -> dict[str, object]:
+        called["mutate"] = True
+        return {"ok": True}
+
+    monkeypatch.setattr("src.cli.dispatch_mutate", _dispatch_mutate)
+
+    code = await run_cli(
+        Namespace(
+            command="mutate",
+            action="write_outline",
+            target="parent-uuid",
+            payload='{"text":"x","children":[]}',
+            json=False,
+        ),
+    )
+
+    assert code == 1
+    assert called["mutate"] is False
+
+
+@pytest.mark.asyncio
+async def test_cli_allows_dry_run_append_journal_under_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from argparse import Namespace
+
+    from src.cli import run_cli
+
+    graph = _minimal_graph(tmp_path)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    called = {"mutate": False}
+
+    async def _dispatch_mutate(*args: object, **kwargs: object) -> dict[str, object]:
+        called["mutate"] = True
+        return {"ok": True, "dry_run": True}
+
+    monkeypatch.setattr("src.cli.dispatch_mutate", _dispatch_mutate)
+
+    code = await run_cli(
+        Namespace(
+            command="mutate",
+            action="append_journal",
+            target="",
+            payload='{"markdown_body":"- dry run note","dry_run":true}',
+            json=False,
+        ),
+    )
+
+    assert code == 0
+    assert called["mutate"] is True
 
 
 @pytest.mark.asyncio
@@ -100,6 +199,29 @@ async def test_mcp_lifespan_calls_prepare_before_yield(
     assert isinstance(graph_root, Path)
     assert graph_root.resolve() == graph.resolve()
     assert calls[0]["eager_graph"] is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_lifespan_skips_graph_writes_in_read_only_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.main import app_lifespan
+
+    graph = _minimal_graph(tmp_path)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setattr(
+        "src.main.prepare_matryca_runtime",
+        lambda **_kwargs: pytest.fail("bootstrap must not run"),
+    )
+    monkeypatch.setattr(
+        "src.main.sweep_dangling_atomic_tmp_files",
+        lambda _path: pytest.fail("sweep must not run"),
+    )
+
+    async with app_lifespan(MagicMock()):
+        pass
 
 
 def test_start_daemon_foreground_defers_prepare_to_run_forever(


### PR DESCRIPTION
## Summary
- enforce MATRYCA_READ_ONLY at CLI and MCP public mutation entry points
- reject applying CLI commands before bootstrap and suppress MCP startup writes in read-only mode
- return the stable graph_read_only MCP error and retain only documented dry-run paths

## Verification
- make check

Closes #348
Refs #346
Refs #20