### PR TITLE
feat(safety): guard graph mutation primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The soak ran 24 hours of accumulated exercise across 144 cycles and 288 attempts
 ### Security
 
 - **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.
-- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement at the CLI and MCP mutation entry points.
+- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement at the CLI and MCP mutation entry points, then extend the same read-only policy to shared atomic write and page-lock primitives before mkdir, temp creation, lock acquisition, rename, unlink, or post-write hook dispatch.
 
 ### Added
 

--- a/src/graph/markdown_blocks.py
+++ b/src/graph/markdown_blocks.py
@@ -15,6 +15,7 @@ from .io_retry import IO_RETRY_ATTEMPTS, IO_RETRY_INITIAL_DELAY_S, IO_RETRY_MAX_
 from .logseq_uuid import assert_valid_block_refs_in_markdown
 from .path_sandbox import PathTraversalSecurityError, assert_path_within_graph, read_graph_file_text
 from .path_sandbox import graph_safe_page_path as _graph_safe_page_path
+from .safety.write_policy import guard_graph_mutation
 
 _BULLET = re.compile(r"^(\s*)[-*+]\s+")
 # mkstemp(prefix=f".{basename}.", suffix=".tmp") → ``.{name}.{token}.tmp``
@@ -270,6 +271,7 @@ def atomic_write_bytes_if_unchanged(
     robot_commit_summary: str | None = None,
 ) -> bool:
     """Commit only when ``baseline_mtime`` still matches. Returns ``True`` when written."""
+    guard_graph_mutation(graph_root, file_path, operation="atomic_write_bytes_if_unchanged")
     if file_mtime_drifted(file_path, baseline_mtime):
         return False
     try:
@@ -304,6 +306,7 @@ def atomic_write_bytes(
         ValueError: When ``file_path`` escapes ``graph_root`` or a ``*.md`` payload contains a
             malformed ``((uuid))`` block reference (unless ``validate_block_refs=False``).
     """
+    guard_graph_mutation(graph_root, file_path, operation="atomic_write_bytes")
     is_markdown = Path(file_path).suffix.lower() == ".md"
     if validate_block_refs and is_markdown and b"((" in data:
         text = data.decode("utf-8")
@@ -411,6 +414,7 @@ def sweep_dangling_atomic_tmp_files(graph_root: str | Path) -> int:
     Scans ``pages/`` and ``journals/`` (including nested folders). Returns the count
     of files unlinked.
     """
+    guard_graph_mutation(graph_root, graph_root, operation="sweep_dangling_atomic_tmp_files")
     root = Path(graph_root).expanduser().resolve(strict=False)
     removed = 0
     for sub in ("pages", "journals"):

--- a/src/graph/page_write_lock.py
+++ b/src/graph/page_write_lock.py
@@ -22,6 +22,7 @@ from .io_retry import (
     IO_RETRY_MAX_DELAY_S,
     PageLockUnavailableError,
 )
+from .safety.write_policy import guard_graph_mutation, guard_graph_mutation_from_env
 
 _registry_guard = threading.Lock()
 _page_locks: OrderedDict[str, threading.RLock] = OrderedDict()
@@ -96,6 +97,7 @@ def probe_page_rmw_lock(page_path: str | Path) -> None:
     Raises:
         PageLockUnavailableError: When thread or cross-process locks are contended.
     """
+    guard_graph_mutation_from_env(page_path, operation="probe_page_rmw_lock")
     key = normalize_page_lock_key(page_path)
     thread_lock = _lock_for_key(key)
     if not thread_lock.acquire(blocking=False):
@@ -114,6 +116,7 @@ def probe_page_rmw_lock(page_path: str | Path) -> None:
 @contextmanager
 def page_rmw_lock(page_path: str | Path) -> Iterator[None]:
     """Hold an exclusive lock for one file's full RMW lifecycle (thread- and process-safe)."""
+    guard_graph_mutation_from_env(page_path, operation="page_rmw_lock")
     key = normalize_page_lock_key(page_path)
     thread_lock = _lock_for_key(key)
     delay = IO_RETRY_INITIAL_DELAY_S
@@ -146,6 +149,7 @@ def clear_page_write_locks() -> None:
 
 def sweep_matryca_lock_sidecars(graph_root: str | Path) -> int:
     """Remove orphan ``.{page}.matryca.lock`` sidecars under ``pages/`` and ``journals/``."""
+    guard_graph_mutation(graph_root, graph_root, operation="sweep_matryca_lock_sidecars")
     root = Path(graph_root).expanduser().resolve(strict=False)
     removed = 0
     for sub in ("pages", "journals"):

--- a/src/graph/safety/write_policy.py
+++ b/src/graph/safety/write_policy.py
@@ -146,9 +146,41 @@ def ensure_graph_write_allowed(
     policy.ensure_write_allowed(policy.graph_root, operation=operation)
 
 
+def guard_graph_mutation(
+    graph_root: str | Path,
+    path: str | Path,
+    *,
+    operation: str,
+) -> None:
+    """Fail closed for graph-local mutations when read-only is enabled."""
+
+    if not is_graph_read_only():
+        return
+    policy = RuntimeWritePolicy(graph_root=Path(graph_root), read_only=True)
+    policy.ensure_write_allowed(path, operation=operation)
+
+
+def guard_graph_mutation_from_env(
+    path: str | Path,
+    *,
+    operation: str,
+) -> None:
+    """Fail closed for env-resolved graph mutations when read-only is enabled."""
+
+    if not is_graph_read_only():
+        return
+    raw_graph = os.environ.get("LOGSEQ_GRAPH_PATH", "").strip()
+    if not raw_graph:
+        raise GraphReadOnlyError(operation, path=path, reason="graph_root_unresolvable")
+    policy = RuntimeWritePolicy(graph_root=Path(raw_graph), read_only=True)
+    policy.ensure_write_allowed(path, operation=operation)
+
+
 __all__ = [
     "GraphReadOnlyError",
     "RuntimeWritePolicy",
     "ensure_graph_write_allowed",
+    "guard_graph_mutation",
+    "guard_graph_mutation_from_env",
     "is_graph_read_only",
 ]

--- a/tests/test_markdown_blocks_hygiene.py
+++ b/tests/test_markdown_blocks_hygiene.py
@@ -9,10 +9,12 @@ from unittest.mock import patch
 import pytest
 from src.graph.markdown_blocks import (
     atomic_write_bytes,
+    atomic_write_bytes_if_unchanged,
     file_mtime_drifted,
     occ_snapshot,
     sweep_dangling_atomic_tmp_files,
 )
+from src.graph.safety.write_policy import GraphReadOnlyError
 
 
 def test_occ_snapshot_returns_mtime_ns(tmp_path: Path) -> None:
@@ -60,6 +62,74 @@ def test_atomic_write_unlinks_temp_when_replace_fails(
     assert temps_before == []
 
 
+def test_atomic_write_bytes_blocks_early_when_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    target = tmp_path / "pages" / "Blocked.md"
+    target.parent.mkdir(parents=True)
+
+    with (
+        patch("src.graph.markdown_blocks.tempfile.mkstemp", side_effect=AssertionError("mkstemp")),
+        patch("src.graph.markdown_blocks.os.replace", side_effect=AssertionError("replace")),
+        patch("src.graph.markdown_blocks.Path.mkdir", side_effect=AssertionError("mkdir")),
+        pytest.raises(GraphReadOnlyError),
+    ):
+        atomic_write_bytes(target, b"payload", graph_root=tmp_path)
+
+
+def test_atomic_write_bytes_if_unchanged_blocks_before_delegate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    target = tmp_path / "pages" / "Blocked.md"
+
+    with (
+        patch(
+            "src.graph.markdown_blocks.atomic_write_bytes",
+            side_effect=AssertionError("delegate"),
+        ),
+        pytest.raises(GraphReadOnlyError),
+    ):
+        atomic_write_bytes_if_unchanged(
+            target,
+            b"payload",
+            graph_root=tmp_path,
+            baseline_mtime=0,
+        )
+
+
+def test_atomic_write_bytes_blocks_symlink_containment_in_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    target_dir = graph / "pages"
+    target_dir.mkdir(parents=True)
+    target = target_dir / "Live.md"
+    target.write_text("- live\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    alias = outside / "Alias.md"
+    try:
+        alias.symlink_to(target)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with (
+        patch("src.graph.markdown_blocks.tempfile.mkstemp", side_effect=AssertionError("mkstemp")),
+        pytest.raises(GraphReadOnlyError),
+    ):
+        atomic_write_bytes(alias, b"payload", graph_root=graph)
+
+
 def test_sweep_dangling_atomic_tmp_files_removes_orphans(tmp_path: Path) -> None:
     pages = tmp_path / "pages"
     journals = tmp_path / "journals"
@@ -77,6 +147,26 @@ def test_sweep_dangling_atomic_tmp_files_removes_orphans(tmp_path: Path) -> None
     assert not orphan_page.exists()
     assert not orphan_journal.exists()
     assert keep_page.read_text(encoding="utf-8") == "live"
+
+
+def test_sweep_dangling_atomic_tmp_files_blocks_when_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = tmp_path / "pages"
+    journals = tmp_path / "journals"
+    pages.mkdir()
+    journals.mkdir()
+    (pages / ".Note.md.deadbeef.tmp").write_bytes(b"stale")
+
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with (
+        patch("src.graph.markdown_blocks.Path.unlink", side_effect=AssertionError("unlink")),
+        pytest.raises(GraphReadOnlyError),
+    ):
+        sweep_dangling_atomic_tmp_files(tmp_path)
 
 
 def test_sweep_ignores_unrelated_hidden_files(tmp_path: Path) -> None:

--- a/tests/test_page_write_lock_probe.py
+++ b/tests/test_page_write_lock_probe.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import threading
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from src.graph.io_retry import PageLockUnavailableError
-from src.graph.page_write_lock import clear_page_write_locks, page_rmw_lock, probe_page_rmw_lock
+from src.graph.page_write_lock import (
+    clear_page_write_locks,
+    page_rmw_lock,
+    probe_page_rmw_lock,
+    sweep_matryca_lock_sidecars,
+)
+from src.graph.safety.write_policy import GraphReadOnlyError
 
 
 @pytest.fixture(autouse=True)
@@ -46,3 +53,87 @@ def test_probe_page_rmw_lock_fails_when_thread_lock_held(tmp_path: Path) -> None
     finally:
         release.set()
         thread.join(timeout=2.0)
+
+
+def test_probe_page_rmw_lock_blocks_before_locking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "pages" / "ReadOnly.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("- read only\n", encoding="utf-8")
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with pytest.raises(GraphReadOnlyError), monkeypatch.context() as ctx:
+        ctx.setattr(
+            "src.graph.page_write_lock._lock_for_key",
+            lambda _key: (_ for _ in ()).throw(AssertionError("lock")),
+        )
+        ctx.setattr(
+            "src.graph.page_write_lock.probe_exclusive_flock",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("flock")),
+        )
+        probe_page_rmw_lock(target)
+
+
+def test_page_rmw_lock_blocks_before_locking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "pages" / "ReadOnly.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("- read only\n", encoding="utf-8")
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with pytest.raises(GraphReadOnlyError), monkeypatch.context() as ctx:
+        ctx.setattr(
+            "src.graph.page_write_lock._lock_for_key",
+            lambda _key: (_ for _ in ()).throw(AssertionError("lock")),
+        )
+        ctx.setattr(
+            "src.graph.page_write_lock._cross_process_file_lock",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("flock")),
+        )
+        with page_rmw_lock(target):
+            pass
+
+
+def test_page_lock_symlink_containment_blocks_in_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    target = graph / "pages" / "Live.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("- live\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    alias = outside / "Alias.md"
+    try:
+        alias.symlink_to(target)
+    except (AttributeError, NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with pytest.raises(GraphReadOnlyError):
+        probe_page_rmw_lock(alias)
+
+
+def test_sweep_matryca_lock_sidecars_blocks_before_unlinking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / ".ReadOnly.md.matryca.lock").write_text("lock", encoding="utf-8")
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with (
+        patch("src.graph.page_write_lock.Path.unlink", side_effect=AssertionError("unlink")),
+        pytest.raises(GraphReadOnlyError),
+    ):
+        sweep_matryca_lock_sidecars(tmp_path)


### PR DESCRIPTION
## Summary
- enforce read-only policy in shared atomic writes and page RMW locks
- block temp cleanup and lock-sidecar deletion before graph-local side effects
- add direct primitive tests for early rejection, symlink containment, and normal behavior

## Test plan
- [x] make check

Refs #349
Refs #346
Refs #20