### PR TITLE
docs: standardize repository documentation in English

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,10 @@ GitHub Actions on pushes and pull requests to **`main`** runs **`make ci`** (see
 
 Never commit secrets (no `.env`, tokens, or private graph paths in git).
 
+### Documentation language
+
+Write repository documentation and GitHub-facing prose in English. Non-English text is allowed only when it is an explicit localization or parser fixture, or when a source quotation is accompanied by an English translation.
+
 ### Agent-facing documentation (`llms.txt`)
 
 When you add, rename, or remove **CLI subcommands or flags** that external agents rely on:

--- a/docs/quality/V2_SHADOW_DB_VISION_2026-07-25.md
+++ b/docs/quality/V2_SHADOW_DB_VISION_2026-07-25.md
@@ -1,63 +1,63 @@
-# Cosa ottiene Matryca Plumber con la v2.0 e lo Shadow DB
+# What Matryca Plumber Gains from v2.0 and the Shadow DB
 
-_Nota di lavoro — 2026-07-25, mentre gira il soak da 24h+ (r8) prima del rilascio beta._
+_Working note — 2026-07-25, written while the 24h+ soak (r8) was running before the beta release._
 
-## La tua traccia, verificata
+## The original vision, verified
 
-> "15:07 è partito il SOAK di 24 ore per testare tutto quello che ho costruito nei giorni scorsi per la v2.0 di questo Matryca Plumber, quindi manca veramente poco al salto quantico della v2.0 in cui ci sarà uno shadow DB al supporto e per velocizzare tutte le operazioni di lettura dal database di Logseq, che cambierà moltissimo la potenza di questo sistema e lo renderà adatto al funzionamento come memoria principale super granulare e potente per gli agenti di intelligenza artificiale, con la granularità dei blocchi di Logseq al contrario delle pagine monolitiche di Obsidian e gli altri."
+> "At 15:07, the 24-hour SOAK started to test everything I built over the past few days for Matryca Plumber v2.0. We are therefore very close to the v2.0 quantum leap, which will introduce a supporting Shadow DB and accelerate every read operation from the Logseq database. This will greatly increase the system's capabilities and make it suitable as a highly granular, powerful primary memory for artificial intelligence agents, with Logseq's block-level granularity instead of the monolithic pages used by Obsidian and others."
 
-Ogni affermazione qui è **supportata** da quello che c'è nel codice e nella roadmap, con qualche precisazione tecnica che vale la pena aggiungere per raccontarla bene.
-
----
-
-## 1. Cos'è davvero lo Shadow DB (i fatti)
-
-Non è un nuovo database che sostituisce Logseq: è una **cache di lettura**, gestita interamente dal daemon di Matryca Plumber, che affianca — senza mai sostituire — i file Markdown.
-
-- **Sorgente di verità**: resta sempre il Markdown su disco. Logseq OG continua a scrivere `.md`, Matryca Plumber continua a scrivere `.md` con OCC-safety (`st_mtime` + page lock, la stessa garanzia anti-corruzione che avete già in v1).
-- **Shadow DB** (`shadow.sqlite`, dentro `.matryca_semantic_cache/`) è un **mirror sincronizzato** di quel Markdown, pensato per **letture** rapide: FTS5 (full-text search nativo di SQLite) per la ricerca testuale, e **CTE ricorsive** (Common Table Expressions) per leggere interi sottoalberi di blocchi con una singola query invece di ricostruirli in memoria ogni volta.
-- **Sostituisce** il vecchio percorso v1.9.5: `master_catalog.json` letto interamente in RAM + BM25 calcolato in-process ad ogni ricerca. Quel percorso resta come **fallback automatico** — se lo Shadow DB non è "ready" (es. durante un rebuild, o un mismatch di schema), il sistema torna a leggere da Markdown/BM25 senza che l'utente se ne accorga.
-- **È opt-in**: si attiva con `MATRYCA_SHADOW_DB_ENABLED=true`, default off. Chi non lo attiva ha esattamente il comportamento di oggi. Questo è il motivo per cui il rilascio è così controllato — non è un "big bang", è un acceleratore che si può accendere quando è pronto.
-
-**La cosa concreta che cambia per chi lo usa:** letture "sub-50ms" invece di dover ricaricare/ricalcolare corpus BM25 in memoria a ogni richiesta. Per un agente AI che interroga il grafo decine o centinaia di volte in una sessione di lavoro, è la differenza tra un assistente che "pensa" a ogni domanda e uno che risponde all'istante.
-
-## 2. La granularità a blocchi (perché è la parte più importante)
-
-Qui la tua intuizione è corretta ed è **il** punto differenziante, non un dettaglio tecnico:
-
-- Lo schema dello Shadow DB ha tabelle `pages`, `blocks`, `block_refs`, `blocks_fts` — il **blocco** (il singolo bullet di Logseq, con il suo `id::` UUID) è l'unità atomica indicizzata, non la pagina.
-- Le query `query_subtree_by_block_uuid` (con CTE ricorsive) permettono di chiedere "dammi questo blocco e tutti i suoi figli fino a profondità N" — un'operazione che su un sistema page-based (come Obsidian, dove l'unità è il file/nota intera) semplicemente non esiste nella stessa forma: lì devi caricare tutta la nota e fare parsing testuale per trovare la sotto-sezione che ti interessa.
-- Per un agente AI questo significa **recuperare esattamente il contesto che serve**, non l'intera pagina attorno. È memoria selettiva, non "tutto o niente" — più vicino a come funziona la memoria umana (richiami puntuali, non rilettura integrale di un capitolo) che a un semplice text search su file.
-
-Questo è coerente con la citazione che avete già nel README: *"Logseq is building the best local outliner database. But AI Agent memory is at the very bottom of their roadmap. Matryca Plumber gives you that future today."* — lo Shadow DB è l'infrastruttura che rende quella promessa veloce e scalabile, non solo possibile.
-
-## 3. "Memoria principale per gli agenti AI" — cosa c'è oggi e cosa manca ancora
-
-Qui vale la pena essere precisi per non promettere più di quanto la beta copra:
-
-- **Nella beta v2.0.0-beta.1**: lo Shadow DB copre il **read path** — bootstrap, ricostruzione, routing sanitario (health-gated), FTS5, CTE. Questo è già sufficiente per accelerare drasticamente ogni lettura che gli agenti fanno tramite MCP/CLI.
-- **Fuori scope della beta, già in roadmap (Fase 4)**: la "biological memory" — tabelle come `memory_nodes`, `memory_edges`, `memory_episodes`, `memory_procedures` sono **già disegnate nello schema** (ispirate a un modello di memoria biologica, vedi `ROADMAP_V2_BIOLOGICAL_MEMORY.md`), ma non fanno parte di questo rilascio. Sono il prossimo salto: non solo "leggere più veloce" ma un vero **grafo di memoria** con episodi, procedure, consolidamento — la parte che trasforma lo Shadow DB da acceleratore a vera e propria memoria cognitiva per l'agente.
-
-Quindi la frase corretta per raccontarlo al mondo è: **"la v2.0 beta pone le fondamenta ad altissima velocità per la memoria degli agenti AI — la granularità a blocchi e l'infrastruttura di lettura sono già qui; la memoria biologica/episodica arriva nella fase successiva sulla stessa infrastruttura."**
-
-## 4. Perché il soak di 24 ore non è burocrazia, è la parte che conta
-
-Vale la pena raccontarlo anche questo, perché rende il lancio più credibile, non meno:
-
-- Il team (io, in questo caso) ha già trovato e **corretto un bug reale** durante questo processo: un timeout che non copriva l'intera operazione di lettura tra processi (`multiprocessing.Queue`), che in condizioni di stress poteva far superare il deadline configurato senza un fallback pulito. È stato isolato, corretto, testato (anche con test randomizzati/fuzz), rivisto in PR e mergiato.
-- Da lì: rebuild del pacchetto candidato, verifica dell'integrità del wheel (hash, provenienza) su un vault reale copiato, un **probe di accensione** (ON) mirato che ha validato rebuild, health, ricerca, lettura di sottoalberi e recovery controllata — e ora un **soak esteso di ~25 ore** sullo stesso vault reale, per catturare quello che un test rapido non può vedere: comportamento su cicli lunghi, riavvii, watcher di file (creazione/modifica/rinomina/cancellazione), e garanzia che il Markdown originale resti bit-per-bit invariato.
-- Questo è esattamente lo standard che serve per una feature che tocca la modalità in cui un agente AI legge la tua conoscenza personale: **niente scorciatoie prima di fidarsi**.
-
-## 5. Il messaggio per raccontarlo al mondo
-
-Elementi (tecnici + emotivi) che puoi usare:
-
-1. **Il salto di potenza è reale e misurabile**: da un catalogo JSON caricato in RAM e BM25 ricalcolato ogni volta, a un database SQLite con full-text search nativo e query ad albero in sub-50ms.
-2. **La granularità a blocchi è l'unica vera differenza architetturale con Obsidian**: non è marketing, è nello schema — l'unità è il blocco con il suo UUID, non il file.
-3. **Nulla si rompe per chi non lo vuole**: opt-in, default-off, fallback automatico a Markdown/BM25 se qualcosa non è pronto. Il Markdown resta sempre l'unica fonte di verità — non stai chiedendo a nessuno di fidarsi di un database opaco.
-4. **Il rigore del rilascio è parte della storia**: un bug reale trovato e risolto prima del lancio, un soak di un giorno intero sul vault vero, non su dati sintetici — è il tipo di cura che serve quando l'obiettivo finale è diventare la memoria di un agente AI.
-5. **La direzione è più grande della beta**: questo è il primo mattone di un'infrastruttura che porterà a una vera memoria episodica/biologica per gli agenti — la beta non è la destinazione, è la fondazione veloce su cui costruirla.
+Every statement here is **supported** by the code and roadmap, with a few technical clarifications that make the story more precise.
 
 ---
 
-_Documento di lavoro, non un gate di rilascio — nessuna correlazione con `docs/quality/issue-bodies/v2-beta-readiness.md`, che resta l'unica fonte di verità per la decisione di rilascio._
+## 1. What the Shadow DB actually is
+
+It is not a new database that replaces Logseq. It is a **read cache**, managed entirely by the Matryca Plumber daemon, that complements—but never replaces—the Markdown files.
+
+- **Source of truth:** Markdown on disk always remains authoritative. Logseq OG continues to write `.md` files, and Matryca Plumber continues to write `.md` files with OCC safety (`st_mtime` + page lock, the same anti-corruption guarantee already available in v1).
+- **Shadow DB** (`shadow.sqlite`, inside `.matryca_semantic_cache/`) is a **synchronized mirror** of that Markdown, designed for fast **reads**: FTS5 (SQLite's native full-text search) for text search, and **recursive CTEs** (Common Table Expressions) for reading entire block subtrees with a single query instead of rebuilding them in memory each time.
+- It **replaces** the old v1.9.5 path: loading the entire `master_catalog.json` into RAM and computing BM25 in-process for every search. That path remains available as an **automatic fallback**—if the Shadow DB is not ready, for example during a rebuild or after a schema mismatch, the system returns to Markdown/BM25 without requiring user intervention.
+- It is **opt-in**: enable it with `MATRYCA_SHADOW_DB_ENABLED=true`; the default is off. Users who do not enable it retain the existing behavior. This is why the release is so carefully controlled: it is not a big-bang migration, but an accelerator that can be enabled when ready.
+
+**The concrete difference for users:** sub-50ms reads instead of reloading or recomputing the in-memory BM25 corpus for every request. For an AI agent that queries the graph dozens or hundreds of times during a working session, this is the difference between an assistant that pauses to "think" about every question and one that responds immediately.
+
+## 2. Block-level granularity and why it matters most
+
+This intuition is correct and represents **the** differentiator, not a minor technical detail:
+
+- The Shadow DB schema contains `pages`, `blocks`, `block_refs`, and `blocks_fts` tables. The **block**—a single Logseq bullet with its `id::` UUID—is the atomic indexed unit, not the page.
+- `query_subtree_by_block_uuid` queries use recursive CTEs to request "this block and all its children up to depth N." A page-based system such as Obsidian, where the unit is the whole file or note, does not offer the same operation in the same form: it must load the whole note and parse its text to locate the relevant subsection.
+- For an AI agent, this means **retrieving exactly the context it needs**, rather than the entire surrounding page. It is selective memory rather than "all or nothing"—closer to human recall, which retrieves specific details instead of rereading an entire chapter, than to basic file-based text search.
+
+This aligns with the quotation already in the README: *"Logseq is building the best local outliner database. But AI Agent memory is at the very bottom of their roadmap. Matryca Plumber gives you that future today."* The Shadow DB is the infrastructure that makes this promise fast and scalable, not merely possible.
+
+## 3. "Primary memory for AI agents": what exists now and what comes next
+
+Precision matters here so that the beta does not promise more than it delivers:
+
+- **In v2.0.0-beta.1:** the Shadow DB covers the **read path**—bootstrap, rebuild, health-gated routing, FTS5, and CTEs. This is already sufficient to accelerate every read that agents perform through MCP or the CLI.
+- **Outside the beta scope, already on the roadmap (Phase 4):** the "biological memory" tables—such as `memory_nodes`, `memory_edges`, `memory_episodes`, and `memory_procedures`—are **already designed in the schema** (inspired by a biological memory model; see `ROADMAP_V2_BIOLOGICAL_MEMORY.md`), but are not part of this release. They are the next leap: not merely "reading faster," but creating a true **memory graph** with episodes, procedures, and consolidation. This is what turns the Shadow DB from an accelerator into a genuine cognitive memory for the agent.
+
+The accurate public description is therefore: **"The v2.0 beta lays a high-speed foundation for AI-agent memory. Block-level granularity and the read infrastructure are already here; biological and episodic memory will arrive in the next phase on the same infrastructure."**
+
+## 4. Why the 24-hour soak is not bureaucracy
+
+This is also worth explaining because it makes the launch more credible, not less:
+
+- The team—in this case, the maintainer—found and **fixed a real bug** during this process: a timeout did not cover the entire inter-process read operation (`multiprocessing.Queue`), so stress conditions could exceed the configured deadline without a clean fallback. The bug was isolated, fixed, tested—including randomized and fuzz tests—reviewed in a pull request, and merged.
+- The candidate package was then rebuilt; wheel integrity, hash, and provenance were verified against a real copied vault; and a targeted **enabled-state probe** validated rebuild, health, search, subtree reads, and controlled recovery. An **extended soak of approximately 25 hours** then ran against the same real vault to catch behavior that a short test cannot reveal: long-running cycles, restarts, file watchers for creation/modification/rename/deletion, and the guarantee that the original Markdown remains bit-for-bit unchanged.
+- This is exactly the standard required for a feature that changes how an AI agent reads personal knowledge: **do not take shortcuts before establishing trust**.
+
+## 5. How to communicate it publicly
+
+Technical and narrative points worth using:
+
+1. **The capability increase is real and measurable:** the system moves from a JSON catalog loaded into RAM with BM25 recomputed each time to a SQLite database with native full-text search and sub-50ms tree queries.
+2. **Block-level granularity is the genuine architectural difference from Obsidian:** this is not marketing; it is encoded in the schema. The unit is a block with its UUID, not a file.
+3. **Nothing breaks for users who do not want it:** it is opt-in and default-off, with automatic fallback to Markdown/BM25 whenever the Shadow DB is not ready. Markdown always remains the single source of truth; users are never asked to trust an opaque database.
+4. **Release rigor is part of the story:** a real bug was found and fixed before launch, followed by a full-day soak against a real vault rather than synthetic data. This is the level of care required when the ultimate goal is to become an AI agent's memory.
+5. **The direction is larger than the beta:** this is the first building block of infrastructure that will support genuine episodic and biological memory for agents. The beta is not the destination; it is the fast foundation on which that future will be built.
+
+---
+
+_Working document, not a release gate. It has no bearing on `docs/quality/issue-bodies/v2-beta-readiness.md`, which remains the sole source of truth for the release decision._

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -4,99 +4,99 @@
 **Status:** planned — schema in [`src/shadow/schema.py`](../../src/shadow/schema.py); decay in [`src/memory/decay.py`](../../src/memory/decay.py)  
 **Preparation index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) · OpenSpec: [`biological-memory.md`](../openspec/biological-memory.md)  
 **Prerequisite:** [`ROADMAP_V2_SHADOW_DB.md`](ROADMAP_V2_SHADOW_DB.md) ([#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24), [#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17))  
-**Inspiration:** [Nacre](https://github.com/marcusschimizzi/nacre) by Marcus Sullivan (Apache-2.0) — port nativo Python, non sidecar Node  
+**Inspiration:** [Nacre](https://github.com/marcusschimizzi/nacre) by Marcus Sullivan (Apache-2.0) — native Python port, not a Node sidecar  
 **RFC:** [Discussion #19](https://github.com/MarcoPorcellato/matryca-plumber/discussions/19)
 
 ---
 
-## Cosa sono i due progetti
+## What the two projects are
 
 | | **Nacre** | **Matryca Plumber** |
 |---|---|---|
-| **Scopo** | Memory layer per agenti long-lived (mesi) | Daemon local-first per vault Logseq OG + agenti MCP/CLI |
-| **Stack** | TypeScript monorepo (`@nacre/core`, parser, viz, CLI) | Python 3.12 + React Sovereign UI |
+| **Purpose** | Memory layer for long-lived agents (months) | Local-first daemon for Logseq OG vaults and MCP/CLI agents |
+| **Stack** | TypeScript monorepo (`@nacre/core`, parser, visualization, CLI) | Python 3.12 + React Sovereign UI |
 | **Storage** | `SqliteStore` (WAL, schema v5, embeddings) | JSON sidecars → **Shadow DB** `shadow.sqlite` |
-| **Unità di memoria** | Nodi tipizzati + archi tipizzati | Blocchi/pagine Logseq + wikilink + indice semantico block-level |
-| **Licenza** | Apache-2.0 — Copyright 2026 Marcus Sullivan | Apache-2.0 — Copyright 2026 Marco Porcellato & Matryca.ai |
+| **Memory unit** | Typed nodes + typed edges | Logseq blocks/pages + wikilinks + block-level semantic index |
+| **License** | Apache-2.0 — Copyright 2026 Marcus Sullivan | Apache-2.0 — Copyright 2026 Marco Porcellato & Matryca.ai |
 
-**Principio:** portare il motore di memoria biologica di Nacre *dentro* l'infrastruttura Logseq esistente — non sostituire il parser o il modello a blocchi.
+**Principle:** bring Nacre's biological memory engine *into* the existing Logseq infrastructure without replacing the parser or block model.
 
 ---
 
-## Gap analysis — cosa fa Nacre che Matryca non ha ancora
+## Gap analysis: what Nacre provides that Matryca Plumber does not yet have
 
-### 1. Decay / reinforcement (P0)
+### 1. Decay and reinforcement (P0)
 
 ```
 weight(t) = baseWeight × e^(-λt / stability)
 stability = 1 + β × ln(reinforcementCount + 1)
 ```
 
-Sorgente Nacre: [`packages/core/src/decay.ts`](https://github.com/marcusschimizzi/nacre/blob/main/packages/core/src/decay.ts)  
-Matryca oggi: nessun decay sulle connessioni.
+Nacre source: [`packages/core/src/decay.ts`](https://github.com/marcusschimizzi/nacre/blob/main/packages/core/src/decay.ts)  
+Matryca Plumber today: no decay on connections.
 
-### 2. Hybrid recall a 4 segnali (P0)
+### 2. Four-signal hybrid recall (P0)
 
 Semantic + graph walk + recency + importance — [`recall.ts`](https://github.com/marcusschimizzi/nacre/blob/main/packages/core/src/recall.ts).  
-Matryca: BM25 + dual embedding + link hops, senza fusione unificata.
+Matryca Plumber: BM25 + dual embeddings + link hops, without unified fusion.
 
-### 3. Memoria episodica + procedurale (P1–P2)
+### 3. Episodic and procedural memory (P1–P2)
 
-Episodi sessione + procedure (lesson/preference/skill/…).  
-Matryca: solo `store_fact` → `matryca-config.md` e Journey Log operativo.
+Session episodes + procedures (lesson/preference/skill/…).  
+Matryca Plumber: only `store_fact` → `matryca-config.md` and the operational Journey Log.
 
-### 4. Intelligence layer zero-LLM (P1)
+### 4. Zero-LLM intelligence layer (P1)
 
-Connection suggestions, emerging/fading topics — [`intelligence.ts`](https://github.com/marcusschimizzi/nacre/blob/main/packages/core/src/intelligence.ts).  
-Matryca: overlap parziale (`unlinked_mentions`, `entity_consolidation`, `insights_engine`, `semantic_clustering`).
+Connection suggestions and emerging/fading topics — [`intelligence.ts`](https://github.com/marcusschimizzi/nacre/blob/main/packages/core/src/intelligence.ts).  
+Matryca Plumber: partial overlap (`unlinked_mentions`, `entity_consolidation`, `insights_engine`, `semantic_clustering`).
 
-### 5. Consolidation sleep/wake (P0)
+### 5. Sleep/wake consolidation (P0)
 
-Batch idle post-sync Shadow DB → Phase 3 daemon.
+Idle post-sync Shadow DB batch → Phase 3 daemon.
 
-### 6. MCP memory-native
+### 6. Memory-native MCP
 
-| Nacre | Matryca oggi |
+| Nacre | Matryca Plumber today |
 |---|---|
-| `nacre_recall` | `search_graph` — parziale |
-| `nacre_brief` | dashboard + Graph Insights — parziale |
-| `nacre_remember` | `store_fact` — limitato |
-| `nacre_forget` / `nacre_feedback` / `nacre_lesson` | assenti |
+| `nacre_recall` | `search_graph` — partial |
+| `nacre_brief` | dashboard + Graph Insights — partial |
+| `nacre_remember` | `store_fact` — limited |
+| `nacre_forget` / `nacre_feedback` / `nacre_lesson` | absent |
 
 ---
 
-## Cosa Matryca ha già (non duplicare)
+## What Matryca Plumber already has and must not duplicate
 
-- Paradigma Logseq outliner, OCC, Safe-Sync ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25))
-- Cognitive lint LLM (MARPA, healer, property hygiene, auto-split, backlink backprop)
+- Logseq outliner paradigm, OCC, and Safe-Sync ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25))
+- LLM cognitive lint (MARPA, healer, property hygiene, auto-split, backlink backpropagation)
 - L1/L2 Karpathy model ([`l1_memory.py`](../../src/agent/l1_memory.py))
-- Ingest atomico + Trust & Safety tiers + dual embedding applicability
+- Atomic ingest + Trust & Safety tiers + dual-embedding applicability
 
 ---
 
-## Roadmap di implementazione
+## Implementation roadmap
 
-### Fase A — Fondamenta in Shadow DB
+### Phase A — Shadow DB foundations
 
 DDL in [`src/shadow/schema.py`](../../src/shadow/schema.py). Package [`src/memory/`](../../src/memory/):
 
-| Modulo | Sorgente Nacre |
-|--------|----------------|
+| Module | Nacre source |
+|--------|--------------|
 | `decay.py` | `decay.ts` |
 | `recall.py` | `recall.ts` |
 | `intelligence.py` | `intelligence.ts` |
 | `resolve.py` | `resolve.ts` (+ `alias_index.py`) |
-| `consolidate.py` | pipeline sleep/wake |
+| `consolidate.py` | sleep/wake pipeline |
 
-Estrazione entità **Logseq-native** (non `@nacre/parser`):
+**Logseq-native** entity extraction (not `@nacre/parser`):
 
-- **Structural:** wikilink, block-ref, tags, page properties via `logseq-matryca-parser`
-- **Co-occurrence:** stesso sotto-albero di blocchi (outliner-aware)
+- **Structural:** wikilinks, block references, tags, and page properties via `logseq-matryca-parser`
+- **Co-occurrence:** within the same block subtree (outliner-aware)
 - **Custom:** entity-map YAML in `.matryca/`
 
-Env: `MATRYCA_MEMORY_GRAPH_ENABLED=false` (opt-in alpha).
+Environment variable: `MATRYCA_MEMORY_GRAPH_ENABLED=false` (opt-in alpha).
 
-### Fase B — Hybrid recall
+### Phase B — Hybrid recall
 
 `search_graph(method="recall")` in [`graph_dispatch.py`](../../src/agent/graph_dispatch.py):
 
@@ -104,71 +104,71 @@ Env: `MATRYCA_MEMORY_GRAPH_ENABLED=false` (opt-in alpha).
 final = w_sem×semantic + w_graph×graphWalk + w_recency×recency + w_importance×importance
 ```
 
-### Fase C — Episodi + procedure
+### Phase C — Episodes and procedures
 
-SQLite + mirror umano su `pages/Matryca Procedures.md`. Estendere `store_fact` per `kind=lesson|preference|…`.
+SQLite + human-readable mirror in `pages/Matryca Procedures.md`. Extend `store_fact` with `kind=lesson|preference|…`.
 
-### Fase D — Intelligence & alerts
+### Phase D — Intelligence and alerts
 
-`memory_intelligence.py` → pagina `Matryca Memory Alerts` + pannello Sovereign UI.
+`memory_intelligence.py` → `Matryca Memory Alerts` page + Sovereign UI panel.
 
-### Fase E — Temporal & viz (post-MVP)
+### Phase E — Temporal features and visualization (post-MVP)
 
-`memory_snapshots`, `as_of` recall, grafo 2D in UI.
+`memory_snapshots`, `as_of` recall, and a 2D graph in the UI.
 
-### Fase F — Hive multi-vault (opzionale)
+### Phase F — Multi-vault hive (optional)
 
-Solo se emerge demand reale.
+Only if real demand emerges.
 
 ---
 
-## Priorità
+## Priorities
 
-| Priorità | Feature |
+| Priority | Feature |
 |---|---|
-| P0 | Decay + consolidation sleep |
-| P0 | Hybrid recall unificato |
+| P0 | Decay + sleep consolidation |
+| P0 | Unified hybrid recall |
 | P1 | Intelligence alerts |
-| P1 | Procedure memory |
+| P1 | Procedural memory |
 | P2 | Episodic memory |
 | P2 | Temporal snapshots |
-| P3 | 2D graph viz |
+| P3 | 2D graph visualization |
 | P3 | Hive federation |
 
 ---
 
-## Conformità Apache-2.0
+## Apache-2.0 compliance
 
-Entrambi i progetti sono Apache-2.0. Per ogni merge di codice portato da Nacre:
+Both projects use Apache-2.0. For every merge that ports code from Nacre:
 
-1. Mantieni [`LICENSE`](../../LICENSE) invariato
-2. Aggiorna [`NOTICE`](../../NOTICE) con attribuzione Marcus Sullivan / Nacre
-3. Header SPDX nei file `src/memory/*.py` portati
-4. [`docs/THIRD_PARTY.md`](../THIRD_PARTY.md) al primo merge (file-per-file map)
-5. Test pytest con parità numerica decay (half-life table Nacre)
-6. Non usare “Nacre” come brand Matryca — solo attribuzione in NOTICE/README
+1. Keep [`LICENSE`](../../LICENSE) unchanged.
+2. Update [`NOTICE`](../../NOTICE) with attribution to Marcus Sullivan and Nacre.
+3. Add SPDX headers to ported `src/memory/*.py` files.
+4. Add [`docs/THIRD_PARTY.md`](../THIRD_PARTY.md) with a file-by-file map at the first merge.
+5. Add pytest tests proving numerical decay parity against Nacre's half-life table.
+6. Do not use “Nacre” as a Matryca Plumber brand; use the name only for attribution in NOTICE/README.
 
-Checklist dettagliata: sezione “Conformità Apache-2.0” nel piano originale (mantainer reference).
+Detailed checklist: “Apache-2.0 compliance” section in the original plan (maintainer reference).
 
 ---
 
-## Rischi
+## Risks
 
-| Rischio | Mitigazione |
+| Risk | Mitigation |
 |---|---|
-| Duplicazione semantic JSON | Shadow DB source of truth v2; deprecazione graduale JSON |
-| `maintenance_daemon.py` ~3200 righe | Phase 3 in modulo dedicato ([#57](https://github.com/MarcoPorcellato/matryca-plumber/issues/57)) |
-| Parser Nacre ≠ Logseq | Solo `logseq-matryca-parser` |
-| Embedding dimension mismatch | Meta in `shadow_meta`; stesso fix documentato in Nacre ROADMAP |
-| Scope creep | Flag opt-in; ship decay+recall prima di viz/hive |
+| Duplicate semantic JSON | Shadow DB becomes the v2 source of truth; deprecate JSON gradually |
+| `maintenance_daemon.py` ~3,200 lines | Move Phase 3 into a dedicated module ([#57](https://github.com/MarcoPorcellato/matryca-plumber/issues/57)) |
+| Nacre parser ≠ Logseq | Use only `logseq-matryca-parser` |
+| Embedding dimension mismatch | Store metadata in `shadow_meta`; apply the same fix documented in the Nacre roadmap |
+| Scope creep | Keep the flag opt-in; ship decay + recall before visualization/hive |
 
 ---
 
-## Prossimi passi
+## Next steps
 
-1. ~~Salvare roadmap in repo~~ (this file)
-2. Issue **Biological Memory Layer** linkata a #20/#24
-3. RFC Discussion #19: mapping block UUID → memory node
-4. `src/memory/decay.py` + test parità Nacre
-5. Prototipo consolidation su 100 pagine con `MATRYCA_MEMORY_GRAPH_ENABLED=true`
-6. `NOTICE` + `docs/THIRD_PARTY.md` al primo merge codice Nacre
+1. ~~Save the roadmap in the repository~~ (this file)
+2. Link the **Biological Memory Layer** issue to #20/#24.
+3. Use RFC Discussion #19 to map block UUIDs to memory nodes.
+4. Implement `src/memory/decay.py` + Nacre parity tests.
+5. Prototype consolidation on 100 pages with `MATRYCA_MEMORY_GRAPH_ENABLED=true`.
+6. Add `NOTICE` + `docs/THIRD_PARTY.md` at the first merge of Nacre-derived code.


### PR DESCRIPTION
## Summary

- translate the Shadow DB vision document into English while preserving its historical release context
- translate the Biological Memory roadmap and retain its technical and licensing semantics
- establish English as the repository documentation and GitHub-facing language, with explicit exceptions for localization and parser fixtures

## Test plan

- [x] documentation knowledge bundle and inventory checks
- [x] agent documentation coherence check
- [x] Markdown whitespace validation
- [x] residual-language scan; remaining `caffè` references are intentional FTS5 and Unicode test evidence
- [x] graph-based change analysis: low risk, no affected runtime flows
