### PR TITLE
feat(safety): add read-only Shadow observer daemon (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - **v2.0 release scope and promotion gates** — define fail-closed `v2.0.0-rc.1` and stable readiness matrices for the Shadow read path, require an external Shadow cache compatible with graph Read Only plus exact public-beta re-qualification before default-on, and defer biological memory, Logseq DB Safe-Sync writes, Tana merge, and independent DX work to `v2.1.0` or later.
 - **External Shadow cache under Read Only (`Slices 2–4`)** — route `shadow.sqlite`, WAL/SHM sidecars, and `shadow.writer.flock` through `resolve_shadow_cache_location` for per-graph external caches; permit startup bootstrap and watcher reconciliation to update only that external cache under `MATRYCA_READ_ONLY=true`; make unset `MATRYCA_SHADOW_DB_ENABLED` default-on while preserving explicit false as a zero-Shadow Markdown/BM25 opt-out; expose independent Strict Read Only and Shadow controls, graph-mutation lockout, persistent protection status, and bounded `cache_unavailable` fallback in the Sovereign UI; and isolate wheel/soak subprocesses on a disposable external cache root for default-on qualification.
+- **Side-effect-free Read Only daemon profile** — `MATRYCA_READ_ONLY=true` can run a foreground Shadow observer that performs only external-cache bootstrap and watcher reconciliation; LLM bootstrap, semantic/journey/hygiene/generated writes, hooks, Git, graph-local state, PID, and locks stay disabled, while detached startup fails closed with an explicit status.
 
 ## [2.0.0-beta.1] - 2026-07-30
 

--- a/docs/quality/issue-bodies/v2-external-shadow-cache-read-only.md
+++ b/docs/quality/issue-bodies/v2-external-shadow-cache-read-only.md
@@ -101,6 +101,10 @@ With `MATRYCA_READ_ONLY=true`:
   resolved external cache;
 - allow watcher-driven Shadow reconciliation from external filesystem changes without
   registering any handler that writes back to the vault;
+- run the maintenance daemon as an explicit foreground-only Shadow observer: no LLM
+  bootstrap, semantic writes, journey log, hygiene, generated content, post-write hooks,
+  robot Git, graph-local checkpoint, PID, or lock; detached startup fails closed until a
+  separately qualified external control plane exists;
 - preserve bounded parsing, quarantine, writer coordination, health validation, and
   fallback behavior.
 

--- a/frontend/src/components/MasterHeader.tsx
+++ b/frontend/src/components/MasterHeader.tsx
@@ -214,7 +214,7 @@ export function MasterHeader({
                 disabled={engineBusy || engineRunning || !preflightReady || Boolean(config?.read_only)}
                 title={
                   config?.read_only
-                    ? 'Maintenance engine is unavailable while Strict Read Only is enabled'
+                    ? 'Use the foreground Shadow observer in Strict Read Only mode; detached startup would require graph-local control files'
                     : preflightReady
                       ? 'Start the maintenance daemon'
                       : 'Complete the pre-flight checklist before starting'

--- a/frontend/src/types/daemon.ts
+++ b/frontend/src/types/daemon.ts
@@ -362,6 +362,13 @@ export function normalizeDaemonState(raw: DaemonStateResponse): DaemonStateRespo
       'pageSummariesCreated',
     ),
     daemon_pid: readNumber(source, 'daemon_pid', 'daemonPid') || undefined,
+    daemon_profile:
+      source.daemon_profile === 'read_only_shadow_observer'
+        ? 'read_only_shadow_observer'
+        : 'standard',
+    disabled_duties: Array.isArray(source.disabled_duties)
+      ? source.disabled_duties.filter((value): value is string => typeof value === 'string')
+      : [],
     graph_analytics: graphAnalytics,
     shadow_db: normalizeShadowDb(
       (raw as unknown as Record<string, unknown>).shadow_db
@@ -403,6 +410,8 @@ export interface DaemonStateResponse {
   page_summaries_created?: number
   bootstrap_recent?: Record<string, BootstrapRecentEntry>
   daemon_pid?: number | null
+  daemon_profile?: 'standard' | 'read_only_shadow_observer'
+  disabled_duties?: string[]
   graph_analytics?: GraphAnalytics
   shadow_db?: ShadowDbState
 }

--- a/src/agent/daemon_read_only_profile.py
+++ b/src/agent/daemon_read_only_profile.py
@@ -1,0 +1,86 @@
+"""Strict read-only daemon profile backed only by the external Shadow cache."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+from ..graph.safety.write_policy import is_graph_read_only
+from ..shadow.cache_location import ShadowCacheLocationError, resolve_shadow_cache_location
+from ..shadow.config import shadow_db_enabled
+
+DaemonProfile = Literal["standard", "read_only_shadow_observer"]
+
+STANDARD_DAEMON_PROFILE: DaemonProfile = "standard"
+READ_ONLY_SHADOW_OBSERVER_PROFILE: DaemonProfile = "read_only_shadow_observer"
+READ_ONLY_DISABLED_DUTIES: tuple[str, ...] = (
+    "bootstrap_harvest",
+    "semantic_writes",
+    "journey_log",
+    "property_hygiene",
+    "generated_content",
+    "post_write_hooks",
+    "robot_git",
+    "graph_local_state",
+)
+
+
+class ReadOnlyDaemonProfileError(RuntimeError):
+    """A content-free failure to start the strict read-only daemon profile."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"Read-only daemon profile unavailable ({reason})")
+
+
+def active_daemon_profile() -> DaemonProfile:
+    """Return the configured daemon profile without touching the filesystem."""
+
+    if is_graph_read_only():
+        return READ_ONLY_SHADOW_OBSERVER_PROFILE
+    return STANDARD_DAEMON_PROFILE
+
+
+def disabled_daemon_duties() -> tuple[str, ...]:
+    """Return duties disabled by the active profile."""
+
+    if active_daemon_profile() == READ_ONLY_SHADOW_OBSERVER_PROFILE:
+        return READ_ONLY_DISABLED_DUTIES
+    return ()
+
+
+def prepare_read_only_daemon_environment(graph_root: Path) -> Path:
+    """Validate the external cache and route daemon logs outside the graph."""
+
+    if not is_graph_read_only():
+        raise ReadOnlyDaemonProfileError("read_only_not_enabled")
+    if not shadow_db_enabled():
+        raise ReadOnlyDaemonProfileError("shadow_disabled")
+    try:
+        location = resolve_shadow_cache_location(graph_root)
+        location.ensure_directory()
+    except (OSError, RuntimeError, ShadowCacheLocationError) as exc:
+        raise ReadOnlyDaemonProfileError("external_cache_unavailable") from exc
+
+    daemon_dir = (location.shadow_dir.parent / "daemon").resolve(strict=False)
+    if not daemon_dir.is_relative_to(location.cache_root) or daemon_dir.is_symlink():
+        raise ReadOnlyDaemonProfileError("daemon_directory_unsafe")
+    daemon_dir.mkdir(mode=0o700, exist_ok=True)
+    if os.name == "posix":
+        daemon_dir.chmod(0o700)
+
+    os.environ["MATRYCA_PLUMBER_LOG_PATH"] = str(daemon_dir / "operations.jsonl")
+    os.environ["MATRYCA_LOGURU_LOG_PATH"] = str(daemon_dir / "daemon.log")
+    return daemon_dir
+
+
+__all__ = [
+    "DaemonProfile",
+    "READ_ONLY_DISABLED_DUTIES",
+    "READ_ONLY_SHADOW_OBSERVER_PROFILE",
+    "ReadOnlyDaemonProfileError",
+    "active_daemon_profile",
+    "disabled_daemon_duties",
+    "prepare_read_only_daemon_environment",
+]

--- a/src/agent/maintenance_daemon.py
+++ b/src/agent/maintenance_daemon.py
@@ -107,6 +107,10 @@ from .daemon_process_lock import (
     stop_daemon,
     write_pid_file,
 )
+from .daemon_read_only_profile import (
+    READ_ONLY_DISABLED_DUTIES,
+    prepare_read_only_daemon_environment,
+)
 from .daemon_semantic_write import (
     STRUCTURAL_LINT_HEADER,
     CorrectionOutcome,
@@ -1028,6 +1032,9 @@ class MaintenanceDaemon:
             graph_root=self.graph_root,
             wiki_config=load_matryca_wiki_config(),
         )
+        if is_graph_read_only():
+            self._run_read_only_shadow_observer()
+            return
         state = self._sync_runtime_config(load_daemon_state(self.graph_root))
         llm_config = load_plumber_lint_config()
         logger.info(
@@ -1077,6 +1084,23 @@ class MaintenanceDaemon:
                     break
         finally:
             self._finalize_graceful_shutdown(state)
+
+    def _run_read_only_shadow_observer(self) -> None:
+        """Observe graph changes for external Shadow sync without mutating the graph."""
+
+        logger.bind(profile="read_only_shadow_observer").info(
+            "Read-only Shadow observer active; disabled duties: {}",
+            ", ".join(READ_ONLY_DISABLED_DUTIES),
+        )
+        try:
+            self._start_file_watcher()
+            while not self._stop_requested:
+                self._cycle_wake.wait(timeout=self.poll_seconds)
+                self._cycle_wake.clear()
+                if self._shutdown_event.is_set():
+                    break
+        finally:
+            self._stop_file_watcher()
 
 
 def run_plumber_cluster(
@@ -1133,14 +1157,22 @@ def run_plumber_audit(graph_root: Path | None = None) -> dict[str, Any]:
 def start_daemon_foreground(graph_root: Path | None = None) -> None:
     """Run the daemon in the current process (foreground)."""
     reload_plumber_dotenv()
-    configure_loguru()
     root = graph_root or resolve_graph_root()
+    read_only_profile = is_graph_read_only()
+    if read_only_profile:
+        prepare_read_only_daemon_environment(root)
+    configure_loguru()
     config = load_plumber_lint_config()
     sandbox = resolve_cpu_sandbox_config(config)
     if sandbox.enabled:
         apply_cpu_sandbox(sandbox)
     else:
         apply_plumber_priority(config)
+    if read_only_profile:
+        daemon = MaintenanceDaemon(root)
+        daemon.run_forever()
+        return
+
     lock_fd = _try_acquire_daemon_process_lock(root)
     if lock_fd is None:
         logger.error(
@@ -1165,6 +1197,15 @@ def start_daemon_foreground(graph_root: Path | None = None) -> None:
 def start_daemon_detached(graph_root: Path | None = None) -> dict[str, Any]:
     """Launch a background daemon worker via subprocess (cross-platform)."""
     root = graph_root or resolve_graph_root()
+    if is_graph_read_only():
+        return {
+            "ok": False,
+            "code": "read_only_foreground_required",
+            "message": (
+                "Strict Read Only supports the Shadow observer in foreground only; "
+                "no graph-local PID or lock is created"
+            ),
+        }
     existing = read_pid_file(root)
     if existing is not None and is_plumber_process(existing):
         return {

--- a/src/cli/ui_server.py
+++ b/src/cli/ui_server.py
@@ -31,6 +31,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
 from ..agent.control_room_progress import resolve_control_room_progress
+from ..agent.daemon_read_only_profile import active_daemon_profile, disabled_daemon_duties
 from ..agent.l1_memory import default_matryca_l1_directory_for_graph
 from ..agent.maintenance_daemon import (
     DEFAULT_STOP_GRACE_SECONDS,
@@ -163,6 +164,8 @@ class DaemonStateResponse(BaseModel):
     progress_total: int = 0
     progress_percent: float = 0.0
     daemon_pid: int | None = None
+    daemon_profile: Literal["standard", "read_only_shadow_observer"] = "standard"
+    disabled_duties: list[str] = Field(default_factory=list)
     shadow_db: ShadowDbStateResponse = Field(default_factory=ShadowDbStateResponse)
 
     @classmethod
@@ -823,6 +826,8 @@ def _build_daemon_state_response(graph_root: Path) -> DaemonStateResponse:
             "session_prompt_tokens": session_prompt_tokens,
             "session_completion_tokens": session_completion_tokens,
             "daemon_pid": daemon_pid,
+            "daemon_profile": active_daemon_profile(),
+            "disabled_duties": list(disabled_daemon_duties()),
             "shadow_db": resolve_shadow_db_state_for_api(graph_root),
             **progress.to_api_fields(),
         }

--- a/tests/test_read_only_daemon_profile.py
+++ b/tests/test_read_only_daemon_profile.py
@@ -1,0 +1,185 @@
+"""Contract tests for the side-effect-free strict read-only daemon profile."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from src.agent.daemon_read_only_profile import (
+    READ_ONLY_DISABLED_DUTIES,
+    ReadOnlyDaemonProfileError,
+    active_daemon_profile,
+    prepare_read_only_daemon_environment,
+)
+from src.agent.maintenance_daemon import (
+    DaemonState,
+    MaintenanceDaemon,
+    start_daemon_detached,
+    start_daemon_foreground,
+)
+from src.cli.ui_server import _build_daemon_state_response
+
+
+def _graph(tmp_path: Path) -> Path:
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    (graph / "pages" / "Observed.md").write_text("- unchanged\n", encoding="utf-8")
+    return graph
+
+
+def _read_only_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, graph: Path) -> None:
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(tmp_path / "external-cache"))
+
+
+def test_prepare_read_only_daemon_environment_routes_logs_outside_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    _read_only_env(monkeypatch, tmp_path, graph)
+
+    daemon_dir = prepare_read_only_daemon_environment(graph)
+
+    assert active_daemon_profile() == "read_only_shadow_observer"
+    assert not daemon_dir.is_relative_to(graph.resolve())
+    assert Path(os.environ["MATRYCA_PLUMBER_LOG_PATH"]).parent == daemon_dir
+    assert Path(os.environ["MATRYCA_LOGURU_LOG_PATH"]).parent == daemon_dir
+
+
+def test_prepare_read_only_daemon_environment_requires_shadow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    _read_only_env(monkeypatch, tmp_path, graph)
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+
+    with pytest.raises(ReadOnlyDaemonProfileError, match="shadow_disabled"):
+        prepare_read_only_daemon_environment(graph)
+
+
+def test_run_forever_read_only_runs_only_shadow_observer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    before = {
+        path.relative_to(graph): path.read_bytes() for path in graph.rglob("*") if path.is_file()
+    }
+    _read_only_env(monkeypatch, tmp_path, graph)
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(tmp_path / "external-ops.jsonl"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(tmp_path / "external-daemon.log"))
+
+    daemon = MaintenanceDaemon(graph, llm_client=MagicMock(), poll_seconds=0.01)
+    monkeypatch.setattr(daemon, "_register_daemon_signal_handlers", lambda: None)
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.prepare_matryca_runtime",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_bootstrap_pipeline",
+        lambda *_args, **_kwargs: pytest.fail("read-only observer ran LLM bootstrap"),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "run_cycle",
+        lambda *_args, **_kwargs: pytest.fail("read-only observer ran mutating duty cycle"),
+    )
+    stopped: list[bool] = []
+
+    def _start() -> None:
+        daemon._stop_requested = True
+
+    monkeypatch.setattr(daemon, "_start_file_watcher", _start)
+    monkeypatch.setattr(daemon, "_stop_file_watcher", lambda: stopped.append(True))
+
+    daemon.run_forever()
+
+    after = {
+        path.relative_to(graph): path.read_bytes() for path in graph.rglob("*") if path.is_file()
+    }
+    assert after == before
+    assert stopped == [True]
+    assert "graph_local_state" in READ_ONLY_DISABLED_DUTIES
+
+
+def test_start_daemon_foreground_read_only_skips_graph_control_files_and_llm_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    _read_only_env(monkeypatch, tmp_path, graph)
+    order: list[str] = []
+    daemon = MagicMock()
+
+    def _prepare_profile(_root: Path) -> Path:
+        order.append("profile")
+        return tmp_path / "external-cache"
+
+    monkeypatch.setattr("src.agent.maintenance_daemon.reload_plumber_dotenv", lambda: None)
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.prepare_read_only_daemon_environment",
+        _prepare_profile,
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.configure_loguru",
+        lambda: order.append("logs"),
+    )
+    monkeypatch.setattr("src.agent.maintenance_daemon.load_plumber_lint_config", MagicMock())
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon._try_acquire_daemon_process_lock",
+        lambda _root: pytest.fail("read-only foreground acquired a graph lock"),
+    )
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.write_pid_file",
+        lambda _root: pytest.fail("read-only foreground wrote a graph PID"),
+    )
+    monkeypatch.setattr("src.agent.maintenance_daemon.MaintenanceDaemon", lambda _root: daemon)
+
+    start_daemon_foreground(graph)
+
+    assert order == ["profile", "logs"]
+    daemon.llm_client.probe_backend.assert_not_called()
+    daemon.run_forever.assert_called_once_with()
+
+
+def test_start_daemon_detached_read_only_fails_closed_before_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    _read_only_env(monkeypatch, tmp_path, graph)
+    monkeypatch.setattr(
+        "src.agent.maintenance_daemon.subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("read-only detached daemon spawned"),
+    )
+
+    result = start_daemon_detached(graph)
+
+    assert result["ok"] is False
+    assert result["code"] == "read_only_foreground_required"
+
+
+def test_state_api_reports_read_only_profile_and_disabled_duties(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _graph(tmp_path)
+    _read_only_env(monkeypatch, tmp_path, graph)
+    monkeypatch.setattr("src.cli.ui_server.load_daemon_state", lambda _root: DaemonState())
+    monkeypatch.setattr("src.cli.ui_server.read_pid_file", lambda _root: None)
+    monkeypatch.setattr(
+        "src.cli.ui_server._session_token_totals_for_api",
+        lambda _state: (0, 0),
+    )
+
+    response = _build_daemon_state_response(graph)
+
+    assert response.daemon_profile == "read_only_shadow_observer"
+    assert response.disabled_duties == list(READ_ONLY_DISABLED_DUTIES)


### PR DESCRIPTION
## Summary
- add a strict Read Only daemon profile that runs only external Shadow bootstrap and watcher reconciliation
- disable LLM bootstrap, semantic/journey/hygiene/generated writes, post-write hooks, robot Git, and graph-local daemon state, PID, and lock duties
- route daemon logs to the validated external per-graph cache and fail closed when Shadow or that cache is unavailable
- expose the active daemon profile and disabled duties in the state API; keep detached startup unavailable until an external control plane is qualified

## Test plan
- [x] `make ci` — 1,558 passed, 2 skipped, 1 xfailed; coverage 82.88%
- [x] focused daemon/UI suite — 152 passed
- [x] frontend tests — 16 passed
- [x] frontend build and lint
- [x] staged diff check and code-impact review

Closes #350
Refs #346
Refs #351
Refs #343