### PR TITLE
docs(release): record corrected Gate B RC soak

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,13 @@ Matryca Plumber is local data infrastructure for headless AI agents working with
 
 Architecture debate and RFC: [Discussion #19 — Core Architecture Evolution](https://github.com/MarcoPorcellato/matryca-plumber/discussions/19).
 
-*Status as of **2026-08-03** — `v2.0.0-beta.1` is the current public prerelease; its exact-wheel 72-hour qualification has passed. The unreleased RC-target source now contains the default-on external Shadow/read-only architecture and retrieval hardening described below. Issue numbers link to GitHub; implementation does not imply RC or stable release qualification.*
+*Status as of **2026-08-05** — `v2.0.0-beta.1` is the historical public
+prerelease; `v2.0.0rc1` exact-candidate public qualification is active. The
+`v2.0.0rc1` Gate B soak is currently `RUNNING` and has not yet reached terminal
+`PASS`; implementation progress does not imply stable release qualification.
+The published `2.0.0rc1` line now contains the default-on external
+Shadow/read-only architecture and retrieval hardening described below. Issue numbers
+link to GitHub.*
 
 ---
 
@@ -42,10 +48,11 @@ The exact public-beta wheel has passed its fresh installed-wheel gate and its
 restart-resilient 72-hour soak. The sanitized
 [`terminal evidence record`](docs/quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md)
 records 415 completed cycles, 259,225.349 observed seconds, source Markdown
-unchanged during the source-to-working-copy check, and a terminal `PASS`; this closes only Gate A's exact-beta
-real-vault row.
+unchanged during the source-to-working-copy check, and a terminal `PASS`; this closes only
+Gate A's exact-beta real-vault row. The currently active `2.0.0rc1` Gate B run
+remains `RUNNING` and is tracked as an independent stable-preparation checkpoint.
 
-The unreleased RC-target source has merged Strict Read Only enforcement,
+The published `2.0.0rc1` candidate line has merged Strict Read Only enforcement,
 external per-user Shadow cache routing, default-on Shadow with explicit opt-out,
 the read-only observer daemon, deterministic graph-immutability qualification,
 and the bounded 8,192-entry BM25 result cache (#354–#366). These source changes

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -4,6 +4,67 @@ This runbook starts the two independent, fail-closed soak profiles required by
 the `v2.0.0` Gate B decision. Both profiles run against the installed public
 `matryca-plumber==2.0.0rc1` wheel, never a source checkout.
 
+## Recorded checkpoint snapshot (public candidate `2.0.0rc1`)
+
+The recorded checkpoint for stable-promotion evidence is `RUNNING`
+(no terminal PASS/FAIL yet):
+
+- `checkpoint_recorded_at`: `2026-08-04T23:16:10Z`
+- `attempt_started_at`: `2026-08-04T23:06:09Z` (`2026-08-05 01:06:09`
+  Europe/Rome)
+- `status`: `RUNNING`
+
+| Field | Value |
+| --- | --- |
+| Candidate artifact | `matryca-plumber==2.0.0rc1` |
+| Public wheel SHA-256 | `f9c60cc89049b9524ca9f9346a053bac3c7aba6f2186d9a31a3993bd7a9253cd` |
+| Runner source | `main@1e8805ec99c6471549ecf36e4a261a31013a0f6f` |
+| Qualifier SHA-256 | `b4cee6a2b6c8a8fbd8bb890cf583b7d126f2e40bda8b55cb7a0c499c8490dbe6` |
+| Supervisor SHA-256 | `bfcae04483a5003df8e83fb52ece42c0c933d7c708c9e73d55733309736e7445` |
+| Profiles | `default-on`, `read-only-external` |
+| target_duration_seconds | `259200` |
+| max_cycles | `1000` |
+| interval_seconds | `600` |
+| page_parse_timeout_seconds | `15` |
+| exact installed-wheel/RECORD gate | `PASS` |
+| earliest uninterrupted completion estimate | 2026-08-08 01:06 (Europe/Rome) |
+
+### Recorded checkpoint history and recovery proof
+
+- An earlier attempt sequence accumulated `108` attempts **per profile** and produced
+  zero completed cycles, zero valid elapsed seconds, and `probe_invalid` outcomes.
+  The profile adapter omitted required `elapsed_ms` from otherwise successful probe
+  payloads, so the generic collector rejected each as `probe_invalid`; this evidence
+  is explicitly excluded from qualification and not reused.
+- PR #382 corrected that probe path by adding measured `elapsed_ms` to profile probe
+  payloads and adding adapter-to-collector regression coverage.
+- A corrected preflight launch then failed closed as `working_copy_exists` because
+  previous working/cache roots remained after creating fresh evidence directories.
+  The failed preflight bundle, old roots, and logs were archived and excluded from
+  the active checkpoint.
+- A fully fresh attempt began at `2026-08-04T23:06:09Z` with clean working/cache/
+  evidence roots and the same public wheel.
+- At the first valid checkpoint both profiles reached cycle 1 with:
+  - `cycle 1` completed
+  - two PASS phase attempts each (ON/OFF)
+  - non-empty chained attempt cursor
+  - no stderr errors
+  - elapsed: `440.1835287499998s` (`default-on`), `440.2918676670015s`
+    (`read-only-external`)
+- A controlled service stop/reload proof was then executed. While stopped, state
+  files were byte-identical and no elapsed seconds were credited. Both LaunchAgents
+  reloaded and resumed, advanced to cycle 2, and retained `two completed cycles`
+  with `four PASS phase attempts` per profile at recorded checkpoint
+  `2026-08-04T23:16:10Z`.
+  Post-resume elapsed values became: `448.1676894170014s` (`default-on`) and
+  `447.76504575099534s` (`read-only-external`).
+- At the recorded checkpoint, the corrected fresh attempt had controlled service stop/reload proof;
+  it has not yet been host-reboot-tested. Prior deployment behavior supports
+  LaunchAgent restart resilience, but host-restart behavior has not yet been
+  demonstrated for this attempt.
+- A separate six-hour supervisory health check observes evidence and service health,
+  reporting material changes, interventions, failures, and terminal completion.
+
 ## Profiles
 
 | Profile | Shadow flag | Read Only | Graph activity | Required proof |

--- a/docs/quality/issue-bodies/v2-rc-stable-readiness.md
+++ b/docs/quality/issue-bodies/v2-rc-stable-readiness.md
@@ -21,13 +21,34 @@ default-on release candidate requires both re-qualification of the exact public
 `matryca-plumber==2.0.0b1` predecessor and qualification of the exact new
 candidate. Evidence from one artifact never transfers silently to the other.
 
-As of 2026-08-03, the unreleased RC-target source contains the Strict Read Only
+As of 2026-08-05, the published `2.0.0rc1` candidate line contains the Strict Read Only
 policy and guarded runtime, external per-user Shadow routing, default-on Shadow
 with explicit opt-out, read-only observer daemon, deterministic graph
 immutability gate, bounded 8,192-entry BM25 result cache, and Linux/macOS/Windows
 Shadow contract CI merged through #376. Gate A is qualified on the exact merged
-commit recorded below. This is not an RC publication or a stable release
-decision.
+commit recorded below. This is not a stable release decision.
+
+### Recorded exact-candidate Gate B context
+
+The exact `2.0.0rc1` publication is currently in a recorded Gate B checkpoint for
+stable readiness and was non-terminal at the recorded checkpoint (neither PASS
+nor FAIL).
+
+- Candidate: `matryca-plumber==2.0.0rc1`
+- Public wheel SHA-256:
+  `f9c60cc89049b9524ca9f9346a053bac3c7aba6f2186d9a31a3993bd7a9253cd`
+- Runner source: `main@1e8805ec99c6471549ecf36e4a261a31013a0f6f`
+- Qualifier SHA-256:
+  `b4cee6a2b6c8a8fbd8bb890cf583b7d126f2e40bda8b55cb7a0c499c8490dbe6`
+- Supervisor SHA-256:
+  `bfcae04483a5003df8e83fb52ece42c0c933d7c708c9e73d55733309736e7445`
+- Fresh attempt start: `2026-08-04T23:06:09Z`
+- Profiles: `default-on` and `read-only-external`
+- Recorded status (`2026-08-04T23:16:10Z`): `RUNNING` after one
+  controlled stop/reload, two completed cycles, and four PASS phase attempts per
+  profile.
+- Exclusion rule: 108 historical attempts are excluded from qualification per profile
+  because they were `probe_invalid` on both profiles and lacked required `elapsed_ms`.
 
 ## Proposed Architectural Solution
 
@@ -119,9 +140,9 @@ child-process diagnostic is retained in the committed record.
 
 | Requirement | Evidence required | Status |
 |-------------|-------------------|--------|
-| RC observation | At least 7 days of RC availability and maintainer operation, with no unresolved P0/P1 regression | [ ] |
-| Default-on soak | At least 72 hours and preferably 7 days with the flag unset, plus an explicit opt-out control run | [ ] |
-| Read Only external-cache soak | Default-on Shadow reaches and retains `READY` with `MATRYCA_READ_ONLY=true`; all writes remain outside the graph and Markdown fingerprints remain unchanged | [ ] |
+| RC observation | At least 7 days of RC availability and maintainer operation, with no unresolved P0/P1 regression | [ ] — under observation, not yet complete |
+| Default-on soak | At least 72 hours and preferably 7 days with the flag unset, plus an explicit opt-out control run | [ ] — active `RUNNING` checkpoint since `2026-08-04T23:06:09Z`; `2.0.0rc1` candidate running |
+| Read Only external-cache soak | Default-on Shadow reaches and retains `READY` with `MATRYCA_READ_ONLY=true`; all writes remain outside the graph and Markdown fingerprints remain unchanged | [ ] — active `RUNNING` checkpoint since `2026-08-04T23:06:09Z`; both required profiles running |
 | Upgrade matrix | Stable `1.14.5`, alpha `2.0.0a5`, beta `2.0.0b1`, and RC upgrade paths pass from published artifacts | [ ] |
 | Cross-platform gate | Linux, macOS, and Windows CI or installed-runtime evidence passes for the supported Shadow read contract | [ ] |
 | Performance disposition | FTS and subtree measurements have explicit pass thresholds or a documented non-blocking disposition; fallback remains usable | [ ] |
@@ -132,14 +153,19 @@ child-process diagnostic is retained in the committed record.
 
 ### Promotion sequence
 
-1. A terminal exact-beta soak `PASS` closes only the Gate A real-vault row; a
+1. A terminal exact-beta soak `PASS` closes only the Gate A exact-beta real-vault row; a
    `FAIL` blocks promotion and requires disposition.
 2. Complete the other Gate A rows on one frozen candidate commit, then build and
    verify the candidate artifacts.
 3. Publish `v2.0.0-rc.1` only after Gate A is fully checked.
-4. Run Gate B against the installed public RC, not a source checkout or beta
+4. Run Gate B runbook (public `2.0.0rc1`) against the installed public RC, not a source checkout or beta
    artifact.
 5. Publish stable `v2.0.0` only after Gate B is fully checked.
+
+The active Gate B checkpoint remains non-terminal. A stable release claim is not
+made from `RUNNING`. A terminal PASS can close only the two Gate B soak rows after
+integrity and exact artifact-binding reviews; all other Gate B rows remain independently
+blocking for stable readiness.
 
 ### Non-negotiable runtime invariants
 

--- a/docs/roadmaps/ROADMAP_V2_PREPARATION.md
+++ b/docs/roadmaps/ROADMAP_V2_PREPARATION.md
@@ -10,7 +10,10 @@ Matryca Plumber **v2.0.0** adds a daemon-owned **Shadow DB** (`shadow.sqlite`) f
 
 ---
 
-## Where we are today (2026-08-02)
+## Where we are today (2026-08-05)
+
+`v2.0.0rc1` Gate B public-RC qualification is running from the corrected
+checkpoint and remains `RUNNING`; no terminal PASS has been reached yet.
 
 | Layer | Shipped | In tree (not fully operational) | Not wired yet |
 |-------|---------|----------------------------------|---------------|
@@ -19,7 +22,7 @@ Matryca Plumber **v2.0.0** adds a daemon-owned **Shadow DB** (`shadow.sqlite`) f
 | **Shadow query** | `search_blocks_fts` + FTS5 dispatch ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183), [#250](https://github.com/MarcoPorcellato/matryca-plumber/issues/250)) | — | — |
 | **Memory algorithms** | — | [`src/memory/decay.py`](../../src/memory/decay.py) | recall, consolidate, MCP `recall` |
 | **Repository port** | `GraphReadPort`, `MarkdownGraphRepository`, `ShadowGraphRepository`, subtree CTE routing ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17), [#253](https://github.com/MarcoPorcellato/matryca-plumber/issues/253), [#255](https://github.com/MarcoPorcellato/matryca-plumber/issues/255)) | — | — |
-| **Read path** | Published beta: `master_catalog.json` + in-memory BM25 by default; opt-in graph-local Shadow FTS5/CTE ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) | Unreleased RC-target source: default-on external Shadow, explicit false opt-out, Strict Read Only observer, mandatory Markdown/BM25 fallback, bounded 8,192-entry BM25 result cache (#354–#366) | exact-candidate and published-RC qualification |
+| **Read path** | Published beta: `master_catalog.json` + in-memory BM25 by default; opt-in graph-local Shadow FTS5/CTE ([#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)) | Published `2.0.0rc1` line: default-on external Shadow, explicit false opt-out, Strict Read Only observer, mandatory Markdown/BM25 fallback, bounded 8,192-entry BM25 result cache (#354–#366) | exact-beta predecessor qualified; exact RC stable-promotion qualification in progress |
 | **Write path (OG)** | OCC + `.md` + `page_rmw_lock` | — | — |
 | **Write path (Logseq DB)** | — | — | official CLI/API bridge ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)) |
 | **Operator health** | Sovereign UI `/api/state.shadow_db` ([#185](https://github.com/MarcoPorcellato/matryca-plumber/issues/185)) | — | — |
@@ -117,14 +120,14 @@ Sovereign UI: `GET /api/state` → `shadow_db` row (`state`, `last_full_sync_at`
 |-------|-----------------|-------------------|
 | **v2.0.0-alpha.5** | Seven-axis hardening baseline | Pin `@2.0.0-alpha.5`; shadow remains opt-in | **published** 2026-07-19 |
 | **v2.0.0-beta.1** | First public Shadow read-path beta | Default-off flag, Markdown system of record, fallback mandatory; Phase 4 excluded | **published** 2026-07-30 |
-| **v2.0.0-rc.1** | External Shadow cache works under Read Only; health in UI; exact public-beta predecessor and exact RC candidate qualified | **Gate A qualified**; MCP read traffic prefers shadow; explicit `false` remains the opt-out; fallback remains mandatory; public artifact starts Gate B |
+| **v2.0.0-rc.1** | External Shadow cache works under Read Only; health in UI; exact public-beta predecessor and exact RC stable-promotion qualification | **Gate A qualified**; `2.0.0rc1` Gate B remains `RUNNING` |
 | **v2.0.0-stable** | RC observation complete; deprecation notice for in-memory BM25 default | `llms.txt` + `SYSTEM_PROMPT.md` migration per [`llm-os-instructions.md`](../openspec/llm-os-instructions.md) § v2.0 trigger |
 
 **Beta decision record:** [`docs/quality/issue-bodies/v2-beta-readiness.md`](../quality/issue-bodies/v2-beta-readiness.md). Bounded-parse containment, the sanitized soak, installed-wheel upgrade/recovery, full CI, and final code audit all passed with the recorded evidence boundary. Re-qualification against the released source remains required before default-on.
 
 **RC/stable decision record:** [`docs/quality/issue-bodies/v2-rc-stable-readiness.md`](../quality/issue-bodies/v2-rc-stable-readiness.md), tracked by [#343](https://github.com/MarcoPorcellato/matryca-plumber/issues/343). `v2.0.0` is scoped to the stable Shadow read path. Phase 4 biological memory, Logseq DB Safe-Sync writes, content-aware Tana merge, and independent DX tracks move to `v2.1.0` or later.
 
-**Implemented RC storage direction:** [`v2-external-shadow-cache-read-only.md`](../quality/issue-bodies/v2-external-shadow-cache-read-only.md) defines Read Only as a graph-boundary guarantee while permitting a validated external derived cache. The implementation, deterministic source-tree E2E gate, and exact-candidate Gate A qualification are complete; published-RC Gate B remains the stable-release blocker.
+**Implemented RC storage direction:** [`v2-external-shadow-cache-read-only.md`](../quality/issue-bodies/v2-external-shadow-cache-read-only.md) defines Read Only as a graph-boundary guarantee while permitting a validated external derived cache. The implementation, deterministic source-tree E2E gate, and exact-candidate Gate A qualification are complete; the published `2.0.0rc1` Gate B checkpoint remains the stable-release blocker.
 
 **Exact-beta re-qualification:** the public `2.0.0b1` wheel passed its fresh
 installed-wheel gate and completed its restart-resilient 72-hour soak with a
@@ -132,7 +135,8 @@ terminal `PASS` on 2026-08-03. The sanitized
 [`terminal evidence record`](../quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md)
 records 415 completed cycles, 259,225.349 observed seconds, source Markdown
 unchanged during the source-to-working-copy check, and no skipped subtree or synthetic CRUD checks. It closes only the
-exact-beta real-vault row; the remaining Gate A rows still block RC publication.
+exact-beta real-vault row; the active `2.0.0rc1` Gate B checkpoint remains `RUNNING`
+and independent.
 
 ---
 

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -1,7 +1,7 @@
 # v2.0 — Shadow DB read path (checklist)
 
 **Detailed index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) — visitor SSOT for all five v2 phases  
-**Status:** Phase 2 **operational** (bootstrap, reconciliation, runtime gating — [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248)). Phase 3 **read routing shipped** (opt-in flag, FTS5/BM25 + subtree CTE + Sovereign UI health — [#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)). **Published beta:** `v2.0.0-beta.1` / wheel version `2.0.0b1` remains default-off and graph-local. **Unreleased RC-target source:** external per-user cache, default-on Shadow with explicit false opt-out, Strict Read Only observer, deterministic graph-immutability gate, and mandatory Markdown/BM25 fallback (#354–#366).
+**Status:** Phase 2 **operational** (bootstrap, reconciliation, runtime gating — [#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248)). Phase 3 **read routing shipped** (opt-in flag, FTS5/BM25 + subtree CTE + Sovereign UI health — [#177](https://github.com/MarcoPorcellato/matryca-plumber/issues/177)). **Published beta:** `v2.0.0-beta.1` / wheel version `2.0.0b1` remains default-off and graph-local. **Published `2.0.0rc1` line:** external per-user cache, default-on Shadow with explicit false opt-out, Strict Read Only observer, deterministic graph-immutability gate, and mandatory Markdown/BM25 fallback (#354–#366). The `2.0.0rc1` Gate B checkpoint is active and `RUNNING`.
 **Parent epic:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
 **Trackable issue:** [#24 — Shadow DB read path](https://github.com/MarcoPorcellato/matryca-plumber/issues/24)  
 **Prerequisite:** [#17 — GraphRepository abstraction](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) · Phase 2–3 tracking in [`v2_preparation_blueprints.md`](../../v2_preparation_blueprints.md)  
@@ -37,10 +37,10 @@ Canonical DDL: [`src/shadow/schema.py`](../../src/shadow/schema.py)
 | **Memory graph** | `memory_nodes`, `memory_edges`, `memory_pending_edges`, `memory_episodes`, `memory_episode_entities`, `memory_procedures`, `memory_snapshots` | Nacre-inspired biological memory — see [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](ROADMAP_V2_BIOLOGICAL_MEMORY.md) |
 
 Published beta path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite`
-(`shadow_db_path` / `open_shadow_db`). The unreleased RC-target source uses a canonical per-user external cache,
-isolated by versioned graph identity, with `MATRYCA_CACHE_PATH` as an absolute external
-root override. The beta database is rebuilt externally, never moved or mutated in
-place under Read Only.
+(`shadow_db_path` / `open_shadow_db`). The published `2.0.0rc1` line uses a
+canonical per-user external cache, isolated by versioned graph identity, with
+`MATRYCA_CACHE_PATH` as an absolute external root override. The derived Shadow
+database is rebuilt externally and never moved or mutated in place under Read Only.
 
 ---
 
@@ -82,7 +82,7 @@ not replace the unchecked installed-wheel qualification row.
 | v2.0.0-alpha.1 | Axis 1 hardening (#262, #264) | **superseded** |
 | v2.0.0-alpha.5 | Seven-axis hardening campaign close | **published** |
 | v2.0.0-beta.1 | First public Shadow read-path beta; opt-in flag remains default-off | **published** |
-| v2.0.0-rc.1 | External Shadow cache works under Read Only; MCP reads default to Shadow after qualification | planned |
+| v2.0.0-rc.1 | External Shadow cache works under Read Only; MCP reads default to Shadow after qualification | in progress (`RUNNING` Gate B checkpoint) |
 | v2.0.0-stable | Deprecate pure in-memory BM25 as default discovery path after RC observation | planned |
 
 The beta excludes Phase 4 biological memory and Logseq DB Safe-Sync. Its completed gates and accepted evidence boundary are recorded in [`docs/quality/issue-bodies/v2-beta-readiness.md`](../quality/issue-bodies/v2-beta-readiness.md).
@@ -91,8 +91,8 @@ The exact public-beta wheel passed its fresh installed-wheel gate on 2026-07-30
 and completed the required 72-hour real-vault qualification with a terminal
 `PASS` on 2026-08-03. See the sanitized
 [`terminal evidence record`](../quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md);
-it closes only the exact-beta real-vault readiness row, while the remaining
-Gate A requirements remain authoritative before RC publication.
+it closes only the exact-beta real-vault readiness row. The active `2.0.0rc1`
+Gate B checkpoint is `RUNNING` and separate from this historical PASS.
 
 ---
 


### PR DESCRIPTION
## Summary
- record the corrected exact-wheel `2.0.0rc1` Gate B checkpoint and excluded invalid attempts
- document controlled stop/reload, no-downtime-credit, and resilient supervisory behavior
- align the release roadmaps and stable-readiness matrix while keeping `RUNNING` distinct from terminal `PASS`

## Validation
- [x] documentation bundle and inventory checks
- [x] legacy documentation audit
- [x] agent-coherence check
- [x] public-metrics and privacy scan
- [x] `git diff --check`
- [x] documentation-only scope verified

## Release status
The soak remains non-terminal. Stable `v2.0.0` remains blocked until both profiles reach validated terminal `PASS` and all other Gate B rows are complete.
