### PR TITLE
ci(release): qualify Shadow contract cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,39 @@ jobs:
 
       - name: Run CI gate (format check, Ruff, Mypy, Pytest)
         run: make ci
+
+  shadow-cross-platform:
+    name: Shadow contract (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv and Python 3.12
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          python-version: "3.12"
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Sync Python dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Verify the supported Shadow read contract
+        run: >-
+          uv run pytest -q -o addopts=
+          tests/test_shadow_config.py::test_shadow_db_enabled_default_true
+          tests/test_shadow_cache_location.py::test_platform_default_cache_roots
+          tests/test_shadow_connection.py::test_open_shadow_db_uses_only_external_cache_in_read_only_mode
+          tests/test_shadow_connection.py::test_open_shadow_db_rejects_disabled_flag
+          tests/test_shadow_bootstrap.py::test_read_only_startup_builds_external_shadow_without_graph_drift
+          tests/test_shadow_bootstrap.py::test_read_only_shadow_off_touches_neither_graph_nor_external_cache
+          tests/test_shadow_fts_routing.py::test_handle_search_bm25_uses_shadow_when_ready
+          tests/test_shadow_fts_routing.py::test_handle_search_bm25_shadow_not_ready_falls_back

--- a/tests/test_shadow_cache_location.py
+++ b/tests/test_shadow_cache_location.py
@@ -28,27 +28,28 @@ def _symlink(target: Path, link: Path, *, target_is_directory: bool = False) -> 
 
 
 @pytest.mark.parametrize(
-    ("platform_name", "env", "expected"),
+    ("platform_name", "override_key", "expected"),
     [
-        ("darwin", {}, Path("Library/Caches/matryca-plumber")),
-        ("linux", {}, Path(".cache/matryca-plumber")),
-        ("linux", {"XDG_CACHE_HOME": "/xdg-cache"}, Path("/xdg-cache/matryca-plumber")),
-        (
-            "win32",
-            {"LOCALAPPDATA": "/local-app-data"},
-            Path("/local-app-data/matryca-plumber/Cache"),
-        ),
+        ("darwin", None, Path("Library/Caches/matryca-plumber")),
+        ("linux", None, Path(".cache/matryca-plumber")),
+        ("linux", "XDG_CACHE_HOME", Path("matryca-plumber")),
+        ("win32", "LOCALAPPDATA", Path("matryca-plumber/Cache")),
     ],
 )
 def test_platform_default_cache_roots(
     tmp_path: Path,
     platform_name: str,
-    env: dict[str, str],
+    override_key: str | None,
     expected: Path,
 ) -> None:
     graph = _graph(tmp_path)
     home = tmp_path / "home"
-    expected_root = expected if expected.is_absolute() else home / expected
+    env: dict[str, str] = {}
+    expected_root = home / expected
+    if override_key is not None:
+        override_root = tmp_path / "platform-cache"
+        env[override_key] = str(override_root)
+        expected_root = override_root / expected
 
     location = resolve_shadow_cache_location(
         graph,


### PR DESCRIPTION
## Summary
- add a focused macOS and Windows CI matrix for the supported Shadow read contract
- verify default-on routing, platform cache roots, strict Read Only external-cache writes, explicit opt-out, startup immutability, FTS preference, and fallback
- make simulated cache overrides host-native so the contract test runs correctly on Windows
- keep the existing Ubuntu full gate unchanged

## Test plan
- [x] focused cross-platform Shadow contract nodes: 11 passed locally
- [x] Ruff, formatting, and mypy checks for the portability fix
- [x] workflow YAML parses successfully
- [x] git diff check
- [x] GitHub Actions macOS matrix job
- [x] GitHub Actions Windows matrix job
- [x] GitHub Actions Ubuntu full gate
- [x] CodeQL and dependency review

Refs #343