### PR TITLE
feat(shadow): enable external cache under read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Changed
 
 - **v2.0 release scope and promotion gates** — define fail-closed `v2.0.0-rc.1` and stable readiness matrices for the Shadow read path, require an external Shadow cache compatible with graph Read Only plus exact public-beta re-qualification before default-on, and defer biological memory, Logseq DB Safe-Sync writes, Tana merge, and independent DX work to `v2.1.0` or later.
-- **Shadow cache path migration (`Slice 2`)** — route `shadow.sqlite`, WAL/SHM sidecars, and `shadow.writer.flock` through `resolve_shadow_cache_location` for per-graph external caches, while keeping `MATRYCA_SHADOW_DB_ENABLED=false` fail-closed and Markdown/BM25 fallback intact.
+- **External Shadow cache under Read Only (`Slices 2–3`)** — route `shadow.sqlite`, WAL/SHM sidecars, and `shadow.writer.flock` through `resolve_shadow_cache_location` for per-graph external caches; permit startup bootstrap and watcher reconciliation to update only that external cache under `MATRYCA_READ_ONLY=true`, while graph-local provisioning and mutator hooks stay disabled and explicit `MATRYCA_SHADOW_DB_ENABLED=false` remains fail-closed with Markdown/BM25 fallback.
 
 ## [2.0.0-beta.1] - 2026-07-30
 

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -23,6 +23,12 @@ When a valid graph is configured, **daemon and agent CLI** **bootstrap the in-me
 
 If `LOGSEQ_GRAPH_PATH` is unset or invalid, only **log directories** are ensured.
 
+With `MATRYCA_READ_ONLY=true`, every entry surface still runs the light runtime
+bootstrap, but graph-local provisioning, AST/identity refresh, write-back hooks, and
+sidecar maintenance are skipped. When Shadow is enabled, startup may read
+`pages/` and `journals/` and create or reconcile only the validated external Shadow
+cache. Explicit Shadow-off remains zero-touch for that cache.
+
 On first startup, if repo **`.env`** is missing and **`.env.example`** exists, Matryca Plumber copies the example to `.env` (logged at INFO) before loading environment variables.
 
 ---
@@ -66,6 +72,9 @@ or `memory_path` in `matryca-wiki.yml`. Bootstrap will create that path and seed
 **L1 read safety:** `collect_l1_markdown_paths` only reads under `$HOME` or the system temp directory. `README.md` is excluded from agent context by filename (documentation only).
 
 ### 3. Graph-local working directories (when a valid graph is configured)
+
+These artifacts are provisioned only when graph writes are allowed. Strict Read Only
+does not create, repair, lock, rename, or remove any path inside the graph.
 
 | Directory / file | Purpose |
 |------------------|---------|

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -53,6 +53,7 @@ from ..graph.path_sandbox import (
     graph_relative_path_key,
     read_graph_file_text,
 )
+from ..graph.safety.write_policy import is_graph_read_only
 from ..graph.semantic_clustering import (
     CLUSTER_IDS_WITHOUT_FOCUS,
     JOURNAL_CLUSTER_ID,
@@ -374,6 +375,12 @@ class MaintenanceDaemon:
 
     def _on_watchdog_change(self, path: Path, kind: FileEventKind) -> None:
         """Refresh AST cache and wake the duty cycle after debounced vault edits."""
+        if is_graph_read_only():
+            from ..shadow.bootstrap import handle_shadow_watchdog_change
+
+            handle_shadow_watchdog_change(self.graph_root, path, kind)
+            self._cycle_wake.set()
+            return
         get_graph_ast_cache(self.graph_root).apply_file_event(path, kind)
         from ..daemon.config_layer import refresh_identity_config
 

--- a/src/main.py
+++ b/src/main.py
@@ -44,13 +44,13 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
         os.chdir(str(resolved_root))
     read_only = resolved_root is not None and RuntimeWritePolicy.from_env(resolved_root).read_only
     # Lazy AST: handshake must not block on full-vault parse (Hermes connect_timeout).
-    # In read-only mode this bootstrap would create graph-local cache/template files.
-    if not read_only:
-        prepare_matryca_runtime(
-            graph_root=resolved_root,
-            wiki_config=wiki_config,
-            eager_graph=False,
-        )
+    # The bootstrap policy suppresses graph-local provisioning under Read Only while
+    # still allowing the derived external Shadow cache to reconcile from Markdown.
+    prepare_matryca_runtime(
+        graph_root=resolved_root,
+        wiki_config=wiki_config,
+        eager_graph=False,
+    )
     if resolved_root is not None and not read_only:
         swept = await asyncio.to_thread(sweep_dangling_atomic_tmp_files, str(resolved_root))
         if swept:

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -6,7 +6,6 @@ from enum import StrEnum
 from pathlib import Path
 
 from ..graph.path_sandbox import resolved_graph_root
-from ..graph.safety.write_policy import is_graph_read_only
 from .config import shadow_db_enabled
 from .connection import open_shadow_db, shadow_db_path
 from .meta import (
@@ -70,8 +69,6 @@ def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
     if not shadow_db_enabled():
         return ShadowHealthState.DISABLED
     root = resolved_graph_root(graph_root)
-    if is_graph_read_only():
-        return ShadowHealthState.STALE
     if is_shadow_bootstrapping(root):
         return ShadowHealthState.BOOTSTRAPPING
     if not shadow_db_path(root).is_file():

--- a/src/utils/runtime_bootstrap.py
+++ b/src/utils/runtime_bootstrap.py
@@ -137,8 +137,12 @@ def prepare_matryca_runtime(
     policy = RuntimeWritePolicy(graph_root=graph_root, read_only=is_graph_read_only())
     if policy.read_only:
         logger.bind(graph=str(policy.graph_root)).info(
-            "Skipping graph-local runtime bootstrap under read-only policy",
+            "Skipping graph-local runtime bootstrap under read-only policy; "
+            "checking external Shadow cache",
         )
+        from ..shadow.bootstrap import ensure_shadow_runtime_at_startup
+
+        ensure_shadow_runtime_at_startup(graph_root)
         return
 
     cfg = wiki_config or MatrycaWikiConfig()

--- a/tests/test_maintenance_daemon.py
+++ b/tests/test_maintenance_daemon.py
@@ -2167,6 +2167,37 @@ def test_on_watchdog_deleted_logs_link_registry_failure(
     assert any("deleted page" in entry for entry in logged)
 
 
+def test_on_watchdog_read_only_routes_only_to_external_shadow(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = _write_page(graph_root, "Observed", "- externally changed\n")
+    shadow_calls: list[tuple[Path, Path, FileEventKind]] = []
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.get_graph_ast_cache",
+        lambda *_args: pytest.fail("read-only watcher must not refresh graph AST state"),
+    )
+    monkeypatch.setattr(
+        "src.daemon.config_layer.refresh_identity_config",
+        lambda *_args: pytest.fail("read-only watcher must not refresh identity state"),
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.register_page_links_from_path",
+        lambda *_args: pytest.fail("read-only watcher must not update graph link state"),
+    )
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.handle_shadow_watchdog_change",
+        lambda root, changed, kind: shadow_calls.append((Path(root), Path(changed), kind)),
+    )
+
+    daemon = MaintenanceDaemon(graph_root, llm_client=StubLLM())
+    daemon._on_watchdog_change(page, "modified")
+
+    assert shadow_calls == [(graph_root, page, "modified")]
+    assert daemon._cycle_wake.is_set()
+
+
 def test_process_llm_cycle_logs_phase2_link_registry_merge_failure(
     graph_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_runtime_bootstrap_contract.py
+++ b/tests/test_runtime_bootstrap_contract.py
@@ -197,7 +197,11 @@ def test_prepare_matryca_runtime_skips_graph_local_bootstrap_in_read_only_mode(
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
     monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
-    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+    shadow_calls: list[Path] = []
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.ensure_shadow_runtime_at_startup",
+        lambda root: shadow_calls.append(Path(root)),
+    )
 
     prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
 
@@ -207,6 +211,7 @@ def test_prepare_matryca_runtime_skips_graph_local_bootstrap_in_read_only_mode(
     assert not (graph / "templates").exists()
     assert not (graph / "matryca-wiki.yml").exists()
     assert not _expected_sibling_l1(graph).exists()
+    assert shadow_calls == [graph]
 
 
 # ---------------------------------------------------------------------------
@@ -256,7 +261,11 @@ def test_try_prepare_from_env_with_read_only_graph_skips_graph_local_bootstrap(
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
     monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
-    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+    shadow_calls: list[Path] = []
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.ensure_shadow_runtime_at_startup",
+        lambda root: shadow_calls.append(Path(root)),
+    )
 
     try_prepare_matryca_runtime_from_env()
 
@@ -266,6 +275,7 @@ def test_try_prepare_from_env_with_read_only_graph_skips_graph_local_bootstrap(
     assert not (graph / "templates").exists()
     assert not (graph / "matryca-wiki.yml").exists()
     assert not _expected_sibling_l1(graph).exists()
+    assert shadow_calls == [graph]
 
 
 def test_try_prepare_invalid_graph_still_ensures_logs_only(

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -83,7 +83,11 @@ def test_cli_main_read_only_read_path_skips_graph_local_bootstrap(
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_graph_runtime_directories", _blocked)
     monkeypatch.setattr("src.utils.runtime_bootstrap.ensure_matryca_wiki_config_file", _blocked)
     monkeypatch.setattr("src.daemon.register_daemon_post_write_hooks", _blocked)
-    monkeypatch.setattr("src.shadow.bootstrap.ensure_shadow_runtime_at_startup", _blocked)
+    shadow_calls: list[Path] = []
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.ensure_shadow_runtime_at_startup",
+        lambda root: shadow_calls.append(Path(root)),
+    )
 
     async def _run_cli(_args: object) -> int:
         return 0
@@ -98,6 +102,7 @@ def test_cli_main_read_only_read_path_skips_graph_local_bootstrap(
     assert not (graph / "templates").exists()
     assert not (graph / "matryca-wiki.yml").exists()
     assert not (tmp_path / "matryca-l1").exists()
+    assert shadow_calls == [graph]
 
 
 def test_cli_main_rejects_read_only_write_before_prepare(
@@ -255,9 +260,10 @@ async def test_mcp_lifespan_skips_graph_writes_in_read_only_mode(
     graph = _minimal_graph(tmp_path)
     monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
     monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "src.main.prepare_matryca_runtime",
-        lambda **_kwargs: pytest.fail("bootstrap must not run"),
+        lambda **kwargs: calls.append(kwargs),
     )
     monkeypatch.setattr(
         "src.main.sweep_dangling_atomic_tmp_files",
@@ -266,6 +272,10 @@ async def test_mcp_lifespan_skips_graph_writes_in_read_only_mode(
 
     async with app_lifespan(MagicMock()):
         pass
+
+    assert len(calls) == 1
+    assert calls[0]["graph_root"] == graph.resolve()
+    assert calls[0]["eager_graph"] is False
 
 
 def test_start_daemon_foreground_defers_prepare_to_run_forever(

--- a/tests/test_shadow_bootstrap.py
+++ b/tests/test_shadow_bootstrap.py
@@ -58,6 +58,20 @@ def _minimal_graph(tmp_path: Path) -> Path:
     return graph
 
 
+def _graph_snapshot(graph: Path) -> dict[str, tuple[str, bytes | str]]:
+    """Capture graph inventory and file bytes without following symlinks."""
+    snapshot: dict[str, tuple[str, bytes | str]] = {}
+    for path in sorted(graph.rglob("*")):
+        rel = path.relative_to(graph).as_posix()
+        if path.is_symlink():
+            snapshot[rel] = ("symlink", str(path.readlink()))
+        elif path.is_dir():
+            snapshot[rel] = ("directory", "")
+        else:
+            snapshot[rel] = ("file", path.read_bytes())
+    return snapshot
+
+
 def test_rebuild_indexes_existing_vault(tmp_path: Path) -> None:
     graph = _minimal_graph(tmp_path)
     _write_page(
@@ -371,6 +385,92 @@ def test_startup_bootstrap_via_prepare_matryca_runtime(tmp_path: Path) -> None:
         assert get_meta(conn, META_LAST_FULL_SYNC_COMPLETED) == "true"
     finally:
         conn.close()
+
+
+def test_read_only_startup_builds_external_shadow_without_graph_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(
+        graph,
+        "pages/ReadOnly.md",
+        "- external cache only\n  id:: dddddddd-dddd-4ddd-8ddd-dddddddddddd\n",
+    )
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    before = _graph_snapshot(graph)
+
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    database = shadow_db_path(graph)
+    assert database.is_file()
+    assert not database.is_relative_to(graph)
+    assert resolve_shadow_health(graph) == ShadowHealthState.READY
+    assert _graph_snapshot(graph) == before
+
+
+def test_read_only_shadow_off_touches_neither_graph_nor_external_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    _write_page(graph, "pages/Disabled.md", "- remain on Markdown\n")
+    cache_root = tmp_path / "operator-cache"
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache_root))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+    before = _graph_snapshot(graph)
+
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    assert not cache_root.exists()
+    assert resolve_shadow_health(graph) == ShadowHealthState.DISABLED
+    assert _graph_snapshot(graph) == before
+
+
+def test_read_only_watchdog_reconciles_external_shadow_without_graph_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    page = _write_page(graph, "pages/Observed.md", "- first\n")
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    page.write_text("- externally updated\n", encoding="utf-8")
+    before = _graph_snapshot(graph)
+    handle_shadow_watchdog_change(graph, page, "modified")
+
+    conn = open_shadow_db(graph)
+    try:
+        assert conn.execute("SELECT content FROM blocks").fetchall() == [
+            ("externally updated",),
+        ]
+    finally:
+        conn.close()
+    assert _graph_snapshot(graph) == before
+
+    page.unlink()
+    before_delete = _graph_snapshot(graph)
+    handle_shadow_watchdog_change(graph, page, "deleted")
+    conn = open_shadow_db(graph)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 0
+    finally:
+        conn.close()
+    assert _graph_snapshot(graph) == before_delete
+
+    created = _write_page(graph, "pages/Created.md", "- externally created\n")
+    before_create = _graph_snapshot(graph)
+    handle_shadow_watchdog_change(graph, created, "created")
+    conn = open_shadow_db(graph)
+    try:
+        assert conn.execute("SELECT content FROM blocks").fetchall() == [
+            ("externally created",),
+        ]
+    finally:
+        conn.close()
+    assert _graph_snapshot(graph) == before_create
 
 
 def test_rebuild_duplicate_block_uuid_cross_page_bounded_diagnostic(


### PR DESCRIPTION
## Summary
- allow strict Read Only startup to build and reconcile the validated external Shadow cache
- keep graph-local provisioning, AST and identity refresh, write-back hooks, and link sidecars disabled
- route Read Only watcher events directly to external Shadow reconciliation
- permit a valid external Shadow generation to report READY under Read Only
- document the runtime contract and update the Unreleased changelog entry

## Safety boundary
Logseq Markdown remains authoritative. Tests fingerprint graph inventory and bytes across startup and watcher create, update, and delete events. Explicit Shadow-off touches neither the graph nor the external cache.

This PR does not change the Shadow default, add UI controls, migrate or delete legacy cache data, run release qualification, tag, merge, or publish a release.

## Test plan
- [x] make ci: 1550 passed, 2 skipped, 1 xfailed
- [x] targeted Shadow and bootstrap matrix: 362 passed
- [x] Ruff, mypy, graph read sandbox, version consistency, agent coherence, and prompt hash checks
- [x] graph-based change analysis against origin/main

Refs #351
Refs #343
Refs #20
