### PR TITLE
perf(bm25): benchmark representative cache capacities (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Reproducible BM25 capacity evidence** — add deterministic capacity, distribution, tail-latency, RSS, row-pressure, invalidation, rebuild, concurrent-corpus, and correctness-parity benchmarks; retain the 8,192-entry and 65,536-row production defaults under an explicit synthetic-evidence boundary.
 - **OKF v0.2 documentation governance** — align the maintained knowledge bundle with the pinned portable format, separate Matryca classification from official lifecycle status, add provenance, freshness, canonical-role, link, anchor, and chronology gates, migrate the full documentation inventory to schema v2, make documentation integrity mandatory in `make check` and `make ci`, and document the repository-to-projection operating model.
 - **Gate B public-RC soak qualification** — add separate resumable `default-on` and `read-only-external` profiles bound to the installed `2.0.0rc1` wheel, explicit opt-out controls, full graph-manifest integrity, external-cache isolation, and a terminal-aware supervisor for restart-safe multi-day evidence collection.
 

--- a/benchmarks/results/bm25_query_cache_capacity_macos_arm64_2026-08-07.json
+++ b/benchmarks/results/bm25_query_cache_capacity_macos_arm64_2026-08-07.json
@@ -1,0 +1,2086 @@
+{
+  "benchmark_schema_version": 1,
+  "config": {
+    "capacities": [
+      512,
+      2048,
+      8192,
+      16384
+    ],
+    "documents": 128,
+    "multi_corpora": 4,
+    "repetitions": 3,
+    "requests": 20000,
+    "seed": 20260802,
+    "warmup": 512
+  },
+  "corpus_manifest": {
+    "benchmark_query_key_cardinality": 16384,
+    "bucket_cardinality": 29,
+    "documents": 128,
+    "terms_per_document": 4,
+    "topic_cardinality": 64
+  },
+  "environment": {
+    "machine": "arm64",
+    "os": "macOS-15.7.3-arm64-arm-64bit",
+    "python": "3.12.13",
+    "source_commit": "5ef1418602a0363b2e9457920e9af34011743507"
+  },
+  "measurements": {
+    "capacity_matrix": {
+      "capacity_pressure": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 9.958,
+            "p50": 9.958,
+            "p95": 11.541,
+            "p99": 17.166
+          },
+          "parity": true,
+          "peak_rss_bytes": 273121280,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 606208,
+          "rss_end_bytes": 273203200,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 10.041,
+            "p50": 10.041,
+            "p95": 12.459,
+            "p99": 19.417
+          },
+          "parity": true,
+          "peak_rss_bytes": 273989632,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 49152,
+          "rss_end_bytes": 274038784,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 10.25,
+            "p50": 10.25,
+            "p95": 12.833,
+            "p99": 24.458
+          },
+          "parity": true,
+          "peak_rss_bytes": 274120704,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 81920,
+          "rss_end_bytes": 274169856,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 17952,
+          "latency_us": {
+            "median": 10.208,
+            "p50": 10.208,
+            "p95": 12.791,
+            "p99": 21.125
+          },
+          "parity": true,
+          "peak_rss_bytes": 274710528,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 16384,
+          "rss_end_bytes": 274710528,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 17952,
+          "latency_us": {
+            "median": 10.125,
+            "p50": 10.125,
+            "p95": 12.333,
+            "p99": 19.042
+          },
+          "parity": true,
+          "peak_rss_bytes": 274726912,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 274726912,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 17952,
+          "latency_us": {
+            "median": 10.125,
+            "p50": 10.125,
+            "p95": 11.791,
+            "p99": 18.292
+          },
+          "parity": true,
+          "peak_rss_bytes": 274776064,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 32768,
+          "rss_end_bytes": 274792448,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 11808,
+          "latency_us": {
+            "median": 9.958,
+            "p50": 9.958,
+            "p95": 12.833,
+            "p99": 18.417
+          },
+          "parity": true,
+          "peak_rss_bytes": 277544960,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 2195456,
+          "rss_end_bytes": 277561344,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 11808,
+          "latency_us": {
+            "median": 10.041,
+            "p50": 10.041,
+            "p95": 12.708,
+            "p99": 20.75
+          },
+          "parity": true,
+          "peak_rss_bytes": 278183936,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 606208,
+          "rss_end_bytes": 278183936,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 11808,
+          "latency_us": {
+            "median": 10.125,
+            "p50": 10.125,
+            "p95": 13.0,
+            "p99": 22.875
+          },
+          "parity": true,
+          "peak_rss_bytes": 279003136,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 294912,
+          "rss_end_bytes": 279003136,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 16384,
+            "hits": 3616,
+            "invalidations": 0,
+            "misses": 16384,
+            "result_row_capacity": 65536,
+            "result_rows": 16384
+          },
+          "cache_hit_ratio": 0.1808,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.792,
+            "p50": 9.792,
+            "p95": 12.875,
+            "p99": 21.0
+          },
+          "parity": true,
+          "peak_rss_bytes": 282673152,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 3702784,
+          "rss_end_bytes": 282705920,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 16384,
+            "hits": 3616,
+            "invalidations": 0,
+            "misses": 16384,
+            "result_row_capacity": 65536,
+            "result_rows": 16384
+          },
+          "cache_hit_ratio": 0.1808,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.75,
+            "p50": 9.75,
+            "p95": 12.583,
+            "p99": 19.5
+          },
+          "parity": true,
+          "peak_rss_bytes": 283279360,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 606208,
+          "rss_end_bytes": 283312128,
+          "unique_requests": 16384
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 16384,
+            "hits": 3616,
+            "invalidations": 0,
+            "misses": 16384,
+            "result_row_capacity": 65536,
+            "result_rows": 16384
+          },
+          "cache_hit_ratio": 0.1808,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.75,
+            "p50": 9.75,
+            "p95": 12.125,
+            "p99": 17.958
+          },
+          "parity": true,
+          "peak_rss_bytes": 283590656,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 278528,
+          "rss_end_bytes": 283590656,
+          "unique_requests": 16384
+        }
+      ],
+      "edge_cases": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 14.062,
+            "p50": 14.062,
+            "p95": 105.167,
+            "p99": 121.067
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 10.354,
+            "p50": 10.354,
+            "p95": 80.864,
+            "p99": 90.206
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 2,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 11.5,
+            "p50": 11.5,
+            "p95": 88.761,
+            "p99": 99.686
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 3,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 13.562,
+            "p50": 13.562,
+            "p95": 87.062,
+            "p99": 97.713
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 10.667,
+            "p50": 10.667,
+            "p95": 95.552,
+            "p99": 108.71
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 2,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 10.229,
+            "p50": 10.229,
+            "p95": 94.208,
+            "p99": 106.842
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 3,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 15.937,
+            "p50": 15.937,
+            "p95": 111.937,
+            "p99": 127.42
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 13.479,
+            "p50": 13.479,
+            "p95": 90.562,
+            "p99": 102.479
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 2,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 11.729,
+            "p50": 11.729,
+            "p95": 91.709,
+            "p99": 102.942
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 3,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 12.937,
+            "p50": 12.937,
+            "p95": 130.635,
+            "p99": 149.76
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 11.021,
+            "p50": 11.021,
+            "p95": 108.76,
+            "p99": 125.618
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 2,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 15
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 11.062,
+            "p50": 11.062,
+            "p95": 110.958,
+            "p99": 128.058
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 3,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6
+        }
+      ],
+      "hot_80_20": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 1976,
+            "invalidations": 0,
+            "misses": 18024,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0988,
+          "capacity": 512,
+          "entry_pressure_evictions": 17512,
+          "latency_us": {
+            "median": 10.125,
+            "p50": 10.125,
+            "p95": 12.375,
+            "p99": 17.791
+          },
+          "parity": true,
+          "peak_rss_bytes": 284114944,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284114944,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 1976,
+            "invalidations": 0,
+            "misses": 18024,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0988,
+          "capacity": 512,
+          "entry_pressure_evictions": 17512,
+          "latency_us": {
+            "median": 9.917,
+            "p50": 9.917,
+            "p95": 11.169,
+            "p99": 16.625
+          },
+          "parity": true,
+          "peak_rss_bytes": 284147712,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 49152,
+          "rss_end_bytes": 284180480,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 1976,
+            "invalidations": 0,
+            "misses": 18024,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0988,
+          "capacity": 512,
+          "entry_pressure_evictions": 17512,
+          "latency_us": {
+            "median": 10.208,
+            "p50": 10.208,
+            "p95": 12.583,
+            "p99": 34.792
+          },
+          "parity": true,
+          "peak_rss_bytes": 284737536,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 16384,
+          "rss_end_bytes": 284737536,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 7342,
+            "invalidations": 0,
+            "misses": 12658,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.3671,
+          "capacity": 2048,
+          "entry_pressure_evictions": 10610,
+          "latency_us": {
+            "median": 9.875,
+            "p50": 9.875,
+            "p95": 11.916,
+            "p99": 16.375
+          },
+          "parity": true,
+          "peak_rss_bytes": 284753920,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284753920,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 7342,
+            "invalidations": 0,
+            "misses": 12658,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.3671,
+          "capacity": 2048,
+          "entry_pressure_evictions": 10610,
+          "latency_us": {
+            "median": 9.917,
+            "p50": 9.917,
+            "p95": 11.5,
+            "p99": 15.25
+          },
+          "parity": true,
+          "peak_rss_bytes": 284753920,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284753920,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 7342,
+            "invalidations": 0,
+            "misses": 12658,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.3671,
+          "capacity": 2048,
+          "entry_pressure_evictions": 10610,
+          "latency_us": {
+            "median": 9.834,
+            "p50": 9.834,
+            "p95": 11.125,
+            "p99": 14.625
+          },
+          "parity": true,
+          "peak_rss_bytes": 284803072,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 49152,
+          "rss_end_bytes": 284803072,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.334,
+            "p50": 1.334,
+            "p95": 10.5,
+            "p99": 14.0
+          },
+          "parity": true,
+          "peak_rss_bytes": 284819456,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 16384,
+          "rss_end_bytes": 284819456,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.334,
+            "p50": 1.334,
+            "p95": 10.583,
+            "p99": 13.5
+          },
+          "parity": true,
+          "peak_rss_bytes": 284819456,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 284819456,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.417,
+            "p50": 1.417,
+            "p95": 10.917,
+            "p99": 15.25
+          },
+          "parity": true,
+          "peak_rss_bytes": 284835840,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 32768,
+          "rss_end_bytes": 284852224,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.459,
+            "p50": 1.459,
+            "p95": 11.125,
+            "p99": 14.959
+          },
+          "parity": true,
+          "peak_rss_bytes": 285392896,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 285392896,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.375,
+            "p50": 1.375,
+            "p95": 10.625,
+            "p99": 13.75
+          },
+          "parity": true,
+          "peak_rss_bytes": 285392896,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 285392896,
+          "unique_requests": 6723
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 6723,
+            "hits": 13277,
+            "invalidations": 0,
+            "misses": 6723,
+            "result_row_capacity": 65536,
+            "result_rows": 6723
+          },
+          "cache_hit_ratio": 0.66385,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.417,
+            "p50": 1.417,
+            "p95": 10.75,
+            "p99": 14.084
+          },
+          "parity": true,
+          "peak_rss_bytes": 285392896,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 285392896,
+          "unique_requests": 6723
+        }
+      ],
+      "row_pressure": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 51200
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 35.917,
+            "p50": 35.917,
+            "p95": 43.75,
+            "p99": 55.542
+          },
+          "parity": true,
+          "peak_rss_bytes": 286015488,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 622592,
+          "rss_end_bytes": 286015488,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 51200
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 35.875,
+            "p50": 35.875,
+            "p95": 43.542,
+            "p99": 55.833
+          },
+          "parity": true,
+          "peak_rss_bytes": 288292864,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 180224,
+          "rss_end_bytes": 288292864,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 51200
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 19488,
+          "latency_us": {
+            "median": 35.834,
+            "p50": 35.834,
+            "p95": 43.625,
+            "p99": 55.958
+          },
+          "parity": true,
+          "peak_rss_bytes": 290766848,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 376832,
+          "rss_end_bytes": 290766848,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 36.417,
+            "p50": 36.417,
+            "p95": 47.666,
+            "p99": 71.044
+          },
+          "parity": true,
+          "peak_rss_bytes": 293355520,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 458752,
+          "rss_end_bytes": 293355520,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 35.875,
+            "p50": 35.875,
+            "p95": 42.917,
+            "p99": 53.416
+          },
+          "parity": true,
+          "peak_rss_bytes": 295911424,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 458752,
+          "rss_end_bytes": 295911424,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 35.875,
+            "p50": 35.875,
+            "p95": 42.959,
+            "p99": 56.668
+          },
+          "parity": true,
+          "peak_rss_bytes": 296108032,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 196608,
+          "rss_end_bytes": 296173568,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 35.834,
+            "p50": 35.834,
+            "p95": 43.125,
+            "p99": 53.375
+          },
+          "parity": true,
+          "peak_rss_bytes": 298270720,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 298270720,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 36.084,
+            "p50": 36.084,
+            "p95": 43.169,
+            "p99": 59.125
+          },
+          "parity": true,
+          "peak_rss_bytes": 300367872,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 300367872,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 36.0,
+            "p50": 36.0,
+            "p95": 44.166,
+            "p99": 62.083
+          },
+          "parity": true,
+          "peak_rss_bytes": 302579712,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 114688,
+          "rss_end_bytes": 302579712,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 36.084,
+            "p50": 36.084,
+            "p95": 44.583,
+            "p99": 65.292
+          },
+          "parity": true,
+          "peak_rss_bytes": 304676864,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 304676864,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 35.958,
+            "p50": 35.958,
+            "p95": 43.125,
+            "p99": 52.918
+          },
+          "parity": true,
+          "peak_rss_bytes": 304988160,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 278528,
+          "rss_end_bytes": 304988160,
+          "unique_requests": 20000
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 20000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 35.834,
+            "p50": 35.834,
+            "p95": 43.002,
+            "p99": 51.544
+          },
+          "parity": true,
+          "peak_rss_bytes": 305070080,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 19345,
+          "rss_delta_bytes": 81920,
+          "rss_end_bytes": 305070080,
+          "unique_requests": 20000
+        }
+      ],
+      "uniform": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 627,
+            "invalidations": 0,
+            "misses": 19373,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.03135,
+          "capacity": 512,
+          "entry_pressure_evictions": 18861,
+          "latency_us": {
+            "median": 10.0,
+            "p50": 10.0,
+            "p95": 12.708,
+            "p99": 17.584
+          },
+          "parity": true,
+          "peak_rss_bytes": 305070080,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305070080,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 627,
+            "invalidations": 0,
+            "misses": 19373,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.03135,
+          "capacity": 512,
+          "entry_pressure_evictions": 18861,
+          "latency_us": {
+            "median": 10.042,
+            "p50": 10.042,
+            "p95": 12.125,
+            "p99": 17.792
+          },
+          "parity": true,
+          "peak_rss_bytes": 305070080,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305070080,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 627,
+            "invalidations": 0,
+            "misses": 19373,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.03135,
+          "capacity": 512,
+          "entry_pressure_evictions": 18861,
+          "latency_us": {
+            "median": 10.167,
+            "p50": 10.167,
+            "p95": 12.958,
+            "p99": 21.875
+          },
+          "parity": true,
+          "peak_rss_bytes": 305102848,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305102848,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 2335,
+            "invalidations": 0,
+            "misses": 17665,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.11675,
+          "capacity": 2048,
+          "entry_pressure_evictions": 15617,
+          "latency_us": {
+            "median": 10.208,
+            "p50": 10.208,
+            "p95": 12.792,
+            "p99": 23.833
+          },
+          "parity": true,
+          "peak_rss_bytes": 305119232,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 16384,
+          "rss_end_bytes": 305119232,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 2335,
+            "invalidations": 0,
+            "misses": 17665,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.11675,
+          "capacity": 2048,
+          "entry_pressure_evictions": 15617,
+          "latency_us": {
+            "median": 10.084,
+            "p50": 10.084,
+            "p95": 12.419,
+            "p99": 18.375
+          },
+          "parity": true,
+          "peak_rss_bytes": 305152000,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305152000,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 2335,
+            "invalidations": 0,
+            "misses": 17665,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.11675,
+          "capacity": 2048,
+          "entry_pressure_evictions": 15617,
+          "latency_us": {
+            "median": 10.208,
+            "p50": 10.208,
+            "p95": 12.875,
+            "p99": 20.293
+          },
+          "parity": true,
+          "peak_rss_bytes": 305152000,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305152000,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 7431,
+            "invalidations": 0,
+            "misses": 12569,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.37155,
+          "capacity": 8192,
+          "entry_pressure_evictions": 4377,
+          "latency_us": {
+            "median": 9.791,
+            "p50": 9.791,
+            "p95": 11.292,
+            "p99": 16.958
+          },
+          "parity": true,
+          "peak_rss_bytes": 305152000,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305152000,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 7431,
+            "invalidations": 0,
+            "misses": 12569,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.37155,
+          "capacity": 8192,
+          "entry_pressure_evictions": 4377,
+          "latency_us": {
+            "median": 9.959,
+            "p50": 9.959,
+            "p95": 11.791,
+            "p99": 23.834
+          },
+          "parity": true,
+          "peak_rss_bytes": 305676288,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305676288,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 8192,
+            "hits": 7431,
+            "invalidations": 0,
+            "misses": 12569,
+            "result_row_capacity": 65536,
+            "result_rows": 8192
+          },
+          "cache_hit_ratio": 0.37155,
+          "capacity": 8192,
+          "entry_pressure_evictions": 4377,
+          "latency_us": {
+            "median": 9.792,
+            "p50": 9.792,
+            "p95": 12.625,
+            "p99": 18.0
+          },
+          "parity": true,
+          "peak_rss_bytes": 305709056,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 32768,
+          "rss_end_bytes": 305709056,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 11532,
+            "hits": 8468,
+            "invalidations": 0,
+            "misses": 11532,
+            "result_row_capacity": 65536,
+            "result_rows": 11532
+          },
+          "cache_hit_ratio": 0.4234,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.583,
+            "p50": 9.583,
+            "p95": 11.791,
+            "p99": 19.708
+          },
+          "parity": true,
+          "peak_rss_bytes": 305709056,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305709056,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 11532,
+            "hits": 8468,
+            "invalidations": 0,
+            "misses": 11532,
+            "result_row_capacity": 65536,
+            "result_rows": 11532
+          },
+          "cache_hit_ratio": 0.4234,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.5,
+            "p50": 9.5,
+            "p95": 11.791,
+            "p99": 17.541
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 16384,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 11532
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 11532,
+            "hits": 8468,
+            "invalidations": 0,
+            "misses": 11532,
+            "result_row_capacity": 65536,
+            "result_rows": 11532
+          },
+          "cache_hit_ratio": 0.4234,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 9.541,
+            "p50": 9.541,
+            "p95": 11.959,
+            "p99": 17.708
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 11532
+        }
+      ],
+      "zipf": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 13497,
+            "invalidations": 0,
+            "misses": 6503,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.67485,
+          "capacity": 512,
+          "entry_pressure_evictions": 5991,
+          "latency_us": {
+            "median": 1.166,
+            "p50": 1.166,
+            "p95": 10.916,
+            "p99": 13.25
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 13497,
+            "invalidations": 0,
+            "misses": 6503,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.67485,
+          "capacity": 512,
+          "entry_pressure_evictions": 5991,
+          "latency_us": {
+            "median": 1.167,
+            "p50": 1.167,
+            "p95": 10.875,
+            "p99": 13.166
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 13497,
+            "invalidations": 0,
+            "misses": 6503,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.67485,
+          "capacity": 512,
+          "entry_pressure_evictions": 5991,
+          "latency_us": {
+            "median": 1.167,
+            "p50": 1.167,
+            "p95": 10.875,
+            "p99": 12.459
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 15725,
+            "invalidations": 0,
+            "misses": 4275,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.78625,
+          "capacity": 2048,
+          "entry_pressure_evictions": 2227,
+          "latency_us": {
+            "median": 1.125,
+            "p50": 1.125,
+            "p95": 11.208,
+            "p99": 12.333
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 15725,
+            "invalidations": 0,
+            "misses": 4275,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.78625,
+          "capacity": 2048,
+          "entry_pressure_evictions": 2227,
+          "latency_us": {
+            "median": 1.125,
+            "p50": 1.125,
+            "p95": 10.625,
+            "p99": 13.291
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 2048,
+            "hits": 15725,
+            "invalidations": 0,
+            "misses": 4275,
+            "result_row_capacity": 65536,
+            "result_rows": 2048
+          },
+          "cache_hit_ratio": 0.78625,
+          "capacity": 2048,
+          "entry_pressure_evictions": 2227,
+          "latency_us": {
+            "median": 1.125,
+            "p50": 1.125,
+            "p95": 10.667,
+            "p99": 12.625
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.125,
+            "p50": 1.125,
+            "p95": 10.541,
+            "p99": 12.917
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.125,
+            "p50": 1.125,
+            "p95": 10.375,
+            "p99": 12.542
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.084,
+            "p50": 1.084,
+            "p95": 10.333,
+            "p99": 12.625
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.084,
+            "p50": 1.084,
+            "p95": 10.292,
+            "p99": 12.542
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 1,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.083,
+            "p50": 1.083,
+            "p95": 10.25,
+            "p99": 12.292
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 2,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 3855,
+            "hits": 16145,
+            "invalidations": 0,
+            "misses": 3855,
+            "result_row_capacity": 65536,
+            "result_rows": 3855
+          },
+          "cache_hit_ratio": 0.80725,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.084,
+            "p50": 1.084,
+            "p95": 10.25,
+            "p99": 13.084
+          },
+          "parity": true,
+          "peak_rss_bytes": 305741824,
+          "repetition": 3,
+          "requests": 20000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 305741824,
+          "unique_requests": 3855
+        }
+      ]
+    },
+    "corpus_build_seconds": 0.000135,
+    "multi_corpus": {
+      "corpora": 4,
+      "parity": true,
+      "peak_rss_bytes": 305758208,
+      "requests_per_corpus": 20000,
+      "rss_end_bytes": 305758208,
+      "wall_seconds": 0.607439
+    },
+    "mutation_storm": {
+      "cache": {
+        "capacity": 8192,
+        "entries": 194,
+        "hits": 6,
+        "invalidations": 99,
+        "misses": 194,
+        "result_row_capacity": 65536,
+        "result_rows": 194
+      },
+      "invalidation_latency_us_p99": 15.429,
+      "parity": true,
+      "rebuild_latency_us_p99": 109.949
+    }
+  },
+  "production_default_entries": 8192
+}

--- a/benchmarks/results/bm25_query_cache_large_corpus_macos_arm64_2026-08-07.json
+++ b/benchmarks/results/bm25_query_cache_large_corpus_macos_arm64_2026-08-07.json
@@ -1,0 +1,742 @@
+{
+  "benchmark_schema_version": 1,
+  "config": {
+    "capacities": [
+      512,
+      2048,
+      8192,
+      16384
+    ],
+    "documents": 8192,
+    "multi_corpora": 4,
+    "repetitions": 1,
+    "requests": 1000,
+    "seed": 20260802,
+    "warmup": 128
+  },
+  "corpus_manifest": {
+    "benchmark_query_key_cardinality": 16384,
+    "bucket_cardinality": 29,
+    "documents": 8192,
+    "terms_per_document": 4,
+    "topic_cardinality": 64
+  },
+  "environment": {
+    "machine": "arm64",
+    "os": "macOS-15.7.3-arm64-arm-64bit",
+    "python": "3.12.13",
+    "source_commit": "5ef1418602a0363b2e9457920e9af34011743507"
+  },
+  "measurements": {
+    "capacity_matrix": {
+      "capacity_pressure": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 488,
+          "latency_us": {
+            "median": 521.292,
+            "p50": 521.292,
+            "p95": 566.175,
+            "p99": 610.252
+          },
+          "parity": true,
+          "peak_rss_bytes": 47808512,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 425984,
+          "rss_end_bytes": 48136192,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 1000,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 1000
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 518.917,
+            "p50": 518.917,
+            "p95": 565.307,
+            "p99": 590.464
+          },
+          "parity": true,
+          "peak_rss_bytes": 49102848,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 294912,
+          "rss_end_bytes": 49266688,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 1000,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 1000
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 518.833,
+            "p50": 518.833,
+            "p95": 566.807,
+            "p99": 598.474
+          },
+          "parity": true,
+          "peak_rss_bytes": 50020352,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 50069504,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 1000,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 1000
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 518.875,
+            "p50": 518.875,
+            "p95": 567.873,
+            "p99": 597.371
+          },
+          "parity": true,
+          "peak_rss_bytes": 50839552,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 49152,
+          "rss_end_bytes": 50855936,
+          "unique_requests": 1000
+        }
+      ],
+      "edge_cases": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 109
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 585.062,
+            "p50": 585.062,
+            "p95": 4045.657,
+            "p99": 4164.499
+          },
+          "parity": true,
+          "peak_rss_bytes": 51888128,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 51888128,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 109
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 593.542,
+            "p50": 593.542,
+            "p95": 3857.865,
+            "p99": 3917.707
+          },
+          "parity": true,
+          "peak_rss_bytes": 52035584,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52035584,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 109
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 625.5,
+            "p50": 625.5,
+            "p95": 4048.896,
+            "p99": 4169.546
+          },
+          "parity": true,
+          "peak_rss_bytes": 52232192,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52232192,
+          "unique_requests": 6
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 4,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 4,
+            "result_row_capacity": 65536,
+            "result_rows": 109
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 585.042,
+            "p50": 585.042,
+            "p95": 4027.584,
+            "p99": 4150.15
+          },
+          "parity": true,
+          "peak_rss_bytes": 52363264,
+          "repetition": 1,
+          "requests": 6,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52363264,
+          "unique_requests": 6
+        }
+      ],
+      "hot_80_20": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 69,
+            "invalidations": 0,
+            "misses": 931,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.069,
+          "capacity": 512,
+          "entry_pressure_evictions": 419,
+          "latency_us": {
+            "median": 520.75,
+            "p50": 520.75,
+            "p95": 570.149,
+            "p99": 601.168
+          },
+          "parity": true,
+          "peak_rss_bytes": 52363264,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52363264,
+          "unique_requests": 909
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 909,
+            "hits": 91,
+            "invalidations": 0,
+            "misses": 909,
+            "result_row_capacity": 65536,
+            "result_rows": 909
+          },
+          "cache_hit_ratio": 0.091,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 515.792,
+            "p50": 515.792,
+            "p95": 563.085,
+            "p99": 587.497
+          },
+          "parity": true,
+          "peak_rss_bytes": 52379648,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52379648,
+          "unique_requests": 909
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 909,
+            "hits": 91,
+            "invalidations": 0,
+            "misses": 909,
+            "result_row_capacity": 65536,
+            "result_rows": 909
+          },
+          "cache_hit_ratio": 0.091,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 522.959,
+            "p50": 522.959,
+            "p95": 575.538,
+            "p99": 613.215
+          },
+          "parity": true,
+          "peak_rss_bytes": 52494336,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 49152,
+          "rss_end_bytes": 52494336,
+          "unique_requests": 909
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 909,
+            "hits": 91,
+            "invalidations": 0,
+            "misses": 909,
+            "result_row_capacity": 65536,
+            "result_rows": 909
+          },
+          "cache_hit_ratio": 0.091,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 519.604,
+            "p50": 519.604,
+            "p95": 575.3,
+            "p99": 640.536
+          },
+          "parity": true,
+          "peak_rss_bytes": 52494336,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 52494336,
+          "unique_requests": 909
+        }
+      ],
+      "row_pressure": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 51200
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 512,
+          "entry_pressure_evictions": 488,
+          "latency_us": {
+            "median": 2380.812,
+            "p50": 2380.812,
+            "p95": 2563.083,
+            "p99": 2745.782
+          },
+          "parity": true,
+          "peak_rss_bytes": 57901056,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 3932160,
+          "rss_end_bytes": 57982976,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 2380.125,
+            "p50": 2380.125,
+            "p95": 2554.309,
+            "p99": 2671.181
+          },
+          "parity": true,
+          "peak_rss_bytes": 60096512,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 345,
+          "rss_delta_bytes": 1540096,
+          "rss_end_bytes": 60096512,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 2389.833,
+            "p50": 2389.833,
+            "p95": 2539.066,
+            "p99": 2632.748
+          },
+          "parity": true,
+          "peak_rss_bytes": 60948480,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 345,
+          "rss_delta_bytes": 819200,
+          "rss_end_bytes": 60948480,
+          "unique_requests": 1000
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 655,
+            "hits": 0,
+            "invalidations": 0,
+            "misses": 1000,
+            "result_row_capacity": 65536,
+            "result_rows": 65500
+          },
+          "cache_hit_ratio": 0.0,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 2358.979,
+            "p50": 2358.979,
+            "p95": 2500.162,
+            "p99": 2612.354
+          },
+          "parity": true,
+          "peak_rss_bytes": 60948480,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 345,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 60948480,
+          "unique_requests": 1000
+        }
+      ],
+      "uniform": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 512,
+            "hits": 25,
+            "invalidations": 0,
+            "misses": 975,
+            "result_row_capacity": 65536,
+            "result_rows": 512
+          },
+          "cache_hit_ratio": 0.025,
+          "capacity": 512,
+          "entry_pressure_evictions": 463,
+          "latency_us": {
+            "median": 517.188,
+            "p50": 517.188,
+            "p95": 567.375,
+            "p99": 610.926
+          },
+          "parity": true,
+          "peak_rss_bytes": 60948480,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 60948480,
+          "unique_requests": 967
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 967,
+            "hits": 33,
+            "invalidations": 0,
+            "misses": 967,
+            "result_row_capacity": 65536,
+            "result_rows": 967
+          },
+          "cache_hit_ratio": 0.033,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 521.812,
+            "p50": 521.812,
+            "p95": 571.809,
+            "p99": 607.779
+          },
+          "parity": true,
+          "peak_rss_bytes": 61243392,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61243392,
+          "unique_requests": 967
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 967,
+            "hits": 33,
+            "invalidations": 0,
+            "misses": 967,
+            "result_row_capacity": 65536,
+            "result_rows": 967
+          },
+          "cache_hit_ratio": 0.033,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 521.375,
+            "p50": 521.375,
+            "p95": 572.504,
+            "p99": 608.253
+          },
+          "parity": true,
+          "peak_rss_bytes": 61259776,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61259776,
+          "unique_requests": 967
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 967,
+            "hits": 33,
+            "invalidations": 0,
+            "misses": 967,
+            "result_row_capacity": 65536,
+            "result_rows": 967
+          },
+          "cache_hit_ratio": 0.033,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 523.583,
+            "p50": 523.583,
+            "p95": 571.175,
+            "p99": 612.609
+          },
+          "parity": true,
+          "peak_rss_bytes": 61259776,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61259776,
+          "unique_requests": 967
+        }
+      ],
+      "zipf": [
+        {
+          "cache": {
+            "capacity": 512,
+            "entries": 414,
+            "hits": 586,
+            "invalidations": 0,
+            "misses": 414,
+            "result_row_capacity": 65536,
+            "result_rows": 414
+          },
+          "cache_hit_ratio": 0.586,
+          "capacity": 512,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.708,
+            "p50": 1.708,
+            "p95": 548.669,
+            "p99": 573.339
+          },
+          "parity": true,
+          "peak_rss_bytes": 61292544,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61292544,
+          "unique_requests": 414
+        },
+        {
+          "cache": {
+            "capacity": 2048,
+            "entries": 414,
+            "hits": 586,
+            "invalidations": 0,
+            "misses": 414,
+            "result_row_capacity": 65536,
+            "result_rows": 414
+          },
+          "cache_hit_ratio": 0.586,
+          "capacity": 2048,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.667,
+            "p50": 1.667,
+            "p95": 551.021,
+            "p99": 575.259
+          },
+          "parity": true,
+          "peak_rss_bytes": 61292544,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61292544,
+          "unique_requests": 414
+        },
+        {
+          "cache": {
+            "capacity": 8192,
+            "entries": 414,
+            "hits": 586,
+            "invalidations": 0,
+            "misses": 414,
+            "result_row_capacity": 65536,
+            "result_rows": 414
+          },
+          "cache_hit_ratio": 0.586,
+          "capacity": 8192,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.667,
+            "p50": 1.667,
+            "p95": 555.171,
+            "p99": 585.133
+          },
+          "parity": true,
+          "peak_rss_bytes": 61292544,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61292544,
+          "unique_requests": 414
+        },
+        {
+          "cache": {
+            "capacity": 16384,
+            "entries": 414,
+            "hits": 586,
+            "invalidations": 0,
+            "misses": 414,
+            "result_row_capacity": 65536,
+            "result_rows": 414
+          },
+          "cache_hit_ratio": 0.586,
+          "capacity": 16384,
+          "entry_pressure_evictions": 0,
+          "latency_us": {
+            "median": 1.625,
+            "p50": 1.625,
+            "p95": 543.81,
+            "p99": 583.722
+          },
+          "parity": true,
+          "peak_rss_bytes": 61292544,
+          "repetition": 1,
+          "requests": 1000,
+          "row_pressure_evictions": 0,
+          "rss_delta_bytes": 0,
+          "rss_end_bytes": 61292544,
+          "unique_requests": 414
+        }
+      ]
+    },
+    "corpus_build_seconds": 0.005445,
+    "multi_corpus": {
+      "corpora": 4,
+      "parity": true,
+      "peak_rss_bytes": 63930368,
+      "requests_per_corpus": 1000,
+      "rss_end_bytes": 63930368,
+      "wall_seconds": 2.080604
+    },
+    "mutation_storm": {
+      "cache": {
+        "capacity": 8192,
+        "entries": 10,
+        "hits": 0,
+        "invalidations": 99,
+        "misses": 10,
+        "result_row_capacity": 65536,
+        "result_rows": 10
+      },
+      "invalidation_latency_us_p99": 4.34,
+      "parity": true,
+      "rebuild_latency_us_p99": 5527.052
+    }
+  },
+  "production_default_entries": 8192
+}

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -1,0 +1,77 @@
+---
+type: Decision
+title: BM25 query-cache capacity decision
+description: Reproducible workload, latency, memory, churn, and parity evidence for the 8,192-entry BM25 query-cache default.
+resource: src/graph/generational_cache.py
+tags: [bm25, cache, performance, benchmark, capacity]
+generated: { by: human:marco-porcellato, at: '2026-08-07T00:00:00Z' }
+verified: { by: human:marco-porcellato, at: '2026-08-07T00:00:00Z' }
+last_verified: 2026-08-07
+stale_after: 2027-02-03
+status: stable
+classification: canonical
+canonical_for: performance.bm25-query-cache-capacity
+audience: [maintainer, contributor, agent]
+owner: core-runtime
+supersedes: []
+related:
+  - /architecture/cache-friendly-retrieval.md
+legacy_sources:
+  - ../../../scripts/bench_bm25_query_cache.py
+  - ../../../benchmarks/results/bm25_query_cache_capacity_macos_arm64_2026-08-07.json
+  - ../../../benchmarks/results/bm25_query_cache_large_corpus_macos_arm64_2026-08-07.json
+---
+
+# BM25 query-cache capacity decision
+
+## Decision
+
+Keep **8,192 entries** and **65,536 result rows** as the production defaults. The evidence does not justify doubling the entry capacity to 16,384.
+
+This decision changes no runtime behavior. It closes the evidence gap tracked by [issue #392](https://github.com/MarcoPorcellato/matryca-plumber/issues/392) and must be revisited only with stronger live-corpus or cross-platform evidence.
+
+## Reproducible evidence
+
+Both runs use Python 3.12.13 on macOS 15.7.3 arm64, seed `20260802`, and benchmark source commit `5ef1418602a0363b2e9457920e9af34011743507`. Every measured request asserts exact result parity before contributing latency data.
+
+| Profile | Corpus | Requests | Repetitions | Purpose | Raw result |
+| --- | ---: | ---: | ---: | --- | --- |
+| Capacity | 128 documents | 20,000 | 3 | Working-set pressure across 512, 2,048, 8,192, and 16,384 entries | [JSON](../../../benchmarks/results/bm25_query_cache_capacity_macos_arm64_2026-08-07.json) |
+| Large corpus | 8,192 documents | 1,000 | 1 | Four concurrent corpora, rebuild cost, RSS, and large-corpus latency | [JSON](../../../benchmarks/results/bm25_query_cache_large_corpus_macos_arm64_2026-08-07.json) |
+
+Reproduce from the bound commit:
+
+```bash
+uv run python scripts/bench_bm25_query_cache.py \
+  --output benchmarks/results/bm25_query_cache_capacity_macos_arm64_2026-08-07.json
+
+uv run python scripts/bench_bm25_query_cache.py \
+  --documents 8192 --requests 1000 --repetitions 1 --warmup 128 \
+  --capacities 512,2048,8192,16384 --multi-corpora 4 \
+  --output benchmarks/results/bm25_query_cache_large_corpus_macos_arm64_2026-08-07.json
+```
+
+## Capacity results
+
+Values are medians across three repetitions. Hit ratios are exact deterministic run ratios; p99 is microseconds.
+
+| Workload | 512 hit / p99 | 2,048 hit / p99 | 8,192 hit / p99 | 16,384 hit / p99 |
+| --- | ---: | ---: | ---: | ---: |
+| Hot 80/20 | 9.880% / 17.791 | 36.710% / 15.250 | **66.385% / 14.000** | 66.385% / 14.084 |
+| Uniform | 3.135% / 17.792 | 11.675% / 20.293 | **37.155% / 18.000** | 42.340% / 17.708 |
+| Zipf | 67.485% / 13.166 | 78.625% / 12.625 | **80.725% / 12.625** | 80.725% / 12.542 |
+| Full-key replay | 0% / 19.417 | 0% / 19.042 | **0% / 20.750** | 18.080% / 19.500 |
+
+The 16,384-entry candidate adds no hit-rate benefit for the representative hot or Zipf distributions. It adds 5.185 percentage points for broad uniform traffic and benefits the deliberately adversarial replay of all 16,384 keys. Those cases do not outweigh the doubled retention ceiling without live-corpus evidence showing a comparable working set.
+
+## Memory, row pressure, and churn
+
+- The 8,192 capacity-pressure phase retained 8,192 entries and 8,192 result rows. Its largest observed per-run RSS delta was 2,195,456 bytes. The 16,384 phase retained 16,384 entries and rows with a 3,702,784-byte largest delta.
+- Broad `limit=100` queries reached 65,500 retained rows and only 655 entries at every entry capacity of 2,048 or greater. The row budget therefore bounds memory before the entry limit for broad results.
+- The 128-document mutation probe completed 99 invalidations with 15.429 microseconds p99 invalidation latency and 109.949 microseconds p99 rebuild latency.
+- The 8,192-document probe completed 99 invalidations with 4.340 microseconds p99 invalidation latency and 5,527.052 microseconds p99 rebuild latency.
+- Four concurrent 8,192-document corpora preserved parity, completed 1,000 requests per corpus in 2.080604 seconds, and ended at 63,930,368 bytes RSS in the benchmark process.
+
+## Evidence boundary
+
+These are deterministic synthetic results, not live-vault qualification. RSS and process peak are measured in one sequential benchmark process, so allocator reuse and cumulative peak state make per-capacity memory deltas directional rather than isolated. The run covers one arm64 macOS machine and one fixed seed. A future capacity increase requires representative sanitized live-corpus traces, isolated-process memory measurements, and cross-platform confirmation without material p99 or correctness regression.

--- a/docs/knowledge/architecture/index.md
+++ b/docs/knowledge/architecture/index.md
@@ -8,6 +8,7 @@ Progressive-disclosure index for maintained system concepts. [`docs/ARCHITECTURE
 - [Graph plane](graph-plane.md) — Markdown SSOT, parser, OCC, locks, sandbox, `graph_dispatch`.
 - [Shadow DB](shadow-db.md) — Opt-in SQLite read cache, sync, health, routing, fallback (`v2.0.0-alpha`+).
 - [Cache-friendly retrieval](cache-friendly-retrieval.md) — Retrieval/context cache boundaries, deterministic output, and staged validation.
+- [BM25 query-cache capacity](bm25-query-cache-capacity.md) — Reproducible capacity, latency, RSS, churn, and parity decision for the 8,192-entry default.
 - [LLM-free information-cluster recognition](llm-free-cluster-recognition.md) — Deterministic feature generations, clustering quality, invalidation, and reuse across related-note functions.
 
 ## Planned concepts

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -1,5 +1,9 @@
 # Documentation update log
 
+## 2026-08-07
+
+- **Performance evidence:** Added the reproducible BM25 query-cache capacity decision, raw benchmark bindings, memory envelope, and synthetic-evidence boundary.
+
 ## 2026-08-06
 
 - **Upgrade:** Aligned the maintained bundle with the pinned Open Knowledge Format v0.2 contract.

--- a/scripts/bench_bm25_query_cache.py
+++ b/scripts/bench_bm25_query_cache.py
@@ -86,24 +86,30 @@ def _corpus(document_count: int, *, namespace: str = "") -> Bm25Corpus:
 
 def _workloads(config: BenchmarkConfig) -> dict[str, list[Request]]:
     rng = random.Random(config.seed)
-    documents = tuple(f"document{index}" for index in range(config.documents))
-    hot_count = max(1, config.documents // 5)
-    cold_documents = documents[hot_count:] or documents
-    weights = tuple(1.0 / ((index + 1) ** 1.1) for index in range(config.documents))
+    key_count = max(config.capacities)
+    query_keys = tuple(
+        f"document{index % config.documents} nonce{index}" for index in range(key_count)
+    )
+    hot_count = max(1, key_count // 5)
+    cold_keys = query_keys[hot_count:] or query_keys
+    weights = tuple(1.0 / ((index + 1) ** 1.1) for index in range(key_count))
 
-    uniform = [Request(rng.choice(documents), 8) for _ in range(config.requests)]
+    uniform = [Request(rng.choice(query_keys), 8) for _ in range(config.requests)]
     hot_80_20 = [
         Request(
-            rng.choice(documents[:hot_count] if rng.random() < 0.8 else cold_documents),
+            rng.choice(query_keys[:hot_count] if rng.random() < 0.8 else cold_keys),
             8,
         )
         for _ in range(config.requests)
     ]
     zipf = [
-        Request(query, 8) for query in rng.choices(documents, weights=weights, k=config.requests)
+        Request(query, 8) for query in rng.choices(query_keys, weights=weights, k=config.requests)
     ]
     capacity_pressure = [
-        Request(f"absent{index}", _RESULT_LIMITS[index % len(_RESULT_LIMITS)])
+        Request(
+            query_keys[index % key_count],
+            _RESULT_LIMITS[index % len(_RESULT_LIMITS)],
+        )
         for index in range(config.requests)
     ]
     row_pressure = [Request(f"shared absent{index}", 100) for index in range(config.requests)]
@@ -344,6 +350,7 @@ def run_benchmark(config: BenchmarkConfig) -> dict[str, Any]:
         "benchmark_schema_version": 1,
         "config": asdict(config),
         "corpus_manifest": {
+            "benchmark_query_key_cardinality": max(config.capacities),
             "documents": config.documents,
             "terms_per_document": 4,
             "topic_cardinality": 64,

--- a/scripts/bench_bm25_query_cache.py
+++ b/scripts/bench_bm25_query_cache.py
@@ -1,26 +1,67 @@
-"""Measure synthetic, LLM-free BM25 query-cache cold and warm paths."""
+"""Run deterministic, LLM-free BM25 query-cache decision benchmarks."""
 
 from __future__ import annotations
 
+import argparse
+import importlib
 import json
+import math
+import os
+import platform
 import random
+import subprocess
+import sys
 import time
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from statistics import median
+from typing import Any, NamedTuple
 
 import src.graph.generational_cache as generational_cache
 from src.graph.generational_cache import Bm25Corpus, bm25_query_cache_stats, score_bm25_query
 
-_DOCUMENTS = 8_192
-_REQUESTS = 16_000
+resource_module: Any
+try:
+    resource_module = importlib.import_module("resource")
+except ImportError:  # pragma: no cover - Windows uses the optional edge dependency
+    resource_module = None
+
+psutil_module: Any
+try:
+    psutil_module = importlib.import_module("psutil")
+except ImportError:  # pragma: no cover - POSIX falls back to ps(1)
+    psutil_module = None
+
 _SEED = 20260802
-_CAPACITIES = (512, 1_024, 2_048, 4_096, 8_192)
+_CAPACITIES = (512, 2_048, 8_192, 16_384)
+_DEFAULT_CAPACITY = 8_192
+_RESULT_LIMITS = (1, 8, 32, 100)
 
 
-def _corpus() -> Bm25Corpus:
+class Request(NamedTuple):
+    query: str
+    limit: int
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkConfig:
+    documents: int
+    requests: int
+    repetitions: int
+    warmup: int
+    seed: int
+    capacities: tuple[int, ...]
+    multi_corpora: int
+
+
+def _corpus(document_count: int, *, namespace: str = "") -> Bm25Corpus:
     rels: list[str] = []
     doc_term_freqs: list[dict[str, int]] = []
     doc_lens: list[int] = []
     df: dict[str, int] = {}
-    for index in range(_DOCUMENTS):
+    for index in range(document_count):
         tokens = [
             "shared",
             f"topic{index % 64}",
@@ -28,7 +69,7 @@ def _corpus() -> Bm25Corpus:
             f"document{index}",
         ]
         term_freqs = {token: tokens.count(token) for token in tokens}
-        rels.append(f"pages/{index:05d}.md")
+        rels.append(f"{namespace}pages/{index:05d}.md")
         doc_term_freqs.append(term_freqs)
         doc_lens.append(len(tokens))
         for token in term_freqs:
@@ -38,72 +79,335 @@ def _corpus() -> Bm25Corpus:
         doc_term_freqs=doc_term_freqs,
         doc_lens=doc_lens,
         df=df,
-        n_docs=_DOCUMENTS,
-        avgdl=sum(doc_lens) / _DOCUMENTS,
+        n_docs=document_count,
+        avgdl=sum(doc_lens) / document_count,
     )
 
 
-def _uniform_random_requests() -> list[str]:
-    rng = random.Random(_SEED)
-    return [f"document{rng.randrange(_DOCUMENTS)}" for _ in range(_REQUESTS)]
+def _workloads(config: BenchmarkConfig) -> dict[str, list[Request]]:
+    rng = random.Random(config.seed)
+    documents = tuple(f"document{index}" for index in range(config.documents))
+    hot_count = max(1, config.documents // 5)
+    cold_documents = documents[hot_count:] or documents
+    weights = tuple(1.0 / ((index + 1) ** 1.1) for index in range(config.documents))
 
-
-def _hot_set_random_requests() -> list[str]:
-    rng = random.Random(_SEED)
-    hot_set = [f"document{rng.randrange(_DOCUMENTS)}" for _ in range(64)]
-    return [rng.choice(hot_set) for _ in range(_REQUESTS)]
-
-
-def _measure(corpus: Bm25Corpus, requests: list[str], *, force_miss: bool) -> float:
-    started = time.perf_counter()
-    for query in requests:
-        if force_miss:
-            with corpus._query_lock:
-                corpus.query_cache.clear()
-                corpus.query_cache_result_rows = 0
-        score_bm25_query(corpus, query, limit=8)
-    return time.perf_counter() - started
-
-
-def _benchmark_capacities(
-    requests: list[str],
-) -> list[dict[str, float | int | dict[str, int]]]:
-    uncached = _corpus()
-    uncached_seconds = _measure(uncached, requests, force_miss=True)
-
-    results: list[dict[str, float | int | dict[str, int]]] = []
-    for capacity in _CAPACITIES:
-        generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES = capacity
-        cached = _corpus()
-        cached_seconds = _measure(cached, requests, force_miss=False)
-        results.append(
-            {
-                "cache": bm25_query_cache_stats(cached),
-                "cached_seconds": round(cached_seconds, 6),
-                "speedup": (round(uncached_seconds / cached_seconds, 2) if cached_seconds else 0.0),
-                "uncached_seconds": round(uncached_seconds, 6),
-                "unique_requests": len(set(requests)),
-            }
+    uniform = [Request(rng.choice(documents), 8) for _ in range(config.requests)]
+    hot_80_20 = [
+        Request(
+            rng.choice(documents[:hot_count] if rng.random() < 0.8 else cold_documents),
+            8,
         )
-    return results
+        for _ in range(config.requests)
+    ]
+    zipf = [
+        Request(query, 8) for query in rng.choices(documents, weights=weights, k=config.requests)
+    ]
+    capacity_pressure = [
+        Request(f"absent{index}", _RESULT_LIMITS[index % len(_RESULT_LIMITS)])
+        for index in range(config.requests)
+    ]
+    row_pressure = [Request(f"shared absent{index}", 100) for index in range(config.requests)]
+    edge_cases = [
+        Request("", 8),
+        Request("   ", 8),
+        Request("shared shared", 1),
+        Request("shared shared", 8),
+        Request("missing-token", 32),
+        Request("topic1 bucket1", 100),
+    ]
+    return {
+        "capacity_pressure": capacity_pressure,
+        "edge_cases": edge_cases,
+        "hot_80_20": hot_80_20,
+        "row_pressure": row_pressure,
+        "uniform": uniform,
+        "zipf": zipf,
+    }
 
 
-def main() -> None:
+def _percentile(sorted_values: Sequence[int], percentile: float) -> float:
+    if not sorted_values:
+        return 0.0
+    position = (len(sorted_values) - 1) * percentile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return float(sorted_values[lower])
+    weight = position - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def _current_rss_bytes() -> int:
+    if psutil_module is not None:
+        return int(psutil_module.Process().memory_info().rss)
+    if os.name != "posix":
+        raise RuntimeError("current RSS measurement requires the 'edge' dependency")
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(os.getpid())],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return int(completed.stdout.strip()) * 1_024
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return _peak_rss_bytes()
+
+
+def _peak_rss_bytes() -> int:
+    if resource_module is None:
+        raise RuntimeError("peak RSS measurement requires the 'edge' dependency")
+    peak = resource_module.getrusage(resource_module.RUSAGE_SELF).ru_maxrss
+    return int(peak if sys.platform == "darwin" else peak * 1_024)
+
+
+def _reset_query_cache(corpus: Bm25Corpus, *, invalidation: bool = False) -> None:
+    with corpus._query_lock:
+        corpus.query_cache.clear()
+        corpus.query_cache_hits = 0
+        corpus.query_cache_misses = 0
+        corpus.query_cache_result_rows = 0
+        if invalidation:
+            corpus.query_cache_invalidations += 1
+
+
+def _expected_results(corpus: Bm25Corpus, requests: Sequence[Request]) -> dict[Request, Any]:
+    expected: dict[Request, Any] = {}
+    for request in dict.fromkeys(requests):
+        expected[request] = score_bm25_query(corpus, request.query, limit=request.limit)
+    return expected
+
+
+def _measure_workload(
+    corpus: Bm25Corpus,
+    requests: Sequence[Request],
+    expected: dict[Request, Any],
+    *,
+    warmup: int,
+) -> dict[str, Any]:
+    for request in requests[:warmup]:
+        score_bm25_query(corpus, request.query, limit=request.limit)
+    _reset_query_cache(corpus)
+
+    latencies_ns: list[int] = []
+    entry_pressure_evictions = 0
+    row_pressure_evictions = 0
+    rss_before = _current_rss_bytes()
+    for request in requests:
+        before = bm25_query_cache_stats(corpus)
+        started = time.perf_counter_ns()
+        observed = score_bm25_query(corpus, request.query, limit=request.limit)
+        latencies_ns.append(time.perf_counter_ns() - started)
+        if observed != expected[request]:
+            raise AssertionError(f"BM25 parity failed for {request!r}")
+        after = bm25_query_cache_stats(corpus)
+        if after["misses"] > before["misses"]:
+            if before["entries"] + 1 > before["capacity"]:
+                entry_pressure_evictions += 1
+            if before["result_rows"] + len(observed) > before["result_row_capacity"]:
+                row_pressure_evictions += 1
+
+    stats = bm25_query_cache_stats(corpus)
+    sorted_latencies = sorted(latencies_ns)
+    cacheable = stats["hits"] + stats["misses"]
+    return {
+        "cache": stats,
+        "cache_hit_ratio": round(stats["hits"] / cacheable, 6) if cacheable else 0.0,
+        "entry_pressure_evictions": entry_pressure_evictions,
+        "latency_us": {
+            "median": round(median(sorted_latencies) / 1_000, 3),
+            "p50": round(_percentile(sorted_latencies, 0.50) / 1_000, 3),
+            "p95": round(_percentile(sorted_latencies, 0.95) / 1_000, 3),
+            "p99": round(_percentile(sorted_latencies, 0.99) / 1_000, 3),
+        },
+        "parity": True,
+        "peak_rss_bytes": _peak_rss_bytes(),
+        "requests": len(requests),
+        "row_pressure_evictions": row_pressure_evictions,
+        "rss_delta_bytes": _current_rss_bytes() - rss_before,
+        "rss_end_bytes": _current_rss_bytes(),
+        "unique_requests": len(set(requests)),
+    }
+
+
+def _capacity_matrix(config: BenchmarkConfig) -> dict[str, list[dict[str, Any]]]:
+    workloads = _workloads(config)
+    expected = {
+        name: _expected_results(_corpus(config.documents), requests)
+        for name, requests in workloads.items()
+    }
+    matrix: dict[str, list[dict[str, Any]]] = {}
+    for name, requests in workloads.items():
+        matrix[name] = []
+        for capacity in config.capacities:
+            for repetition in range(config.repetitions):
+                generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES = capacity
+                measured = _measure_workload(
+                    _corpus(config.documents),
+                    requests,
+                    expected[name],
+                    warmup=min(config.warmup, len(requests)),
+                )
+                matrix[name].append(
+                    {"capacity": capacity, "repetition": repetition + 1, **measured}
+                )
+    return matrix
+
+
+def _mutation_probe(config: BenchmarkConfig) -> dict[str, Any]:
+    corpus = _corpus(config.documents)
+    requests = _workloads(config)["hot_80_20"]
+    expected = _expected_results(_corpus(config.documents), requests)
+    latencies_ns: list[int] = []
+    rebuild_ns: list[int] = []
+    every = max(1, len(requests) // 100)
+    for index, request in enumerate(requests):
+        if index and index % every == 0:
+            started = time.perf_counter_ns()
+            _reset_query_cache(corpus, invalidation=True)
+            latencies_ns.append(time.perf_counter_ns() - started)
+        if index and index % (every * 10) == 0:
+            started = time.perf_counter_ns()
+            _corpus(config.documents)
+            rebuild_ns.append(time.perf_counter_ns() - started)
+        if score_bm25_query(corpus, request.query, limit=request.limit) != expected[request]:
+            raise AssertionError("BM25 parity failed during mutation probe")
+    return {
+        "cache": bm25_query_cache_stats(corpus),
+        "invalidation_latency_us_p99": round(_percentile(sorted(latencies_ns), 0.99) / 1_000, 3),
+        "parity": True,
+        "rebuild_latency_us_p99": round(_percentile(sorted(rebuild_ns), 0.99) / 1_000, 3),
+    }
+
+
+def _multi_corpus_probe(config: BenchmarkConfig) -> dict[str, Any]:
+    requests = _workloads(config)["uniform"]
+    corpora = [
+        _corpus(config.documents, namespace=f"graph{index}/")
+        for index in range(config.multi_corpora)
+    ]
+    expected = [
+        _expected_results(
+            _corpus(config.documents, namespace=f"graph{index}/"),
+            requests,
+        )
+        for index in range(config.multi_corpora)
+    ]
+
+    def run(index: int) -> None:
+        corpus = corpora[index]
+        for request in requests:
+            if (
+                score_bm25_query(corpus, request.query, limit=request.limit)
+                != expected[index][request]
+            ):
+                raise AssertionError(f"BM25 parity failed for corpus {index}")
+
+    started = time.perf_counter_ns()
+    with ThreadPoolExecutor(max_workers=config.multi_corpora) as executor:
+        list(executor.map(run, range(config.multi_corpora)))
+    return {
+        "corpora": config.multi_corpora,
+        "parity": True,
+        "peak_rss_bytes": _peak_rss_bytes(),
+        "requests_per_corpus": len(requests),
+        "rss_end_bytes": _current_rss_bytes(),
+        "wall_seconds": round((time.perf_counter_ns() - started) / 1_000_000_000, 6),
+    }
+
+
+def _source_commit() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    return completed.stdout.strip()
+
+
+def run_benchmark(config: BenchmarkConfig) -> dict[str, Any]:
     original_capacity = generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES
     try:
-        payload = {
-            "documents": _DOCUMENTS,
-            "requests": _REQUESTS,
-            "seed": _SEED,
-            "workloads": {
-                "hot_set_random": _benchmark_capacities(_hot_set_random_requests()),
-                "uniform_random": _benchmark_capacities(_uniform_random_requests()),
-            },
-        }
+        build_started = time.perf_counter_ns()
+        _corpus(config.documents)
+        build_seconds = (time.perf_counter_ns() - build_started) / 1_000_000_000
+        matrix = _capacity_matrix(config)
+        generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES = _DEFAULT_CAPACITY
+        mutation = _mutation_probe(config)
+        multi_corpus = _multi_corpus_probe(config)
     finally:
         generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES = original_capacity
-    print(json.dumps(payload, sort_keys=True))
+    return {
+        "benchmark_schema_version": 1,
+        "config": asdict(config),
+        "corpus_manifest": {
+            "documents": config.documents,
+            "terms_per_document": 4,
+            "topic_cardinality": 64,
+            "bucket_cardinality": 29,
+        },
+        "environment": {
+            "machine": platform.machine(),
+            "os": platform.platform(),
+            "python": platform.python_version(),
+            "source_commit": _source_commit(),
+        },
+        "measurements": {
+            "capacity_matrix": matrix,
+            "corpus_build_seconds": round(build_seconds, 6),
+            "multi_corpus": multi_corpus,
+            "mutation_storm": mutation,
+        },
+        "production_default_entries": original_capacity,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--documents", type=int, default=128)
+    parser.add_argument("--requests", type=int, default=20_000)
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=512)
+    parser.add_argument("--seed", type=int, default=_SEED)
+    parser.add_argument("--capacities", default="512,2048,8192,16384")
+    parser.add_argument("--multi-corpora", type=int, default=4)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    capacities = tuple(int(value) for value in args.capacities.split(","))
+    if (
+        args.documents < 1
+        or args.requests < 1
+        or args.repetitions < 1
+        or args.warmup < 0
+        or args.multi_corpora < 1
+        or not capacities
+        or any(capacity < 1 for capacity in capacities)
+    ):
+        raise SystemExit("benchmark dimensions and capacities must be positive")
+    config = BenchmarkConfig(
+        documents=args.documents,
+        requests=args.requests,
+        repetitions=args.repetitions,
+        warmup=args.warmup,
+        seed=args.seed,
+        capacities=capacities,
+        multi_corpora=args.multi_corpora,
+    )
+    rendered = json.dumps(run_benchmark(config), indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(rendered, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -42,6 +42,15 @@ def test_workloads_are_deterministic_and_cover_required_distributions(
     assert len(set(first["uniform"])) > config.capacities[0]
 
 
+def test_default_cli_profile_pressures_the_largest_candidate_capacity() -> None:
+    args = benchmark._parser().parse_args([])
+    capacities = tuple(int(value) for value in args.capacities.split(","))
+
+    assert args.requests > max(capacities)
+    assert args.repetitions >= 3
+    assert args.warmup > 0
+
+
 def test_benchmark_matrix_preserves_parity_and_capacity_bounds(
     config: benchmark.BenchmarkConfig,
 ) -> None:

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -1,0 +1,110 @@
+"""Tests for the deterministic BM25 query-cache benchmark harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import scripts.bench_bm25_query_cache as benchmark
+
+
+@pytest.fixture
+def config() -> benchmark.BenchmarkConfig:
+    return benchmark.BenchmarkConfig(
+        documents=16,
+        requests=24,
+        repetitions=1,
+        warmup=4,
+        seed=7,
+        capacities=(4, 16),
+        multi_corpora=2,
+    )
+
+
+def test_workloads_are_deterministic_and_cover_required_distributions(
+    config: benchmark.BenchmarkConfig,
+) -> None:
+    first = benchmark._workloads(config)
+    second = benchmark._workloads(config)
+
+    assert first == second
+    assert set(first) == {
+        "capacity_pressure",
+        "edge_cases",
+        "hot_80_20",
+        "row_pressure",
+        "uniform",
+        "zipf",
+    }
+    assert {request.limit for request in first["capacity_pressure"]} == {1, 8, 32, 100}
+    assert any(not request.query.strip() for request in first["edge_cases"])
+
+
+def test_benchmark_matrix_preserves_parity_and_capacity_bounds(
+    config: benchmark.BenchmarkConfig,
+) -> None:
+    payload = benchmark.run_benchmark(config)
+
+    assert payload["production_default_entries"] == 8_192
+    assert payload["config"] == {
+        "capacities": (4, 16),
+        "documents": 16,
+        "multi_corpora": 2,
+        "repetitions": 1,
+        "requests": 24,
+        "seed": 7,
+        "warmup": 4,
+    }
+    for runs in payload["measurements"]["capacity_matrix"].values():
+        for run in runs:
+            assert run["parity"] is True
+            assert run["cache"]["entries"] <= run["cache"]["capacity"]
+            assert run["cache"]["result_rows"] <= run["cache"]["result_row_capacity"]
+            assert set(run["latency_us"]) == {"median", "p50", "p95", "p99"}
+            assert run["peak_rss_bytes"] > 0
+            assert run["rss_end_bytes"] > 0
+
+    entry_pressure = payload["measurements"]["capacity_matrix"]["capacity_pressure"]
+    assert entry_pressure[0]["entry_pressure_evictions"] > 0
+
+    mutation = payload["measurements"]["mutation_storm"]
+    assert mutation["parity"] is True
+    assert mutation["cache"]["invalidations"] > 0
+    assert mutation["invalidation_latency_us_p99"] >= 0
+    assert mutation["rebuild_latency_us_p99"] >= 0
+
+    multi_corpus = payload["measurements"]["multi_corpus"]
+    assert multi_corpus["parity"] is True
+    assert multi_corpus["corpora"] == config.multi_corpora
+    assert multi_corpus["peak_rss_bytes"] > 0
+    assert multi_corpus["rss_end_bytes"] > 0
+
+
+def test_main_writes_machine_readable_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "result.json"
+    monkeypatch.setattr(benchmark, "_source_commit", lambda: "a" * 40)
+
+    assert (
+        benchmark.main(
+            [
+                "--documents",
+                "8",
+                "--requests",
+                "12",
+                "--capacities",
+                "4,8",
+                "--multi-corpora",
+                "2",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["benchmark_schema_version"] == 1
+    assert payload["environment"]["source_commit"] == "a" * 40

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -39,6 +39,7 @@ def test_workloads_are_deterministic_and_cover_required_distributions(
     }
     assert {request.limit for request in first["capacity_pressure"]} == {1, 8, 32, 100}
     assert any(not request.query.strip() for request in first["edge_cases"])
+    assert len(set(first["uniform"])) > config.capacities[0]
 
 
 def test_benchmark_matrix_preserves_parity_and_capacity_bounds(
@@ -67,6 +68,7 @@ def test_benchmark_matrix_preserves_parity_and_capacity_bounds(
 
     entry_pressure = payload["measurements"]["capacity_matrix"]["capacity_pressure"]
     assert entry_pressure[0]["entry_pressure_evictions"] > 0
+    assert entry_pressure[-1]["cache_hit_ratio"] > entry_pressure[0]["cache_hit_ratio"]
 
     mutation = payload["measurements"]["mutation_storm"]
     assert mutation["parity"] is True


### PR DESCRIPTION
## Summary

- replace the narrow cold/warm script with a deterministic BM25 capacity matrix covering 512, 2,048, 8,192, and 16,384 entries;
- measure uniform, hot 80/20, Zipf, full-key, row-pressure, edge-case, mutation-storm, and concurrent-corpus workloads with p50/p95/p99, hit ratio, RSS, eviction, rebuild, and exact parity evidence;
- commit two machine-readable macOS arm64 result profiles bound to benchmark source commit `5ef1418602a0363b2e9457920e9af34011743507`;
- document the governed decision to retain the 8,192-entry and 65,536-result-row defaults.

## Decision

8,192 matches 16,384 on the representative hot 80/20 and Zipf workloads. The larger candidate only improves the broad uniform and adversarial full-key cases, while the row budget already dominates broad result sets. Keep the current defaults until sanitized live-corpus, isolated-memory, and cross-platform evidence justifies a change.

## Test plan

- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy src/ tests/`
- [x] focused benchmark and current-main integration tests: 20 passed
- [x] documentation, agent-coherence, sandbox-read, version, public-metrics, and generated-prompt checks
- [x] full local suite: 1,600 passed, 5 skipped; the single sandbox-denied `ps` probe passed on an unsandboxed focused rerun
- [x] both raw result profiles pass schema, source-commit, mutation, multi-corpus, and all-request parity validation

## Evidence boundary

Results are deterministic and synthetic, from one macOS arm64 machine and one fixed seed. They do not claim live-vault or cross-platform qualification.

Closes #392
