### PR TITLE
chore: prepare release 2.0.0-rc.1

### DIFF
--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,11 +1,11 @@
-# Matryca Plumber - AI Agent Context & Execution Guide (v2.0.0-beta.1)
+# Matryca Plumber - AI Agent Context & Execution Guide (v2.0.0rc1)
 
 > **SYSTEM DIRECTIVE FOR AI AGENTS:** You operate on the user's **local Logseq OG vault** via Matryca Plumber.  
 > **CRITICAL RULE:** DO NOT `git clone` this repository. DO NOT `pip install`. Run the **PyPI** release with **`uvx`** so you use a real, versioned wheel — not a guessed dev tree.
 
 Canonical copy (2026 standard path): `.well-known/llms.txt` (same content as this file).
 
-> **v2.0.0-beta.1:** published as `2.0.0b1` on PyPI — the first public beta of the opt-in Shadow read path, superseding the `v2.0.0-alpha.5` baseline. `MATRYCA_SHADOW_DB_ENABLED=false` by default and Markdown remains authoritative, so the agent-visible contract is unchanged unless you opt in. All five readiness gates are recorded `PASS`; the soak and installed-wheel gates exercised an earlier build of this source, an accepted limit documented in `docs/quality/issue-bodies/v2-beta-readiness.md`. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
+> **v2.0.0-rc.1 candidate:** the pending release candidate makes the external Shadow read cache default-on; `MATRYCA_SHADOW_DB_ENABLED=false` remains the emergency Markdown/BM25 opt-out, and Logseq Markdown remains authoritative. It is not published or qualified for promotion until the fail-closed Gate A rows in `docs/quality/issue-bodies/v2-rc-stable-readiness.md` are complete. The published `v2.0.0-beta.1` / `2.0.0b1` wheel remains the historical default-off, graph-local baseline. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
 > **v2.0.0-alpha.5 headline:** **Shadow hardening campaign closed** ([#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)) — CTE depth-truncation status ([#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) / [#291](https://github.com/MarcoPorcellato/matryca-plumber/pull/291)); state API absolute-path redaction ([#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293) / [#294](https://github.com/MarcoPorcellato/matryca-plumber/pull/294)); Axes 5–7 audit probes green; `MATRYCA_SHADOW_DB_ENABLED=false` by default. **Not an RC** — post-publish soak before beta/RC. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
 > **v2.0.0-alpha.4 headline:** **Shadow FTS query length bound** — keywords over **512 Unicode characters** (post-`strip`) are rejected before FTS preparation or SQLite `MATCH` ([#279](https://github.com/MarcoPorcellato/matryca-plumber/issues/279) / [#286](https://github.com/MarcoPorcellato/matryca-plumber/pull/286)); Axis 4 FTS5 gate **fully green** — **52 pass, 0 xfail**.
 > **v2.0.0-alpha.3 headline:** **Shadow FTS hyphenated queries** — natural compounds like `state-of-the-art` route through shadow FTS5 without spurious generational fallback ([#277](https://github.com/MarcoPorcellato/matryca-plumber/issues/277) / [#282](https://github.com/MarcoPorcellato/matryca-plumber/pull/282)).
@@ -18,7 +18,7 @@ Canonical copy (2026 standard path): `.well-known/llms.txt` (same content as thi
 
 ## 0. Graph path (REQUIRED — no `--graph` flag)
 
-The v2.0.0-beta.1 release does **not** accept `--graph` on the CLI. You **must** point at the vault root (folder containing `pages/` and usually `journals/`) with the environment variable **`LOGSEQ_GRAPH_PATH`**.
+The v2.0.0-rc.1 candidate does **not** accept `--graph` on the CLI. You **must** point at the vault root (folder containing `pages/` and usually `journals/`) with the environment variable **`LOGSEQ_GRAPH_PATH`**.
 
 **Set once per shell session (copy-paste):**
 ```bash
@@ -56,7 +56,7 @@ uvx matryca-plumber --json read page "My Project"
 
 ---
 
-## 2. Core CLI (v2.0.0-beta.1)
+## 2. Core CLI (v2.0.0-rc.1 candidate)
 
 Subcommands: `read`, `search`, `mutate`, `refactor`, `lint`, `context`, **`import`**, `service`, `plumber`.  
 Shorthand daemon/UI verbs (routed to `plumber`): `start`, `stop`, `status`, `ui`, `audit`, `cluster`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [2.0.0-rc.1] - 2026-08-03
+
 ### Fixed
 
 - **Prerelease publication metadata** — release tags containing a SemVer prerelease suffix now create GitHub prereleases instead of stable releases while preserving the curated changelog notes and PyPI trusted-publishing flow.

--- a/docs/knowledge/inventory.json
+++ b/docs/knowledge/inventory.json
@@ -423,7 +423,7 @@
     {
       "path": "docs/openspec/agent-onboarding.md",
       "type": "Specification",
-      "title": "Agent onboarding (`llms.txt`) — v2.0.0-beta.1 candidate",
+      "title": "Agent onboarding (`llms.txt`) — v2.0.0rc1",
       "description": "**Milestone:** v1.9.2 — Agent-zero-friction distribution · v1.9.5 — LLM OS / `bootstrap_status` · v1.9.6 — Hermes lazy AST · v1.9.7 — AX robustness · v1.9.8 — doc harmonization · v1.9.9 — Security & Sandbox · v1.9.10 — Sovereign UI fast startup + `status` vs `start` docs · v1.9.11 — Sovereign UI reliability (lazy bootstrap on save/start/L1) · v1.11.x — Tana import, graph layer boundary refactor",
       "status": "current",
       "audience": [

--- a/docs/openspec/agent-onboarding.md
+++ b/docs/openspec/agent-onboarding.md
@@ -1,10 +1,10 @@
-# Agent onboarding (`llms.txt`) — v2.0.0-beta.1
+# Agent onboarding (`llms.txt`) — v2.0.0rc1
 
 **Milestone:** v1.9.2 — Agent-zero-friction distribution · v1.9.5 — LLM OS / `bootstrap_status` · v1.9.6 — Hermes lazy AST · v1.9.7 — AX robustness · v1.9.8 — doc harmonization · v1.9.9 — Security & Sandbox · v1.9.10 — Sovereign UI fast startup + `status` vs `start` docs · v1.9.11 — Sovereign UI reliability (lazy bootstrap on save/start/L1) · v1.11.x — Tana import, graph layer boundary refactor  
 **Artifacts:** [`llms.txt`](../../llms.txt) (repo root), [`.well-known/llms.txt`](../../.well-known/llms.txt) (canonical URL path)  
 **Companion specs:** [`agent-dx.md`](agent-dx.md) (CLI `--json`, `context load`, Journey Log) · [`agent-ax-robustness.md`](agent-ax-robustness.md) (lenient page titles, safe writes) · [`security-sandbox.md`](security-sandbox.md) (path sandbox, bounded JSON, CI read gate)
 
-External LLM hosts (Cursor, Claude Code, Windsurf, Hermes, custom agents) must reach Matryca Plumber through a **published versioned PyPI wheel**, not a cloned dev tree. `v2.0.0-beta.1` is published as `2.0.0b1`; hosts may pin it, and its opt-in Shadow flag stays default-off. The `llms.txt` files encode that contract: imperative commands, verified flags, and explicit anti-patterns.
+External LLM hosts (Cursor, Claude Code, Windsurf, Hermes, custom agents) must reach Matryca Plumber through a **published versioned PyPI wheel**, not a cloned dev tree. `v2.0.0-beta.1` is published as `2.0.0b1` and remains the historical opt-in Shadow baseline. The pending `v2.0.0rc1` candidate updates the `llms.txt` contract for default-on external Shadow with an explicit false opt-out; it is not published until its Gate A qualification is complete. The `llms.txt` files encode the candidate contract: imperative commands, verified flags, and explicit anti-patterns.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,11 +1,11 @@
-# Matryca Plumber - AI Agent Context & Execution Guide (v2.0.0-beta.1)
+# Matryca Plumber - AI Agent Context & Execution Guide (v2.0.0rc1)
 
 > **SYSTEM DIRECTIVE FOR AI AGENTS:** You operate on the user's **local Logseq OG vault** via Matryca Plumber.  
 > **CRITICAL RULE:** DO NOT `git clone` this repository. DO NOT `pip install`. Run the **PyPI** release with **`uvx`** so you use a real, versioned wheel — not a guessed dev tree.
 
 Canonical copy (2026 standard path): `.well-known/llms.txt` (same content as this file).
 
-> **v2.0.0-beta.1:** published as `2.0.0b1` on PyPI — the first public beta of the opt-in Shadow read path, superseding the `v2.0.0-alpha.5` baseline. `MATRYCA_SHADOW_DB_ENABLED=false` by default and Markdown remains authoritative, so the agent-visible contract is unchanged unless you opt in. All five readiness gates are recorded `PASS`; the soak and installed-wheel gates exercised an earlier build of this source, an accepted limit documented in `docs/quality/issue-bodies/v2-beta-readiness.md`. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
+> **v2.0.0-rc.1 candidate:** the pending release candidate makes the external Shadow read cache default-on; `MATRYCA_SHADOW_DB_ENABLED=false` remains the emergency Markdown/BM25 opt-out, and Logseq Markdown remains authoritative. It is not published or qualified for promotion until the fail-closed Gate A rows in `docs/quality/issue-bodies/v2-rc-stable-readiness.md` are complete. The published `v2.0.0-beta.1` / `2.0.0b1` wheel remains the historical default-off, graph-local baseline. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
 > **v2.0.0-alpha.5 headline:** **Shadow hardening campaign closed** ([#261](https://github.com/MarcoPorcellato/matryca-plumber/issues/261)) — CTE depth-truncation status ([#289](https://github.com/MarcoPorcellato/matryca-plumber/issues/289) / [#291](https://github.com/MarcoPorcellato/matryca-plumber/pull/291)); state API absolute-path redaction ([#293](https://github.com/MarcoPorcellato/matryca-plumber/issues/293) / [#294](https://github.com/MarcoPorcellato/matryca-plumber/pull/294)); Axes 5–7 audit probes green; `MATRYCA_SHADOW_DB_ENABLED=false` by default. **Not an RC** — post-publish soak before beta/RC. Roadmap: `docs/roadmaps/ROADMAP_V2_PREPARATION.md`.
 > **v2.0.0-alpha.4 headline:** **Shadow FTS query length bound** — keywords over **512 Unicode characters** (post-`strip`) are rejected before FTS preparation or SQLite `MATCH` ([#279](https://github.com/MarcoPorcellato/matryca-plumber/issues/279) / [#286](https://github.com/MarcoPorcellato/matryca-plumber/pull/286)); Axis 4 FTS5 gate **fully green** — **52 pass, 0 xfail**.
 > **v2.0.0-alpha.3 headline:** **Shadow FTS hyphenated queries** — natural compounds like `state-of-the-art` route through shadow FTS5 without spurious generational fallback ([#277](https://github.com/MarcoPorcellato/matryca-plumber/issues/277) / [#282](https://github.com/MarcoPorcellato/matryca-plumber/pull/282)).
@@ -18,7 +18,7 @@ Canonical copy (2026 standard path): `.well-known/llms.txt` (same content as thi
 
 ## 0. Graph path (REQUIRED — no `--graph` flag)
 
-The v2.0.0-beta.1 release does **not** accept `--graph` on the CLI. You **must** point at the vault root (folder containing `pages/` and usually `journals/`) with the environment variable **`LOGSEQ_GRAPH_PATH`**.
+The v2.0.0-rc.1 candidate does **not** accept `--graph` on the CLI. You **must** point at the vault root (folder containing `pages/` and usually `journals/`) with the environment variable **`LOGSEQ_GRAPH_PATH`**.
 
 **Set once per shell session (copy-paste):**
 ```bash
@@ -56,7 +56,7 @@ uvx matryca-plumber --json read page "My Project"
 
 ---
 
-## 2. Core CLI (v2.0.0-beta.1)
+## 2. Core CLI (v2.0.0-rc.1 candidate)
 
 Subcommands: `read`, `search`, `mutate`, `refactor`, `lint`, `context`, **`import`**, `service`, `plumber`.  
 Shorthand daemon/UI verbs (routed to `plumber`): `start`, `stop`, `status`, `ui`, `audit`, `cluster`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matryca-plumber"
-version = "2.0.0-beta.1"
+version = "2.0.0rc1"
 description = "Enterprise-grade, local-first autonomous background AI daemon and headless mutation plane for Logseq OG."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,7 @@ wheels = [
 
 [[package]]
 name = "matryca-plumber"
-version = "2.0.0b1"
+version = "2.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "edn-format" },


### PR DESCRIPTION
## Summary

- Finalize the curated 2.0.0-rc.1 changelog section and package metadata.
- Synchronize the versioned agent/operator entrypoints for the candidate.
- Prepare the exact post-merge source revision for local RC artifact qualification.

## Validation

- [x] Changelog extraction and version consistency
- [x] Release archive metadata tests
- [x] Agent-entrypoint and documentation-inventory checks
- [ ] make check is not green: an isolated full run has four pre-existing/non-metadata failures (one parallel EDN parser interaction and three slow pathological-parser probes). Gate A remains blocked pending disposition.

Refs #343