### PR TITLE
fix(release): record Gate B profile probe duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- **Gate B RC artifact binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1` before starting either soak, while preserving the historical beta collector's default contract.
+- **Gate B RC artifact and timing binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1`, and include measured probe time so valid profile probes advance the resumable soak instead of retrying as `probe_invalid`, while preserving the historical beta collector's default contract.
 
 ## [2.0.0-rc.1] - 2026-08-03
 

--- a/scripts/qualify_gate_b_soak.py
+++ b/scripts/qualify_gate_b_soak.py
@@ -11,6 +11,7 @@ import re
 import stat
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -461,11 +462,13 @@ def _run_profile_probe(
     cycle: int,
     *,
     command_runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    clock: Callable[[], float] = time.monotonic,
 ) -> dict[str, object]:
     working = working.resolve(strict=True)
     cache_root = cache_root.resolve(strict=False)
     before = _graph_manifest_digest(working)
     code = _DEFAULT_ON_PROBE if profile == "default-on" else _READ_ONLY_PROBE
+    started = clock()
     try:
         completed = command_runner(
             [str(candidate_python), "-c", code],
@@ -480,6 +483,7 @@ def _run_profile_probe(
         raise EvidenceError("probe_timeout") from exc
     except OSError as exc:
         raise EvidenceError("probe_launch_failed") from exc
+    elapsed_ms = max(0.0, (clock() - started) * 1_000)
     if completed.returncode != 0:
         raise EvidenceError("probe_flag_on_failed")
     try:
@@ -487,6 +491,7 @@ def _run_profile_probe(
     except json.JSONDecodeError as exc:
         raise EvidenceError("probe_payload_invalid") from exc
     validated = _validate_payload(payload)
+    validated["elapsed_ms"] = elapsed_ms
     if _graph_manifest_digest(working) != before:
         raise EvidenceError("working_copy_changed")
     return validated

--- a/tests/test_gate_b_soak.py
+++ b/tests/test_gate_b_soak.py
@@ -99,6 +99,7 @@ def test_profile_probe_uses_unset_default_and_preserves_graph(
     module = _module()
     graph = _graph(tmp_path)
     observed: list[dict[str, str]] = []
+    clock_values = iter((10.0, 10.125))
 
     def command(_command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         environment = kwargs["env"]
@@ -114,9 +115,13 @@ def test_profile_probe_uses_unset_default_and_preserves_graph(
         30,
         0,
         command_runner=command,
+        clock=lambda: next(clock_values),
     )
 
     assert result["synthetic_crud"] == crud
+    assert result["elapsed_ms"] == 125.0
+    soak_module = importlib.import_module("beta_evidence.soak")
+    assert soak_module._validate_probe_payload(result)["elapsed_ms"] == 125.0
     assert "MATRYCA_SHADOW_DB_ENABLED" not in observed[0]
     assert (observed[0].get("MATRYCA_READ_ONLY") == "true") is read_only
 


### PR DESCRIPTION
## Summary
- include measured `elapsed_ms` in Gate B profile probe payloads
- allow valid default-on and read-only-external probes to advance the generic resumable soak
- add adapter-to-collector regression coverage and update the changelog

## Test plan
- [x] 1,590 tests passed, 5 skipped
- [x] total coverage: 83.16%
- [x] Gate B and evidence suite: 76 passed
- [x] full Ruff format and lint checks
- [x] full mypy across 372 source files
- [x] documentation knowledge/inventory and agent-coherence checks
- [x] real installed-wheel default-on probe passed through corrected adapter
- [x] real installed-wheel read-only-external probe passed through corrected adapter