### PR TITLE
feat(safety): guard read-only runtime bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - **Prerelease publication metadata** — release tags containing a SemVer prerelease suffix now create GitHub prereleases instead of stable releases while preserving the curated changelog notes and PyPI trusted-publishing flow.
+- **Read-only runtime bootstrap safety** — `prepare_matryca_runtime()` now skips graph-local cache/templates, seeded wiki config, L1 provisioning, Shadow startup, and dangling tmp cleanup when `MATRYCA_READ_ONLY=true`, so CLI read bootstrap and direct startup preserve reads without creating vault artifacts.
 
 ### Changed
 

--- a/src/utils/runtime_bootstrap.py
+++ b/src/utils/runtime_bootstrap.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from ..agent.l1_memory import ensure_matryca_l1_dir
 from ..config import MatrycaWikiConfig, load_matryca_wiki_config
+from ..graph.safety.write_policy import RuntimeWritePolicy, is_graph_read_only
 from .config_paths import ensure_plumber_log_directories
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -131,6 +132,13 @@ def prepare_matryca_runtime(
     """
     ensure_plumber_log_directories()
     if graph_root is None:
+        return
+
+    policy = RuntimeWritePolicy(graph_root=graph_root, read_only=is_graph_read_only())
+    if policy.read_only:
+        logger.bind(graph=str(policy.graph_root)).info(
+            "Skipping graph-local runtime bootstrap under read-only policy",
+        )
         return
 
     cfg = wiki_config or MatrycaWikiConfig()

--- a/tests/test_runtime_bootstrap_contract.py
+++ b/tests/test_runtime_bootstrap_contract.py
@@ -179,6 +179,36 @@ def test_prepare_does_not_create_lazy_runtime_ledgers(tmp_path: Path) -> None:
     assert not (graph / ".matryca_semantic_cache" / "master_catalog.json").exists()
 
 
+def test_prepare_matryca_runtime_skips_graph_local_bootstrap_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    ops = tmp_path / "logs" / "ops.log"
+    loguru = tmp_path / "logs" / "app.log"
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(ops))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(loguru))
+
+    def _blocked(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("read-only bootstrap must not touch graph-local runtime artifacts")
+
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_l1_dir", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
+    monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
+    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    assert ops.parent.is_dir()
+    assert loguru.parent.is_dir()
+    assert not (graph / ".matryca_semantic_cache").exists()
+    assert not (graph / "templates").exists()
+    assert not (graph / "matryca-wiki.yml").exists()
+    assert not _expected_sibling_l1(graph).exists()
+
+
 # ---------------------------------------------------------------------------
 # Environment-driven prepare
 # ---------------------------------------------------------------------------
@@ -197,6 +227,45 @@ def test_try_prepare_from_env_with_valid_graph(
 
     assert _expected_sibling_l1(graph).is_dir()
     assert (graph / ".matryca_semantic_cache").is_dir()
+
+
+def test_try_prepare_from_env_with_read_only_graph_skips_graph_local_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    ops = tmp_path / "logs" / "ops.log"
+    loguru = tmp_path / "logs" / "app.log"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(ops))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(loguru))
+    monkeypatch.setattr(
+        "src.utils.runtime_bootstrap.ensure_repo_dotenv_from_example",
+        lambda **_kw: False,
+    )
+    monkeypatch.setattr(
+        "src.agent.plumber_config.reload_plumber_dotenv",
+        lambda **_kw: None,
+    )
+
+    def _blocked(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("read-only CLI bootstrap must not touch graph-local runtime artifacts")
+
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_l1_dir", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
+    monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
+    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+
+    try_prepare_matryca_runtime_from_env()
+
+    assert ops.parent.is_dir()
+    assert loguru.parent.is_dir()
+    assert not (graph / ".matryca_semantic_cache").exists()
+    assert not (graph / "templates").exists()
+    assert not (graph / "matryca-wiki.yml").exists()
+    assert not _expected_sibling_l1(graph).exists()
 
 
 def test_try_prepare_invalid_graph_still_ensures_logs_only(

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -56,6 +56,50 @@ def test_cli_main_calls_try_prepare_before_dispatch(monkeypatch: pytest.MonkeyPa
     assert eager_flags == [True]
 
 
+def test_cli_main_read_only_read_path_skips_graph_local_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.cli import main as cli_main
+
+    graph = _minimal_graph(tmp_path)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(tmp_path / "logs" / "ops.log"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(tmp_path / "logs" / "app.log"))
+    monkeypatch.setattr(
+        "src.utils.runtime_bootstrap.ensure_repo_dotenv_from_example",
+        lambda **_kw: False,
+    )
+    monkeypatch.setattr(
+        "src.agent.plumber_config.reload_plumber_dotenv",
+        lambda **_kw: None,
+    )
+
+    def _blocked(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("read-only CLI bootstrap must not touch graph-local runtime artifacts")
+
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_l1_dir", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
+    monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
+    monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
+    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+
+    async def _run_cli(_args: object) -> int:
+        return 0
+
+    monkeypatch.setattr("src.cli.run_cli", _run_cli)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["read", "memory"])
+
+    assert exc.value.code == 0
+    assert not (graph / ".matryca_semantic_cache").exists()
+    assert not (graph / "templates").exists()
+    assert not (graph / "matryca-wiki.yml").exists()
+    assert not (tmp_path / "matryca-l1").exists()
+
+
 def test_cli_main_rejects_read_only_write_before_prepare(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- prevent graph-local runtime bootstrap artifacts when read-only mode is active
- cover direct bootstrap and CLI read-path bootstrap with regression tests
- preserve normal startup provisioning behavior

## Test plan
- [x] make check

Refs #349
Refs #346
Refs #20