### PR TITLE
fix(read-only): guard residual graph persistence (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 - **Prerelease publication metadata** — release tags containing a SemVer prerelease suffix now create GitHub prereleases instead of stable releases while preserving the curated changelog notes and PyPI trusted-publishing flow.
-- **Read-only runtime bootstrap safety** — `prepare_matryca_runtime()` now skips graph-local cache/templates, seeded wiki config, L1 provisioning, Shadow startup, and dangling tmp cleanup when `MATRYCA_READ_ONLY=true`, so CLI read bootstrap and direct startup preserve reads without creating vault artifacts.
+- **Read-only graph persistence safety** — `MATRYCA_READ_ONLY=true` now prevents graph-local cache, index, registry, clustering, daemon recovery/PID/lock, catalog backup/quarantine, vector sidecar, and Shadow DB mutations, while read paths avoid creating `.flock` files and fall back to Markdown when Shadow cannot be opened without writes.
 
 ### Changed
 

--- a/src/agent/daemon_process_lock.py
+++ b/src/agent/daemon_process_lock.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from ..graph.markdown_blocks import atomic_write_bytes
+from ..graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 from .daemon_state import load_daemon_state, save_daemon_state
 
 PID_FILENAME = ".matryca_plumber_daemon.pid"
@@ -57,6 +58,10 @@ def bind_daemon_process_lock_fd(fd: int) -> None:
 def _try_acquire_daemon_process_lock_windows(graph_root: Path) -> int | None:
     """Acquire an exclusive daemon lock on platforms without ``fcntl`` (Windows)."""
     path = daemon_lock_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="acquire_daemon_process_lock")
+    except GraphReadOnlyError:
+        return None
     path.parent.mkdir(parents=True, exist_ok=True)
     for _attempt in range(3):
         try:
@@ -93,9 +98,13 @@ def _try_acquire_daemon_process_lock_windows(graph_root: Path) -> int | None:
 
 def _try_acquire_daemon_process_lock(graph_root: Path) -> int | None:
     """Acquire an exclusive daemon lock; return ``None`` when another process holds it."""
+    path = daemon_lock_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="acquire_daemon_process_lock")
+    except GraphReadOnlyError:
+        return None
     if _fcntl is None:
         return _try_acquire_daemon_process_lock_windows(graph_root)
-    path = daemon_lock_path(graph_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
     try:
@@ -118,6 +127,10 @@ def _release_daemon_process_lock(graph_root: Path) -> None:
             os.close(_daemon_process_lock_fd)
         _daemon_process_lock_fd = None
     lock_path = daemon_lock_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, lock_path, operation="release_daemon_process_lock")
+    except GraphReadOnlyError:
+        return
     with contextlib.suppress(OSError):
         lock_path.unlink(missing_ok=True)
 
@@ -186,6 +199,10 @@ def is_plumber_process(pid: int) -> bool:
 
 def write_pid_file(graph_root: Path) -> None:
     path = pid_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="write_daemon_pid")
+    except GraphReadOnlyError:
+        return
     payload = json.dumps({"pid": os.getpid(), "marker": PLUMBER_PID_MARKER}) + "\n"
     atomic_write_bytes(
         path,
@@ -225,6 +242,10 @@ def read_pid_file(graph_root: Path) -> int | None:
 
 def remove_pid_file(graph_root: Path) -> None:
     path = pid_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="remove_daemon_pid")
+    except GraphReadOnlyError:
+        return
     if path.is_file():
         path.unlink(missing_ok=True)
 

--- a/src/agent/daemon_state.py
+++ b/src/agent/daemon_state.py
@@ -23,7 +23,11 @@ from ..graph.bootstrap_harvest import BootstrapHarvestStatus
 from ..graph.graph_analytics import reconcile_telemetry_ledger
 from ..graph.json_flock import cross_process_json_flock
 from ..graph.path_sandbox import graph_relative_path_key, normalize_daemon_file_key
-from ..graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
+from ..graph.safety.write_policy import (
+    GraphReadOnlyError,
+    guard_graph_mutation,
+    is_graph_read_only,
+)
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .journey_log import JourneyDayLedger
 from .plumber_config import DEFAULT_LM_MODEL, resolve_llm_model_name
@@ -425,7 +429,7 @@ def load_daemon_state(graph_root: Path) -> DaemonState:
             "attempting recovery from .bak backup."
         )
         payload = _read_daemon_state_payload(bak_path)
-        if payload is not None:
+        if payload is not None and not is_graph_read_only():
             try:
                 shutil.copy2(bak_path, path)
             except OSError:

--- a/src/agent/plumber_modules/semantic_cache_router.py
+++ b/src/agent/plumber_modules/semantic_cache_router.py
@@ -17,7 +17,8 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel, ValidationError
 
-from ...graph.json_flock import cross_process_json_flock
+from ...graph.json_flock import cross_process_json_flock, cross_process_json_read_flock
+from ...graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 from ...utils.bounded_json import BoundedJsonError, read_bounded_json
 
 _CACHE_DIRNAME = ".matryca_semantic_cache"
@@ -131,7 +132,7 @@ def cache_get(graph_root: Path, namespace: str, cache_key: str) -> dict[str, Any
     if not path.is_file():
         return None
     try:
-        with cross_process_json_flock(path):
+        with cross_process_json_read_flock(path, graph_root=graph_root):
             raw = read_bounded_json(path)
     except (BoundedJsonError, OSError):
         return None
@@ -140,8 +141,7 @@ def cache_get(graph_root: Path, namespace: str, cache_key: str) -> dict[str, Any
     created = float(raw.get("created_at", 0.0))
     node_ttl = int(raw.get("ttl_seconds", ttl))
     if now - created > node_ttl:
-        with cross_process_json_flock(path):
-            path.unlink(missing_ok=True)
+        cache_evict(graph_root, namespace, cache_key)
         return None
     raw_payload = raw.get("payload")
     if not isinstance(raw_payload, dict):
@@ -163,9 +163,13 @@ def cache_get(graph_root: Path, namespace: str, cache_key: str) -> dict[str, Any
 def cache_evict(graph_root: Path, namespace: str, cache_key: str) -> None:
     """Remove one cache entry from RAM and disk."""
     digest = _digest(namespace, cache_key)
+    path = _cache_root(graph_root) / f"{digest}.json"
+    try:
+        guard_graph_mutation(graph_root, path, operation="evict_semantic_cache")
+    except GraphReadOnlyError:
+        return
     with _lock:
         _memory.pop(digest, None)
-    path = _cache_root(graph_root) / f"{digest}.json"
     with contextlib.suppress(OSError), cross_process_json_flock(path):
         path.unlink(missing_ok=True)
 
@@ -209,6 +213,11 @@ def cache_put(
             _max_cache_payload_bytes(),
         )
         return None
+    root = _cache_root(graph_root)
+    try:
+        guard_graph_mutation(graph_root, root, operation="write_semantic_cache")
+    except GraphReadOnlyError:
+        return None
     ttl = ttl_seconds if ttl_seconds is not None else _env_ttl()
     now = time.time()
     digest = _digest(namespace, cache_key)
@@ -219,7 +228,6 @@ def cache_put(
         "ttl_seconds": ttl,
         "payload": payload,
     }
-    root = _cache_root(graph_root)
     root.mkdir(parents=True, exist_ok=True)
     path = root / f"{digest}.json"
     tmp = path.with_suffix(".tmp")
@@ -274,6 +282,10 @@ def _env_ttl() -> int:
 def purge_expired_semantic_cache(graph_root: Path) -> int:
     """Remove expired on-disk cache entries proactively (returns count removed)."""
     root = _cache_root(graph_root)
+    try:
+        guard_graph_mutation(graph_root, root, operation="purge_semantic_cache")
+    except GraphReadOnlyError:
+        return 0
     if not root.is_dir():
         return 0
     now = time.time()
@@ -318,10 +330,15 @@ def clear_semantic_cache_memory() -> None:
 
 def clear_semantic_cache(graph_root: Path | None = None) -> None:
     """Drop in-process entries and optional on-disk cache directory."""
-    clear_semantic_cache_memory()
     if graph_root is None:
+        clear_semantic_cache_memory()
         return
     root = _cache_root(graph_root)
+    try:
+        guard_graph_mutation(graph_root, root, operation="clear_semantic_cache")
+    except GraphReadOnlyError:
+        return
+    clear_semantic_cache_memory()
     if root.is_dir():
         for path in root.glob("*.json"):
             if path.name in _RESERVED_CACHE_JSON:

--- a/src/graph/backlink_index.py
+++ b/src/graph/backlink_index.py
@@ -14,9 +14,10 @@ from .alias_index import (
     iter_scannable_pages_markdown,
     page_title_from_path,
 )
-from .json_flock import cross_process_json_flock
+from .json_flock import cross_process_json_flock, cross_process_json_read_flock
 from .markdown_blocks import atomic_write_bytes
 from .path_sandbox import read_graph_file_text
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 
 _INDEX_VERSION = 1
 _INDEX_FILENAME = "backlink_counts.json"
@@ -82,7 +83,7 @@ def _load_disk(graph_root: Path) -> dict[str, Any] | None:
     if not path.is_file():
         return None
     try:
-        with cross_process_json_flock(path):
+        with cross_process_json_read_flock(path, graph_root=graph_root):
             raw = read_bounded_json(path)
     except (BoundedJsonError, OSError):
         return None
@@ -91,6 +92,10 @@ def _load_disk(graph_root: Path) -> dict[str, Any] | None:
 
 def _save_disk(graph_root: Path, payload: dict[str, Any]) -> None:
     path = _index_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="save_backlink_index")
+    except GraphReadOnlyError:
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     data = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
     with cross_process_json_flock(path):
@@ -143,10 +148,14 @@ def patch_backlink_index_for_paths(
     if not changed_paths:
         return False
     root = graph_root.expanduser().resolve(strict=False)
+    path = _index_path(root)
+    try:
+        guard_graph_mutation(root, path, operation="invalidate_backlink_index")
+    except GraphReadOnlyError:
+        return False
     key = str(root)
     with _lock:
         _memory.pop(key, None)
-    path = _index_path(root)
     if path.is_file():
         with cross_process_json_flock(path):
             path.unlink(missing_ok=True)

--- a/src/graph/daemon_checkpoint.py
+++ b/src/graph/daemon_checkpoint.py
@@ -10,6 +10,7 @@ from typing import Any
 from loguru import logger
 
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
+from .safety.write_policy import is_graph_read_only
 
 CHECKPOINT_FILENAME = ".matryca_daemon_state.json"
 CHECKPOINT_BAK_FILENAME = f"{CHECKPOINT_FILENAME}.bak"
@@ -60,7 +61,7 @@ def read_daemon_checkpoint(graph_root: str | Path) -> DaemonCheckpointView:
             "attempting recovery from .bak backup."
         )
         payload = _read_checkpoint_payload(bak_path)
-        if payload is not None:
+        if payload is not None and not is_graph_read_only():
             try:
                 shutil.copy2(bak_path, path)
             except OSError:

--- a/src/graph/json_flock.py
+++ b/src/graph/json_flock.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from ..utils.platform_lock import cross_process_sidecar_lock
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 
 
 def flock_sidecar_path(target: Path) -> Path:
@@ -27,4 +28,17 @@ def cross_process_json_flock(target: Path) -> Iterator[None]:
         yield
 
 
-__all__ = ["cross_process_json_flock", "flock_sidecar_path"]
+@contextmanager
+def cross_process_json_read_flock(target: Path, *, graph_root: Path) -> Iterator[None]:
+    """Lock a JSON read without creating a graph-local sidecar in read-only mode."""
+    lock_path = flock_sidecar_path(target)
+    try:
+        guard_graph_mutation(graph_root, lock_path, operation="acquire_json_read_lock")
+    except GraphReadOnlyError:
+        yield
+        return
+    with cross_process_json_flock(target):
+        yield
+
+
+__all__ = ["cross_process_json_flock", "cross_process_json_read_flock", "flock_sidecar_path"]

--- a/src/graph/link_verification.py
+++ b/src/graph/link_verification.py
@@ -22,7 +22,7 @@ from loguru import logger
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from ..utils.env_parse import env_bool, env_float_clamped, env_int_clamped
 from .global_fence_scanner import compute_page_protected_line_indices
-from .json_flock import cross_process_json_flock
+from .json_flock import cross_process_json_flock, cross_process_json_read_flock
 from .markdown_blocks import (
     atomic_write_bytes,
     atomic_write_bytes_if_unchanged,
@@ -42,6 +42,7 @@ from .path_sandbox import (
     read_graph_file_text,
     resolve_graph_relative_key,
 )
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 
 LINK_REGISTRY_FILENAME = ".matryca_link_registry.json"
 REGISTRY_VERSION = 1
@@ -169,6 +170,10 @@ def _load_registry_unlocked(path: Path) -> dict[str, LinkRegistryEntry]:
 
 
 def _save_registry_unlocked(path: Path, entries: dict[str, LinkRegistryEntry]) -> None:
+    try:
+        guard_graph_mutation(path.parent, path, operation="save_link_registry")
+    except GraphReadOnlyError:
+        return
     payload = {
         "version": REGISTRY_VERSION,
         "updated_at": datetime.now(tz=UTC).isoformat(),
@@ -181,12 +186,16 @@ def _save_registry_unlocked(path: Path, entries: dict[str, LinkRegistryEntry]) -
 
 def load_link_registry(graph_root: Path) -> dict[str, LinkRegistryEntry]:
     path = link_registry_path(graph_root)
-    with cross_process_json_flock(path):
+    with cross_process_json_read_flock(path, graph_root=graph_root):
         return _load_registry_unlocked(path)
 
 
 def save_link_registry(graph_root: Path, entries: dict[str, LinkRegistryEntry]) -> None:
     path = link_registry_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="save_link_registry")
+    except GraphReadOnlyError:
+        return
     with cross_process_json_flock(path):
         _save_registry_unlocked(path, entries)
 
@@ -200,6 +209,10 @@ def _persist_checked_registry_updates(
     if not checked_keys:
         return
     path = link_registry_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="update_link_registry")
+    except GraphReadOnlyError:
+        return
     with cross_process_json_flock(path):
         fresh = _load_registry_unlocked(path)
         for key in checked_keys:
@@ -353,6 +366,10 @@ def merge_page_links_into_registry(
         return 0
 
     path = link_registry_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="merge_link_registry")
+    except GraphReadOnlyError:
+        return 0
     new_keys = {entry.registry_key() for entry in new_entries}
     with cross_process_json_flock(path):
         registry = _load_registry_unlocked(path)
@@ -713,7 +730,7 @@ def run_link_verification_cycle(graph_root: Path) -> LinkVerificationCycleResult
     if not link_verify_enabled():
         return LinkVerificationCycleResult()
     path = link_registry_path(graph_root)
-    with cross_process_json_flock(path):
+    with cross_process_json_read_flock(path, graph_root=graph_root):
         registry = _load_registry_unlocked(path)
     if not registry:
         return LinkVerificationCycleResult()
@@ -723,6 +740,10 @@ def run_link_verification_cycle(graph_root: Path) -> LinkVerificationCycleResult
 def _purge_registry_entries_for_page(graph_root: Path, page_relpath: str) -> int:
     """Drop registry rows for a page file that no longer exists."""
     path = link_registry_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="purge_link_registry")
+    except GraphReadOnlyError:
+        return 0
     with cross_process_json_flock(path):
         registry = _load_registry_unlocked(path)
         stale = [key for key, entry in registry.items() if entry.page_relpath == page_relpath]

--- a/src/graph/master_catalog.py
+++ b/src/graph/master_catalog.py
@@ -17,11 +17,11 @@ from loguru import logger
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 from .alias_index import build_alias_index, iter_alias_source_paths, page_title_from_path
 from .generated_hub_write import write_generated_hub_page
-from .json_flock import cross_process_json_flock
+from .json_flock import cross_process_json_flock, cross_process_json_read_flock
 from .markdown_blocks import atomic_write_bytes, occ_snapshot
 from .markdown_io import MmapTextView, read_graph_page_text
 from .path_sandbox import read_graph_file_text
-from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation, is_graph_read_only
 
 CATALOG_FILENAME = "master_catalog.json"
 CATALOG_VERSION = 1
@@ -359,7 +359,7 @@ def _quarantine_corrupt_catalog(catalog_path: Path) -> Path:
 def _load_catalog_payload_from_disk(path: Path, root: Path) -> MasterCatalog:
     """Parse catalog JSON from disk; restore backup or quarantine on corruption."""
     try:
-        with cross_process_json_flock(path):
+        with cross_process_json_read_flock(path, graph_root=root):
             payload = read_bounded_json(path)
     except BoundedJsonError as exc:
         msg = str(exc)
@@ -368,7 +368,7 @@ def _load_catalog_payload_from_disk(path: Path, root: Path) -> MasterCatalog:
         backup = _catalog_backup_path(path)
         if backup.is_file():
             try:
-                with cross_process_json_flock(backup):
+                with cross_process_json_read_flock(backup, graph_root=root):
                     payload = read_bounded_json(backup)
                 logger.warning(
                     "[METADATA CORRUPTION DETECTED] Restored master catalog from backup at {}",
@@ -380,6 +380,8 @@ def _load_catalog_payload_from_disk(path: Path, root: Path) -> MasterCatalog:
                     return catalog
             except BoundedJsonError:
                 pass
+        if is_graph_read_only():
+            return MasterCatalog(graph_root=root, persist_allowed=False)
         try:
             with cross_process_json_flock(path):
                 quarantined = _quarantine_corrupt_catalog(path)
@@ -435,7 +437,7 @@ def load_master_catalog(graph_root: Path, *, force_reload: bool = False) -> Mast
                 msg = f"Could not read master catalog at {path}: {exc}"
                 raise CatalogLoadError(msg) from exc
             else:
-                if catalog.persist_allowed:
+                if catalog.persist_allowed and not is_graph_read_only():
                     backup = _catalog_backup_path(path)
                     try:
                         with cross_process_json_flock(path):

--- a/src/graph/semantic_clustering.py
+++ b/src/graph/semantic_clustering.py
@@ -18,8 +18,9 @@ from typing import Any
 from loguru import logger
 
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
-from .json_flock import cross_process_json_flock
+from .json_flock import cross_process_json_flock, cross_process_json_read_flock
 from .markdown_blocks import atomic_write_bytes
+from .safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 
 CLUSTERS_FILENAME = "semantic_clusters.json"
 CLUSTERS_VERSION = 1
@@ -551,6 +552,10 @@ def save_semantic_clusters(
         "clusters": clusters,
     }
     path = semantic_clusters_path(graph_root)
+    try:
+        guard_graph_mutation(graph_root, path, operation="save_semantic_clusters")
+    except GraphReadOnlyError:
+        return path
     path.parent.mkdir(parents=True, exist_ok=True)
     data = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
     with cross_process_json_flock(path):
@@ -564,7 +569,7 @@ def load_semantic_clusters(graph_root: Path) -> dict[str, list[str]] | None:
     if not path.is_file():
         return None
     try:
-        with cross_process_json_flock(path):
+        with cross_process_json_read_flock(path, graph_root=graph_root):
             payload = read_bounded_json(path)
     except (BoundedJsonError, OSError) as exc:
         logger.warning("Ignoring unreadable semantic cluster cache at {}: {}", path, exc)

--- a/src/semantic/store.py
+++ b/src/semantic/store.py
@@ -15,7 +15,7 @@ from typing import Any
 import ijson
 from loguru import logger
 
-from ..graph.json_flock import cross_process_json_flock
+from ..graph.json_flock import cross_process_json_flock, cross_process_json_read_flock
 from ..graph.safety.write_policy import GraphReadOnlyError, guard_graph_mutation
 from ..utils.bounded_json import BoundedJsonError, read_bounded_json
 
@@ -433,7 +433,7 @@ def iter_block_records_from_disk(graph_root: Path) -> Iterator[tuple[str, BlockV
     if not path.is_file():
         return
     try:
-        with cross_process_json_flock(path), path.open("rb") as handle:
+        with cross_process_json_read_flock(path, graph_root=root), path.open("rb") as handle:
             for block_uuid, raw in ijson.kvitems(handle, "blocks"):
                 if isinstance(raw, dict):
                     yield str(block_uuid), BlockVectorRecord.from_json(raw)
@@ -472,7 +472,7 @@ def load_block_vector_store(
                 store.embedding_dim = _coerce_embedding_dim(meta.get("embedding_dim"))
             else:
                 try:
-                    with cross_process_json_flock(path):
+                    with cross_process_json_read_flock(path, graph_root=Path(key)):
                         payload = read_bounded_json(path)
                     if isinstance(payload, dict):
                         store = BlockVectorStore.from_json(Path(key), payload)

--- a/src/shadow/connection.py
+++ b/src/shadow/connection.py
@@ -6,6 +6,7 @@ import sqlite3
 from pathlib import Path
 
 from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+from ..graph.safety.write_policy import guard_graph_mutation
 from .config import shadow_db_busy_timeout_ms
 from .schema import apply_shadow_schema
 
@@ -27,6 +28,7 @@ def open_shadow_db(graph_root: Path | str) -> sqlite3.Connection:
     ``graph_root`` via :func:`assert_path_within_graph`.
     """
     db_path = shadow_db_path(graph_root)
+    guard_graph_mutation(graph_root, db_path, operation="open_shadow_db")
     db_path.parent.mkdir(parents=True, exist_ok=True)
     connection = sqlite3.connect(str(db_path))
     busy_timeout_ms = shadow_db_busy_timeout_ms()

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -6,6 +6,7 @@ from enum import StrEnum
 from pathlib import Path
 
 from ..graph.path_sandbox import resolved_graph_root
+from ..graph.safety.write_policy import is_graph_read_only
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
 from .meta import (
@@ -69,6 +70,8 @@ def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
     if not shadow_db_enabled():
         return ShadowHealthState.DISABLED
     root = resolved_graph_root(graph_root)
+    if is_graph_read_only():
+        return ShadowHealthState.STALE
     if is_shadow_bootstrapping(root):
         return ShadowHealthState.BOOTSTRAPPING
     if not shadow_db_path(root).is_file():

--- a/tests/test_backlink_index.py
+++ b/tests/test_backlink_index.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from src.graph.backlink_index import load_incoming_backlinks, patch_backlink_index_for_paths
 
 
@@ -28,3 +29,19 @@ def test_patch_backlink_index_invalidates_cache(tmp_path: Path) -> None:
     patch_backlink_index_for_paths(tmp_path, [source])
     incoming = load_incoming_backlinks(tmp_path)
     assert incoming.get("Target", 0) >= 1
+
+
+def test_backlink_index_does_not_mutate_graph_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    source = pages / "Source.md"
+    source.write_text("- [[Target]]\n", encoding="utf-8")
+    (pages / "Target.md").write_text("- target\n", encoding="utf-8")
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert load_incoming_backlinks(tmp_path, force_rebuild=True).get("Target", 0) >= 1
+    assert patch_backlink_index_for_paths(tmp_path, [source]) is False
+    assert not (tmp_path / ".matryca_semantic_cache").exists()

--- a/tests/test_daemon_checkpoint.py
+++ b/tests/test_daemon_checkpoint.py
@@ -69,3 +69,21 @@ def test_read_daemon_checkpoint_logs_when_bak_restore_fails(
     assert view.bootstrap_scanned == 2
     assert view.bootstrap_total == 5
     assert any("restore primary" in err for err in errors)
+
+
+def test_read_daemon_checkpoint_uses_backup_without_restore_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.daemon.checkpoint import CHECKPOINT_BAK_FILENAME, CHECKPOINT_FILENAME
+
+    (tmp_path / "pages").mkdir()
+    primary = tmp_path / CHECKPOINT_FILENAME
+    backup = tmp_path / CHECKPOINT_BAK_FILENAME
+    primary.write_text("{not-json", encoding="utf-8")
+    backup.write_text('{"bootstrap_complete": true}', encoding="utf-8")
+    before = primary.read_bytes()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert read_daemon_checkpoint(tmp_path).bootstrap_complete is True
+    assert primary.read_bytes() == before

--- a/tests/test_dual_embedding.py
+++ b/tests/test_dual_embedding.py
@@ -696,6 +696,36 @@ def test_block_vector_store_skips_graph_local_save_when_read_only(
     assert not (graph / ".matryca_semantic_cache").exists()
 
 
+def test_block_vector_store_reads_without_sidecar_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    store = BlockVectorStore(graph_root=graph)
+    store.upsert(
+        "uuid-block",
+        BlockVectorRecord(
+            page_title="Demo",
+            block_text="seed",
+            applicability_text="cached",
+            vec_content=[1.0, 0.0],
+            vec_applicability=[1.0, 0.0],
+            updated_at="t",
+        ),
+    )
+    store.save()
+    path = BlockVectorStore.store_path(graph)
+    flock = path.parent / f".{path.name}.flock"
+    flock.unlink(missing_ok=True)
+    clear_block_vector_store_cache()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert "uuid-block" in load_block_vector_store(graph, force_reload=True).blocks
+    assert [uuid for uuid, _record in iter_block_records_from_disk(graph)] == ["uuid-block"]
+    assert not flock.exists()
+
+
 def test_apply_page_block_vector_updates_preserves_graph_store_when_read_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_json_flock.py
+++ b/tests/test_json_flock.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from src.graph.io_retry import PageLockUnavailableError
-from src.graph.json_flock import cross_process_json_flock
+from src.graph.json_flock import cross_process_json_flock, cross_process_json_read_flock
 from src.utils.platform_lock import clear_flock_depths
 
 pytestmark = pytest.mark.skipif(
@@ -52,6 +52,20 @@ def test_in_process_json_flock_context_manager(tmp_path: Path) -> None:
     with cross_process_json_flock(target):
         target.write_text('{"ok": true}', encoding="utf-8")
     assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+
+
+def test_json_read_flock_does_not_create_sidecar_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "payload.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with cross_process_json_read_flock(target, graph_root=tmp_path):
+        assert json.loads(target.read_text(encoding="utf-8")) == {}
+
+    assert not (tmp_path / ".payload.json.flock").exists()
 
 
 def test_nested_json_flock_same_thread_reentrant(tmp_path: Path) -> None:

--- a/tests/test_link_verification.py
+++ b/tests/test_link_verification.py
@@ -50,6 +50,21 @@ def graph_with_page(tmp_path: Path) -> tuple[Path, Path]:
     return root, page
 
 
+def test_link_registry_read_and_write_do_not_mutate_read_only_graph(
+    graph_with_page: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_root, _page = graph_with_page
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert load_link_registry(graph_root) == {}
+    save_link_registry(graph_root, {})
+
+    path = link_registry_path(graph_root)
+    assert not path.exists()
+    assert not (path.parent / f".{path.name}.flock").exists()
+
+
 def test_extract_links_from_page(graph_with_page: tuple[Path, Path]) -> None:
     root, page = graph_with_page
     content = page.read_text(encoding="utf-8")

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -248,6 +248,44 @@ def test_save_daemon_state_skips_graph_local_writes_when_read_only(
     assert not any(graph_root.glob(".matryca_daemon_state.json.*"))
 
 
+def test_daemon_lock_and_pid_primitives_skip_read_only_graph(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.agent.daemon_process_lock import (
+        _release_daemon_process_lock,
+        _try_acquire_daemon_process_lock,
+        daemon_lock_path,
+        pid_path,
+        remove_pid_file,
+    )
+
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert _try_acquire_daemon_process_lock(graph_root) is None
+    write_pid_file(graph_root)
+    remove_pid_file(graph_root)
+    _release_daemon_process_lock(graph_root)
+
+    assert not daemon_lock_path(graph_root).exists()
+    assert not pid_path(graph_root).exists()
+
+
+def test_load_daemon_state_uses_backup_without_restore_in_read_only_mode(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primary = state_path(graph_root)
+    backup = state_bak_path(graph_root)
+    primary.write_text("{not-json", encoding="utf-8")
+    backup.write_text(json.dumps(DaemonState(status="idle").to_json()), encoding="utf-8")
+    before = primary.read_bytes()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert load_daemon_state(graph_root).status == "idle"
+    assert primary.read_bytes() == before
+
+
 def test_save_daemon_state_persists_block_ref_error_text(graph_root: Path) -> None:
     """Error strings containing ((uuid)) patterns must not block JSON checkpoint writes."""
     bad_uuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeee"

--- a/tests/test_master_catalog.py
+++ b/tests/test_master_catalog.py
@@ -146,6 +146,25 @@ def test_load_master_catalog_self_heals_corrupt_json(graph_root: Path) -> None:
     assert not path.is_file()
 
 
+def test_load_master_catalog_does_not_heal_or_lock_in_read_only_mode(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_master_catalog_cache(graph_root)
+    path = MasterCatalog.catalog_path(graph_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-json", encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    catalog = load_master_catalog(graph_root, force_reload=True)
+
+    assert catalog.persist_allowed is False
+    assert path.read_bytes() == before
+    assert not list(path.parent.glob(f"{path.name}.corrupt.*"))
+    assert not (path.parent / f".{path.name}.flock").exists()
+
+
 def test_load_master_catalog_oserror_raises_without_cache(
     graph_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_semantic_cache_router.py
+++ b/tests/test_semantic_cache_router.py
@@ -33,6 +33,24 @@ def test_semantic_cache_round_trip(graph_root: Path) -> None:
     assert hit == {"summary": "cached"}
 
 
+def test_semantic_cache_preserves_disk_and_memory_in_read_only_mode(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache_put(graph_root, "index", "key", {"summary": "cached"})
+    cache_root = graph_root / ".matryca_semantic_cache"
+    before = {path.name: path.read_bytes() for path in cache_root.iterdir()}
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert cache_put(graph_root, "index", "new", {"summary": "new"}) is None
+    router.cache_evict(graph_root, "index", "key")
+    assert router.purge_expired_semantic_cache(graph_root) == 0
+    clear_semantic_cache(graph_root)
+
+    assert cache_get(graph_root, "index", "key") == {"summary": "cached"}
+    assert {path.name: path.read_bytes() for path in cache_root.iterdir()} == before
+
+
 def test_semantic_cache_miss_after_ttl_expired(
     graph_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_semantic_clustering.py
+++ b/tests/test_semantic_clustering.py
@@ -92,7 +92,8 @@ def test_load_semantic_clusters_uses_json_flock(
     locked_paths: list[Path] = []
 
     class RecordingFlock:
-        def __init__(self, path: Path) -> None:
+        def __init__(self, path: Path, *, graph_root: Path) -> None:
+            assert graph_root == tmp_path
             locked_paths.append(path)
 
         def __enter__(self) -> None:
@@ -107,7 +108,7 @@ def test_load_semantic_clusters_uses_json_flock(
             _ = (exc_type, exc, traceback)
 
     monkeypatch.setattr(
-        "src.graph.semantic_clustering.cross_process_json_flock",
+        "src.graph.semantic_clustering.cross_process_json_read_flock",
         RecordingFlock,
     )
 
@@ -115,6 +116,24 @@ def test_load_semantic_clusters_uses_json_flock(
 
     assert loaded == clusters
     assert locked_paths == [semantic_clusters_path(tmp_path)]
+
+
+def test_semantic_clusters_preserve_graph_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clusters = {"cluster_001": ["Alpha", "Beta"]}
+    path = save_semantic_clusters(tmp_path, clusters)
+    before = path.read_bytes()
+    flock = path.parent / f".{path.name}.flock"
+    flock.unlink(missing_ok=True)
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    assert load_semantic_clusters(tmp_path) == clusters
+    save_semantic_clusters(tmp_path, {"cluster_002": ["Gamma"]})
+
+    assert path.read_bytes() == before
+    assert not flock.exists()
 
 
 def test_load_or_compute_semantic_clusters_uses_cache(tmp_path: Path) -> None:

--- a/tests/test_shadow_connection.py
+++ b/tests/test_shadow_connection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from src.graph.safety.write_policy import GraphReadOnlyError
 from src.shadow.connection import open_shadow_db, shadow_db_path
 from src.shadow.schema import SHADOW_SCHEMA_VERSION
 
@@ -42,6 +44,18 @@ def test_open_shadow_db_idempotent(tmp_path: Path) -> None:
         assert "blocks" in tables
     finally:
         second.close()
+
+
+def test_open_shadow_db_does_not_create_files_in_read_only_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    with pytest.raises(GraphReadOnlyError):
+        open_shadow_db(tmp_path)
+
+    assert not (tmp_path / ".matryca_semantic_cache").exists()
 
 
 def test_shadow_db_path_sandboxed_under_graph(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- prevent graph-local semantic-cache, backlink-index, link-registry, clustering, daemon recovery/PID/lock, catalog maintenance, vector-sidecar, and Shadow DB mutations when `MATRYCA_READ_ONLY=true`
- add a read-intent JSON lock that preserves normal cross-process locking while avoiding graph-local `.flock` creation in strict read-only mode
- route Shadow reads to the established Markdown fallback when SQLite cannot be opened without possible side effects
- extend regression coverage across each residual persistence primitive and update the Unreleased changelog entry

## Impact

Strict read-only mode now remains artifact-free even when internal persistence functions are called directly. Normal writable mode retains the existing lock, recovery, cache, and Shadow DB behavior.

## Test plan

- [x] `make check`
- [x] 1,529 passed, 2 skipped, 1 xfailed
- [x] Ruff and formatting checks
- [x] mypy across `src/` and `tests/`
- [x] graph read-sandbox, version consistency, agent coherence, and system-prompt checks
- [x] local change-impact review against `main`

Closes #349
