### PR TITLE
fix(release): harden RC qualification provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **RC qualification timeout and provenance** — give the multi-rebuild candidate probe an independent bounded deadline while keeping install commands at 600 seconds, and run installed-package probes from the virtual environment so checkout-local `src` cannot satisfy wheel provenance.
+
 ## [2.0.0-rc.1] - 2026-08-03
 
 ### Fixed

--- a/docs/quality/issue-bodies/v2-rc-stable-readiness.md
+++ b/docs/quality/issue-bodies/v2-rc-stable-readiness.md
@@ -38,12 +38,30 @@ Use two fail-closed promotion gates.
 | Published-artifact identity | PyPI wheel and sdist digests match the GitHub prerelease assets; installed imports resolve from `site-packages` | [x] — verified after `v2.0.0-beta.1` publication |
 | Exact-wheel functional smoke | Fresh PyPI install verifies flag-off, flag-on `READY`, FTS, bounded subtree reads, quarantine state, warm startup, and unchanged Markdown bytes | [x] — post-publication smoke passed |
 | Exact-wheel real-vault qualification | Sanitized daily-use vault copy; product-default 15 s parse deadline; at least 72 hours and preferably 7 days; restart and watcher CRUD; controlled recovery; unchanged Markdown fingerprints | [x] — terminal `PASS` on 2026-08-03: 415 completed cycles, 831 recorded attempts, 259,225.349 observed seconds, 415 subtree and 415 synthetic CRUD checks with none skipped, and source Markdown unchanged during the source-to-working-copy check. This is exact `2.0.0b1` evidence only. See [`SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md`](../SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md) |
-| Upgrade and rollback safety | Clean install plus `1.14.5`, `2.0.0a5`, and `2.0.0b1` upgrades to the exact RC candidate; schema mismatch and a forced rebuild failure each make the read port non-ready before a clean recovery, while opt-out, rollback, and Markdown integrity remain enforced | [ ] — run `scripts/qualify_rc_upgrade_rollback.py` against the frozen local RC wheel with all three `--baseline` values, an explicit source-vault realpath fingerprint, and a disposable output root; record only its sanitized terminal result. |
+| Upgrade and rollback safety | Clean install plus `1.14.5`, `2.0.0a5`, and `2.0.0b1` upgrades to the exact RC candidate; schema mismatch and a forced rebuild failure each make the read port non-ready before a clean recovery, while opt-out, rollback, and Markdown integrity remain enforced | [ ] — provisional functional `PASS` on 2026-08-03 against the `2.0.0rc1` wheel built from `main@685a99d` (SHA-256 `d6ce932ca17647cafd2df70012012f013b1281b3ad2e1d54803d8cdc889fbb4c`): all three baselines installed, upgraded, recovered, and rolled back; every candidate check was true; source and working Markdown were unchanged. The collector repair must merge and the final post-merge wheel must be rebuilt and rebound before this row is checked complete. |
 | Defect threshold | No open P0/P1 in Shadow read-path scope; every P2 has an explicit maintainer disposition | [ ] |
 | External-cache Read Only compatibility | Shadow DB, WAL/SHM, and writer lock resolve outside `LOGSEQ_GRAPH_PATH`; `MATRYCA_READ_ONLY=true` permits only validated external-cache writes; graph fingerprint and graph-local file inventory remain unchanged | [x] — implementation merged through #363; deterministic source-tree E2E gate passes across CLI, MCP, UI, daemon, Shadow, hidden files, Git metadata, and symlink cases. See [`READ_ONLY_IMMUTABILITY_E2E.md`](../READ_ONLY_IMMUTABILITY_E2E.md) and [`v2-external-shadow-cache-read-only.md`](v2-external-shadow-cache-read-only.md) |
 | Default-on contract | Unset `MATRYCA_SHADOW_DB_ENABLED` prefers Shadow reads, including under Read Only with a valid external cache; explicit `false` restores the legacy path; every non-ready state falls back to Markdown/BM25 | [ ] — implemented and source-tested in #362; exact-candidate installed-wheel qualification remains pending |
 | Operator contract | `.env.example`, Sovereign UI settings/help, `llms.txt`, `.well-known/llms.txt`, OpenSpec fragments, generated prompt, roadmap, tests, and changelog agree | [ ] — source surfaces synchronized; final exact-candidate review remains pending |
 | Release-candidate proof | Full CI, code audit, clean release build, installed-wheel smoke, and supported-platform checks pass on the exact RC commit | [ ] |
+
+#### Upgrade/rollback collector diagnosis — 2026-08-03
+
+The first exact-candidate run failed as `candidate_probe_failed` after the
+collector placed four full real-vault rebuild/recovery phases under one
+600-second subprocess deadline. Historical real-vault evidence already
+recorded individual probe durations up to 516 seconds, so this was a harness
+budget defect rather than a Shadow corruption signal. The collector now keeps
+installation commands capped at 600 seconds and gives only the multi-rebuild
+candidate probe an independent, bounded 3,600-second ceiling.
+
+The corrected-timeout run completed all candidate checks but exposed a second
+provenance defect: subprocesses inherited the repository working directory, so
+`import src` could resolve the checkout instead of the installed wheel. Both
+the installed-package and candidate probes now execute from the virtual
+environment directory. A fresh privacy-bounded run then recorded the
+provisional functional `PASS` summarized above. No private path, graph content,
+or child-process diagnostic is retained in the committed record.
 
 `v2.0.0-rc.1` may be published only when every Gate A row is complete.
 

--- a/scripts/qualify_rc_upgrade_rollback.py
+++ b/scripts/qualify_rc_upgrade_rollback.py
@@ -22,6 +22,7 @@ from beta_evidence.wheel import _markdown_fingerprint
 _PACKAGE_VERSION = re.compile(r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?")
 _RESULT_NAME = "rc-upgrade-rollback-result.json"
 _PROCESS_TIMEOUT_SECONDS = 600
+_CANDIDATE_PROBE_TIMEOUT_SECONDS = 3_600
 _PAGE_PARSE_TIMEOUT_SECONDS = 15
 
 CommandRunner = Callable[
@@ -114,6 +115,7 @@ def _installed_package_probe(python: Path, expected_package: str) -> bool:
     try:
         completed = subprocess.run(  # noqa: S603
             [str(python), "-c", probe],
+            cwd=python.parent,
             check=False,
             capture_output=True,
             text=True,
@@ -242,6 +244,7 @@ print(json.dumps({{
     try:
         completed = subprocess.run(  # noqa: S603
             [str(python), "-c", script],
+            cwd=python.parent,
             check=False,
             capture_output=True,
             text=True,
@@ -294,6 +297,7 @@ def collect_upgrade_rollback(
     source_vault: Path,
     expected_source_file: Path,
     timeout_seconds: int = _PROCESS_TIMEOUT_SECONDS,
+    candidate_timeout_seconds: int = _CANDIDATE_PROBE_TIMEOUT_SECONDS,
     command_runner: CommandRunner = _run_command,
     candidate_probe: ProbeRunner = _candidate_probe,
     installed_probe: Callable[[Path, str], bool] = _installed_package_probe,
@@ -309,6 +313,8 @@ def collect_upgrade_rollback(
         raise EvidenceError("baseline_packages_invalid")
     if not 1 <= timeout_seconds <= _PROCESS_TIMEOUT_SECONDS:
         raise EvidenceError("timeout_invalid")
+    if not 1 <= candidate_timeout_seconds <= _CANDIDATE_PROBE_TIMEOUT_SECONDS:
+        raise EvidenceError("candidate_timeout_invalid")
     source = _resolve_source_vault(source_vault, expected_source_file)
     try:
         candidate_wheel = wheel.expanduser().resolve(strict=True)
@@ -365,7 +371,11 @@ def collect_upgrade_rollback(
                 )
             )
             candidate = candidate_probe(
-                python, working_vault, cache_root, candidate_package, timeout_seconds
+                python,
+                working_vault,
+                cache_root,
+                candidate_package,
+                candidate_timeout_seconds,
             )
             _require_success(
                 command_runner(
@@ -425,6 +435,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-vault", required=True)
     parser.add_argument("--expected-source-realpath-file", required=True)
     parser.add_argument("--timeout-seconds", type=int, default=_PROCESS_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--candidate-timeout-seconds",
+        type=int,
+        default=_CANDIDATE_PROBE_TIMEOUT_SECONDS,
+        help=(
+            "Bound for the multi-rebuild candidate probe; install commands keep --timeout-seconds."
+        ),
+    )
     return parser
 
 
@@ -439,6 +457,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_vault=Path(args.source_vault),
             expected_source_file=Path(args.expected_source_realpath_file),
             timeout_seconds=args.timeout_seconds,
+            candidate_timeout_seconds=args.candidate_timeout_seconds,
         )
     except EvidenceError as exc:
         print(f"rc upgrade rollback: {exc.category}", file=sys.stderr)

--- a/tests/test_rc_upgrade_rollback.py
+++ b/tests/test_rc_upgrade_rollback.py
@@ -81,6 +81,39 @@ def test_collector_records_sanitized_pass_for_each_baseline(tmp_path: Path) -> N
     assert json.loads(evidence)["status"] == "PASS"
 
 
+def test_collector_uses_independent_candidate_timeout(tmp_path: Path) -> None:
+    module = _module()
+    source, wheel, expected_source = _source(tmp_path)
+    observed_timeouts: list[int] = []
+
+    def candidate(
+        _python: Path,
+        _graph: Path,
+        _cache_root: Path,
+        _candidate_package: str,
+        timeout: int,
+    ) -> dict[str, bool]:
+        observed_timeouts.append(timeout)
+        return _candidate()
+
+    result = module.collect_upgrade_rollback(
+        tmp_path / "evidence",
+        wheel=wheel,
+        candidate_package="2.0.0rc1",
+        baselines=("2.0.0b1",),
+        source_vault=source,
+        expected_source_file=expected_source,
+        timeout_seconds=30,
+        candidate_timeout_seconds=1_800,
+        command_runner=_command,
+        candidate_probe=candidate,
+        installed_probe=lambda _python, _package: True,
+    )
+
+    assert result["status"] == "PASS"
+    assert observed_timeouts == [1_800]
+
+
 def test_collector_fails_closed_and_preserves_source_on_candidate_failure(tmp_path: Path) -> None:
     module = _module()
     source, wheel, expected_source = _source(tmp_path)
@@ -126,6 +159,25 @@ def test_collector_rejects_duplicate_or_invalid_baselines(tmp_path: Path) -> Non
             assert exc.category == category
         else:
             raise AssertionError("expected a fail-closed validation error")
+
+
+@pytest.mark.parametrize("candidate_timeout", [0, 3_601])
+def test_collector_rejects_invalid_candidate_timeout(
+    tmp_path: Path, candidate_timeout: int
+) -> None:
+    module = _module()
+    source, wheel, expected_source = _source(tmp_path)
+
+    with pytest.raises(module.EvidenceError, match="candidate_timeout_invalid"):
+        module.collect_upgrade_rollback(
+            tmp_path / "evidence",
+            wheel=wheel,
+            candidate_package="2.0.0rc1",
+            baselines=("2.0.0b1",),
+            source_vault=source,
+            expected_source_file=expected_source,
+            candidate_timeout_seconds=candidate_timeout,
+        )
 
 
 def test_collector_rejects_a_source_that_does_not_match_the_private_fingerprint(
@@ -174,8 +226,9 @@ def test_candidate_probe_uses_the_external_cache_location_contract(
     }
     commands: list[list[str]] = []
 
-    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         commands.append(command)
+        assert kwargs["cwd"] == Path(sys.executable).parent
         return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
 
     monkeypatch.setattr(module.subprocess, "run", fake_run)
@@ -190,6 +243,24 @@ def test_candidate_probe_uses_the_external_cache_location_contract(
     assert "schema_mismatch_fallback" in script
     assert "failed_rebuild_fallback" in script
     assert "shadow_read_port_ready(graph)" in script
+
+
+def test_installed_probe_executes_outside_the_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _module()
+    observed_cwd: list[Path] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        cwd = kwargs["cwd"]
+        assert isinstance(cwd, Path)
+        observed_cwd.append(cwd)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    assert module._installed_package_probe(Path(sys.executable), "2.0.0rc1") is True
+    assert observed_cwd == [Path(sys.executable).parent]
 
 
 def test_candidate_probe_exercises_disposable_recovery_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Separate the multi-rebuild candidate deadline from the 600-second install-command deadline.
- Run candidate and installed-package probes from the virtual environment so checkout-local modules cannot satisfy wheel provenance.
- Record the sanitized provisional Gate A result while keeping final post-merge artifact rebinding open.

## Validation

- [x] 10 focused collector tests
- [x] Ruff lint and format checks
- [x] Canonical mypy and documentation checks
- [x] Privacy-bounded real-vault run: 1.14.5, 2.0.0a5, and 2.0.0b1 all install, upgrade, recover, and roll back; every candidate boolean is true; source and working Markdown are unchanged
- [ ] make check remains red on three unrelated/load-sensitive parser tests: control-page 2-second budget, bounded parse startup at a 2-second deadline, and the 90-second pathological hard ceiling

Refs #343