### PR TITLE
fix(release): bind Gate B soaks to public RC wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Gate B public-RC soak qualification** — add separate resumable `default-on` and `read-only-external` profiles bound to the installed `2.0.0rc1` wheel, explicit opt-out controls, full graph-manifest integrity, external-cache isolation, and a terminal-aware supervisor for restart-safe multi-day evidence collection.
 
+### Fixed
+
+- **Gate B RC artifact binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1` before starting either soak, while preserving the historical beta collector's default contract.
+
 ## [2.0.0-rc.1] - 2026-08-03
 
 ### Fixed

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -25,8 +25,9 @@ status categories, and timings.
    exact wheel.
 3. Freeze the committed qualification runner outside the repository, vault,
    working copies, cache roots, and evidence roots; record its commit and digest.
-4. Run the existing installed-wheel evidence gate once in each profile's
-   evidence directory so the resumable collector is bound to the candidate.
+4. Pass the verified wheel path and published SHA-256 to each profile. The
+   collector verifies the installed package RECORD, records the exact wheel
+   binding, and refuses to start the soak if either identity differs.
 5. Copy the private source vault once per profile. Never point either collector
    at the live vault.
 
@@ -39,6 +40,8 @@ Use the profile-specific paths in this template:
   --profile <default-on|read-only-external> \
   --output <evidence-root> \
   --candidate-python <candidate-python> \
+  --candidate-wheel <verified-public-wheel> \
+  --expected-wheel-sha256 <published-wheel-sha256> \
   --source-vault <source-copy> \
   --expected-source-realpath-file <private-realpath-file> \
   --working-root <empty-working-copy-path> \

--- a/scripts/beta_evidence/wheel.py
+++ b/scripts/beta_evidence/wheel.py
@@ -53,7 +53,12 @@ _PROCESS_ENV_ALLOWLIST = frozenset(
     }
 )
 
-_CANDIDATE_PROBE = f"""
+
+def _candidate_probe(expected_package: str) -> str:
+    """Build the installed-RECORD provenance probe for one package version."""
+    if re.fullmatch(r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?", expected_package) is None:
+        raise EvidenceError("candidate_version_invalid")
+    return f"""
 import base64
 import csv
 import hashlib
@@ -68,7 +73,7 @@ origin = Path(src.__file__).resolve()
 prefix = Path(sys.prefix).resolve()
 assert origin.is_relative_to(prefix)
 assert any(part in ("site-packages", "dist-packages") for part in origin.parts)
-assert version("matryca-plumber") == {_WHEEL_CANDIDATE!r}
+assert version("matryca-plumber") == {expected_package!r}
 installed = distribution("matryca-plumber")
 files = installed.files or ()
 record_candidates = sorted(
@@ -146,6 +151,9 @@ for entry in sorted(entries):
     digest.update(b"\\n")
 print(digest.hexdigest())
 """
+
+
+_CANDIDATE_PROBE = _candidate_probe(_WHEEL_CANDIDATE)
 
 
 class CommandRunner(Protocol):
@@ -369,12 +377,15 @@ def _run_wheel_probe(
         raise EvidenceError("probe_invalid") from exc
 
 
-def _verify_candidate_python(candidate_python: Path) -> str:
+def _verify_candidate_python(
+    candidate_python: Path, expected_package: str = _WHEEL_CANDIDATE
+) -> str:
     """Verify the installed candidate and return its sanitized provenance digest."""
 
+    probe = _candidate_probe(expected_package)
     try:
         completed = subprocess.run(
-            [str(candidate_python), "-c", _CANDIDATE_PROBE],
+            [str(candidate_python), "-c", probe],
             cwd=tempfile.gettempdir(),
             env={"PATH": os.environ.get("PATH", ""), "PYTHONNOUSERSITE": "1"},
             capture_output=True,

--- a/scripts/qualify_gate_b_soak.py
+++ b/scripts/qualify_gate_b_soak.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -14,15 +15,25 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from beta_evidence.core import EvidenceError, _atomic_write_json, _is_within
+from beta_evidence.core import (
+    EvidenceError,
+    GateRecord,
+    _atomic_write_json,
+    _candidate_wheel_binding_digest,
+    _canonical_hash,
+    _is_within,
+    _record_gate,
+)
 from beta_evidence.soak import collect_soak
-from beta_evidence.wheel import _copy_vault_without_cache
+from beta_evidence.wheel import _copy_vault_without_cache, _verify_candidate_python
 
 Profile = Literal["default-on", "read-only-external"]
 
 _PROFILE_FILE = "gate-b-profile.json"
 _PROFILE_SCHEMA_VERSION = 1
 _PROFILES: tuple[Profile, ...] = ("default-on", "read-only-external")
+_RC_PACKAGE = "2.0.0rc1"
+_SHA256 = re.compile(r"[0-9a-f]{64}")
 
 _DEFAULT_ON_PROBE = r"""
 import hashlib
@@ -364,6 +375,49 @@ def _bind_manifest(output: Path, profile: Profile, cache_root: Path, working: Pa
         _atomic_write_json(_profile_path(output), payload)
 
 
+def _bind_public_rc_wheel(
+    output: Path,
+    *,
+    candidate_python: Path,
+    candidate_wheel: Path,
+    expected_wheel_sha256: str,
+) -> str:
+    """Record an exact public-RC wheel binding for the installed candidate."""
+    if _SHA256.fullmatch(expected_wheel_sha256) is None:
+        raise EvidenceError("wheel_sha256_invalid")
+    try:
+        wheel = candidate_wheel.expanduser().resolve(strict=True)
+        python = candidate_python.expanduser().absolute()
+        python.parent.resolve(strict=True)
+    except OSError as exc:
+        raise EvidenceError("candidate_artifact_invalid") from exc
+    if not wheel.is_file() or not python.is_file() or not os.access(python, os.X_OK):
+        raise EvidenceError("candidate_artifact_invalid")
+    wheel_sha256 = _sha256(wheel.read_bytes())
+    if wheel_sha256 != expected_wheel_sha256:
+        raise EvidenceError("wheel_sha256_mismatch")
+    provenance = _verify_candidate_python(python, _RC_PACKAGE)
+    binding = _candidate_wheel_binding_digest(wheel_sha256, provenance)
+    input_hash = _canonical_hash({"candidate_package": _RC_PACKAGE, "wheel_sha256": wheel_sha256})
+    _record_gate(
+        output,
+        GateRecord(
+            "wheel",
+            input_hash,
+            "PASS",
+            {
+                "candidate_package": _RC_PACKAGE,
+                "wheel_sha256": wheel_sha256,
+                "candidate_provenance_digest": provenance,
+                "candidate_wheel_binding_digest": binding,
+                "installed_record_verified": True,
+            },
+        ),
+        metadata={"candidate_package": _RC_PACKAGE},
+    )
+    return provenance
+
+
 def _safe_environment(
     graph: Path, cache_root: Path, profile: Profile, cycle: int
 ) -> dict[str, str]:
@@ -443,6 +497,8 @@ def run_gate_b_soak(
     profile: Profile,
     output: Path,
     candidate_python: Path,
+    candidate_wheel: Path,
+    expected_wheel_sha256: str,
     source_vault: Path,
     expected_source_file: Path,
     working_root: Path,
@@ -463,7 +519,25 @@ def run_gate_b_soak(
         output=resolved_output,
         repo=repo,
     )
+    resolved_wheel = candidate_wheel.expanduser().resolve(strict=True)
+    if any(
+        _is_within(resolved_wheel, protected)
+        for protected in (source, work, resolved_output, cache, repo)
+    ):
+        raise EvidenceError("candidate_artifact_unsafe")
+    candidate_provenance = _bind_public_rc_wheel(
+        resolved_output,
+        candidate_python=candidate_python,
+        candidate_wheel=resolved_wheel,
+        expected_wheel_sha256=expected_wheel_sha256,
+    )
     _load_or_create_profile(resolved_output, profile, cache)
+
+    def candidate_verifier(python: Path) -> str:
+        observed = _verify_candidate_python(python, _RC_PACKAGE)
+        if observed != candidate_provenance:
+            raise EvidenceError("soak_candidate_provenance_mismatch")
+        return observed
 
     def copier(copy_source: Path, destination: Path) -> None:
         _copy_vault_without_cache(copy_source, destination)
@@ -491,6 +565,7 @@ def run_gate_b_soak(
         max_cycles=max_cycles,
         interval_seconds=interval_seconds,
         page_parse_timeout_seconds=page_parse_timeout_seconds,
+        candidate_verifier=candidate_verifier,
         probe_runner=probe_runner,
         copier=copier,
     )
@@ -501,6 +576,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--profile", choices=_PROFILES, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--candidate-python", type=Path, required=True)
+    parser.add_argument("--candidate-wheel", type=Path, required=True)
+    parser.add_argument("--expected-wheel-sha256", required=True)
     parser.add_argument("--source-vault", type=Path, required=True)
     parser.add_argument("--expected-source-realpath-file", type=Path, required=True)
     parser.add_argument("--working-root", type=Path, required=True)
@@ -519,6 +596,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             profile=cast(Profile, args.profile),
             output=args.output,
             candidate_python=args.candidate_python,
+            candidate_wheel=args.candidate_wheel,
+            expected_wheel_sha256=args.expected_wheel_sha256,
             source_vault=args.source_vault,
             expected_source_file=args.expected_source_realpath_file,
             working_root=args.working_root,

--- a/tests/test_beta_readiness_evidence.py
+++ b/tests/test_beta_readiness_evidence.py
@@ -686,6 +686,15 @@ def test_soak_rejects_non_executable_candidate_python(tmp_path: Path) -> None:
         soak_module._resolve_candidate_python(candidate_python)
 
 
+def test_candidate_provenance_probe_accepts_explicit_rc_version() -> None:
+    wheel_module = importlib.import_module("beta_evidence.wheel")
+    probe = wheel_module._candidate_probe("2.0.0rc1")
+    assert "version(\"matryca-plumber\") == '2.0.0rc1'" in probe
+    assert wheel_module._candidate_probe("2.0.0b1") == wheel_module._CANDIDATE_PROBE
+    with pytest.raises(wheel_module.EvidenceError, match="candidate_version_invalid"):
+        wheel_module._candidate_probe("v2.0.0-rc.1")
+
+
 def test_wheel_records_only_sanitized_pass_and_keeps_source_untouched(tmp_path: Path) -> None:
     module = _module()
     source, fingerprint, wheel = _wheel_source(tmp_path)

--- a/tests/test_gate_b_soak.py
+++ b/tests/test_gate_b_soak.py
@@ -162,6 +162,52 @@ def test_invalid_probe_payload_is_rejected() -> None:
         module._validate_payload(payload)
 
 
+def test_public_rc_wheel_binding_records_exact_installed_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    wheel = tmp_path / "matryca_plumber-2.0.0rc1-py3-none-any.whl"
+    wheel.write_bytes(b"public rc wheel")
+    expected_sha256 = module._sha256(wheel.read_bytes())
+    provenance = "b" * 64
+    observed: list[tuple[Path, str]] = []
+
+    def verifier(python: Path, package: str) -> str:
+        observed.append((python, package))
+        return provenance
+
+    monkeypatch.setattr(module, "_verify_candidate_python", verifier)
+    assert (
+        module._bind_public_rc_wheel(
+            output,
+            candidate_python=Path(sys.executable),
+            candidate_wheel=wheel,
+            expected_wheel_sha256=expected_sha256,
+        )
+        == provenance
+    )
+    assert observed == [(Path(sys.executable).absolute(), "2.0.0rc1")]
+    checkpoint = json.loads((output / "checkpoint.json").read_text(encoding="utf-8"))
+    details = checkpoint["gates"]["wheel"]["details"]
+    assert details["wheel_sha256"] == expected_sha256
+    assert details["candidate_provenance_digest"] == provenance
+    assert details["installed_record_verified"] is True
+
+
+def test_public_rc_wheel_binding_rejects_digest_mismatch(tmp_path: Path) -> None:
+    module = _module()
+    wheel = tmp_path / "candidate.whl"
+    wheel.write_bytes(b"wrong artifact")
+    with pytest.raises(module.EvidenceError, match="wheel_sha256_mismatch"):
+        module._bind_public_rc_wheel(
+            tmp_path / "evidence",
+            candidate_python=Path(sys.executable),
+            candidate_wheel=wheel,
+            expected_wheel_sha256="a" * 64,
+        )
+
+
 def test_main_reports_privacy_safe_failure(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -174,6 +220,10 @@ def test_main_reports_privacy_safe_failure(
             str(tmp_path / "evidence"),
             "--candidate-python",
             str(tmp_path / "missing-python"),
+            "--candidate-wheel",
+            str(tmp_path / "missing.whl"),
+            "--expected-wheel-sha256",
+            "a" * 64,
             "--source-vault",
             str(tmp_path / "missing-source"),
             "--expected-source-realpath-file",


### PR DESCRIPTION
## Summary
- fail closed unless each Gate B soak is bound to the exact public 2.0.0rc1 wheel and published SHA-256
- verify the installed package RECORD and preserve the historical beta collector default
- update the Gate B runbook, changelog, and regression coverage

## Test plan
- [x] 1,590 tests passed, 5 skipped
- [x] exact-worktree coverage: 83% (minimum 70%)
- [x] focused Gate B and evidence suite: 76 passed
- [x] Ruff format and lint checks
- [x] strict mypy across 378 source files
- [x] documentation, agent-coherence, and sandbox-read checks
- [x] end-to-end binding against the public 2.0.0rc1 wheel and published SHA-256