### PR TITLE
fix(read-only): guard graph-local sidecar persistence (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The soak ran 24 hours of accumulated exercise across 144 cycles and 288 attempts
 ### Security
 
 - **GitPython dependency hardening** — require `GitPython>=3.1.52` and lock `3.1.54` to include the current dependency security fixes.
-- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement at the CLI and MCP mutation entry points, then extend the same read-only policy to shared atomic write and page-lock primitives before mkdir, temp creation, lock acquisition, rename, unlink, or post-write hook dispatch.
+- **Strict read-only graph-write contract** — add `MATRYCA_READ_ONLY=false` and optional `MATRYCA_CACHE_PATH`, plus `RuntimeWritePolicy` / `GraphReadOnlyError(code=graph_read_only)`, to define fail-closed canonical graph containment ahead of caller enforcement at the CLI and MCP mutation entry points; extend the same policy to shared atomic/page-lock primitives and graph-local daemon-state, master-catalog, and block-vector persistence before mkdir, temp creation, lock acquisition, rename, backup, unlink, cache invalidation, or post-write hook dispatch, while preserving explicitly external cache writes.
 
 ### Added
 

--- a/src/agent/daemon_state.py
+++ b/src/agent/daemon_state.py
@@ -23,6 +23,7 @@ from ..graph.bootstrap_harvest import BootstrapHarvestStatus
 from ..graph.graph_analytics import reconcile_telemetry_ledger
 from ..graph.json_flock import cross_process_json_flock
 from ..graph.path_sandbox import graph_relative_path_key, normalize_daemon_file_key
+from ..graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .journey_log import JourneyDayLedger
 from .plumber_config import DEFAULT_LM_MODEL, resolve_llm_model_name
@@ -448,6 +449,11 @@ def load_daemon_state(graph_root: Path) -> DaemonState:
 def save_daemon_state(graph_root: Path, state: DaemonState) -> None:
     """Persist daemon state via POSIX atomic write-and-replace under a cross-process flock."""
     path = state_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="save_daemon_state")
+    except GraphReadOnlyError:
+        logger.debug("Skipping graph-local daemon state save under read-only policy")
+        return
     normalize_daemon_state_file_keys(graph_root, state)
     payload = json.dumps(state.to_json(), indent=2, ensure_ascii=False) + "\n"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -21,6 +21,7 @@ from .json_flock import cross_process_json_flock
 from .markdown_blocks import atomic_write_bytes, occ_snapshot
 from .markdown_io import MmapTextView, read_graph_page_text
 from .path_sandbox import read_graph_file_text
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 
 CATALOG_FILENAME = "master_catalog.json"
 CATALOG_VERSION = 1
@@ -153,6 +154,11 @@ class MasterCatalog:
             )
             return
         path = self.catalog_path(self.graph_root)
+        try:
+            guard_graph_mutation(self.graph_root, path, operation="save_master_catalog")
+        except GraphReadOnlyError:
+            logger.debug("Skipping graph-local master catalog save under read-only policy")
+            return
         path.parent.mkdir(parents=True, exist_ok=True)
         with self._lock:
             pending = dict(self.pages)

--- a/src/semantic/store.py
+++ b/src/semantic/store.py
@@ -16,6 +16,7 @@ import ijson
 from loguru import logger
 
 from ..graph.json_flock import cross_process_json_flock
+from ..graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 
 BLOCK_VECTORS_FILENAME = "block_vectors.json"
@@ -209,6 +210,11 @@ class BlockVectorStore:
 
     def save(self) -> None:
         path = self.store_path(self.graph_root)
+        try:
+            guard_graph_mutation(self.graph_root, path, operation="save_block_vector_store")
+        except GraphReadOnlyError:
+            logger.debug("Skipping graph-local block vector save under read-only policy")
+            return
         path.parent.mkdir(parents=True, exist_ok=True)
         with cross_process_json_flock(path), self._lock:
             self.updated_at = datetime.now(tz=UTC).isoformat()
@@ -310,6 +316,11 @@ def apply_page_block_vector_updates(
     """Apply page-scoped upserts/prunes via streaming merge (avoids full-vault RAM load)."""
     root = graph_root.expanduser().resolve(strict=False)
     path = BlockVectorStore.store_path(root)
+    try:
+        guard_graph_mutation(root, path, operation="apply_page_block_vector_updates")
+    except GraphReadOnlyError:
+        logger.debug("Skipping graph-local block vector update under read-only policy")
+        return 0, 0
 
     embedding_dim = (
         _coerce_embedding_dim(_read_block_vectors_header(path).get("embedding_dim"))

--- a/tests/test_dual_embedding.py
+++ b/tests/test_dual_embedding.py
@@ -12,6 +12,7 @@ from src.semantic.math_util import cosine_similarity, hybrid_score
 from src.semantic.search import hybrid_block_search
 from src.semantic.store import (
     BlockVectorRecord,
+    BlockVectorStore,
     apply_page_block_vector_updates,
     clear_block_vector_store_cache,
     iter_block_records_from_disk,
@@ -659,6 +660,134 @@ def test_apply_page_block_vector_updates_preserves_other_pages(
     assert "other-page-block" in reloaded.blocks
     assert "demo-stale" not in reloaded.blocks
     assert reloaded.blocks["demo-new"].block_text == "fresh"
+
+
+def test_block_vector_store_skips_graph_local_save_when_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    def _unexpected_cache_update(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("read-only save must not update the resident cache")
+
+    monkeypatch.setattr(
+        "src.semantic.store._cache_block_vector_store",
+        _unexpected_cache_update,
+    )
+    store = BlockVectorStore(graph_root=graph)
+    store.upsert(
+        "uuid-block",
+        BlockVectorRecord(
+            page_title="Demo",
+            block_text="blocked",
+            applicability_text="blocked",
+            vec_content=[1.0, 0.0],
+            vec_applicability=[1.0, 0.0],
+            updated_at="t",
+        ),
+    )
+
+    store.save()
+
+    assert not BlockVectorStore.store_path(graph).exists()
+    assert not (graph / ".matryca_semantic_cache").exists()
+
+
+def test_apply_page_block_vector_updates_preserves_graph_store_when_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    clear_block_vector_store_cache()
+    store = load_block_vector_store(graph)
+    store.upsert(
+        "uuid-block",
+        BlockVectorRecord(
+            page_title="Demo",
+            block_text="seed",
+            applicability_text="cached",
+            vec_content=[1.0, 0.0],
+            vec_applicability=[1.0, 0.0],
+            updated_at="t",
+        ),
+    )
+    store.save()
+    path = BlockVectorStore.store_path(graph)
+    before = path.read_bytes()
+
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    def _unexpected_cache_invalidation(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("read-only update must not invalidate the block vector cache")
+
+    monkeypatch.setattr(
+        "src.semantic.store._invalidate_block_vector_cache",
+        _unexpected_cache_invalidation,
+    )
+    result = apply_page_block_vector_updates(
+        graph,
+        "Demo",
+        upserts={
+            "uuid-updated": BlockVectorRecord(
+                page_title="Demo",
+                block_text="updated",
+                applicability_text="updated",
+                vec_content=[0.0, 1.0],
+                vec_applicability=[0.5, 0.5],
+                updated_at="t2",
+            ),
+        },
+        keep_uuids={"uuid-updated"},
+    )
+
+    assert result == (0, 0)
+    assert path.read_bytes() == before
+    assert not path.with_suffix(".json.tmp").exists()
+
+
+def test_apply_page_block_vector_updates_allows_external_store_when_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    external_cache = tmp_path / "external-cache"
+    external_path = external_cache / "block_vectors.json"
+
+    def _external_store_path(_root: Path) -> Path:
+        return external_path
+
+    monkeypatch.setattr(
+        BlockVectorStore,
+        "store_path",
+        staticmethod(_external_store_path),
+    )
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(external_cache))
+
+    result = apply_page_block_vector_updates(
+        graph,
+        "Demo",
+        upserts={
+            "uuid-external": BlockVectorRecord(
+                page_title="Demo",
+                block_text="external",
+                applicability_text="external cache",
+                vec_content=[0.2, 0.8],
+                vec_applicability=[0.3, 0.7],
+                updated_at="t",
+            ),
+        },
+        keep_uuids={"uuid-external"},
+    )
+
+    assert result == (1, 0)
+    assert external_path.is_file()
+    assert not (graph / ".matryca_semantic_cache").exists()
 
 
 def test_load_block_vector_store_ondemand_reads_header_only(

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -35,6 +35,7 @@ from src.agent.maintenance_daemon import (
     save_daemon_state,
     start_daemon_detached,
     start_daemon_foreground,
+    state_bak_path,
     state_path,
     stop_daemon,
     write_pid_file,
@@ -222,6 +223,29 @@ def test_daemon_state_roundtrip(graph_root: Path, monkeypatch: pytest.MonkeyPatc
     assert loaded.status == "idle"
     assert page_key in loaded.files
     assert loaded.files[page_key].mtime == 123.0
+
+
+def test_save_daemon_state_skips_graph_local_writes_when_read_only(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    state = DaemonState(
+        status="running",
+        files={
+            "pages/ReadOnly.md": FileState(
+                mtime=1.0,
+                processed_at="2026-01-01T00:00:00+00:00",
+                status="processed",
+            ),
+        },
+    )
+
+    save_daemon_state(graph_root, state)
+
+    assert not state_path(graph_root).exists()
+    assert not state_bak_path(graph_root).exists()
+    assert not any(graph_root.glob(".matryca_daemon_state.json.*"))
 
 
 def test_save_daemon_state_persists_block_ref_error_text(graph_root: Path) -> None:

--- a/tests/test_master_catalog.py
+++ b/tests/test_master_catalog.py
@@ -218,6 +218,30 @@ def test_load_and_save_master_catalog(graph_root: Path) -> None:
     assert reloaded.pages["Demo"].domain == "mappa"
 
 
+def test_save_master_catalog_skips_graph_local_writes_when_read_only(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    catalog = load_master_catalog(graph_root)
+    catalog.upsert(
+        "Blocked",
+        CatalogEntry(
+            summary="Block",
+            domain="mappa",
+            tags=[],
+            last_mtime=100,
+            orphan=False,
+        ),
+    )
+
+    catalog.save()
+
+    path = MasterCatalog.catalog_path(graph_root)
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
 def test_load_master_catalog_serializes_reads_under_concurrent_save(graph_root: Path) -> None:
     """Concurrent reloads must not observe torn JSON during atomic catalog saves (#35)."""
     baseline = load_master_catalog(graph_root)


### PR DESCRIPTION
## Summary

- skip daemon checkpoint and master catalog persistence before graph-local side effects when strict read-only mode is active
- block graph-local block-vector saves and page updates before directory creation, temp writes, replacement, or cache mutation
- preserve writes to explicitly external block-vector targets and document the completed policy coverage

## Impact

Strict read-only mode no longer leaves residual daemon-state, master-catalog, or block-vector artifacts inside the graph. Normal writable behavior remains unchanged.

## Test plan

- [x] focused read-only and external-cache regression tests
- [x] graph-based diff impact review
- [x] `make check` — 1518 passed, 2 skipped, 1 xfailed; coverage 82.77%

Refs #349
