### PR TITLE
fix: isolate read-only startup logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Read-only startup log isolation (#388)** — redirect graph-local ops and Loguru paths to the validated external per-graph runtime cache before directory creation, preserve explicitly external paths, and bind Loguru to its configured sink rather than the ops JSONL path.
 - **Gate B RC artifact and timing binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1`, and include measured probe time so valid profile probes advance the resumable soak instead of retrying as `probe_invalid`, while preserving the historical beta collector's default contract.
 
 ## [2.0.0-rc.1] - 2026-08-03

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -25,7 +25,9 @@ If `LOGSEQ_GRAPH_PATH` is unset or invalid, only **log directories** are ensured
 
 With `MATRYCA_READ_ONLY=true`, every entry surface still runs the light runtime
 bootstrap, but graph-local provisioning, AST/identity refresh, write-back hooks, and
-sidecar maintenance are skipped. When Shadow is enabled, startup may read
+sidecar maintenance are skipped. A configured graph-local ops or Loguru path is
+redirected to the validated external per-graph runtime cache before any directory is
+created; explicitly external log paths keep their configured locations. When Shadow is enabled, startup may read
 `pages/` and `journals/` and create or reconcile only the validated external Shadow
 cache. Explicit Shadow-off remains zero-touch for that cache.
 
@@ -45,6 +47,15 @@ On first startup, if repo **`.env`** is missing and **`.env.example`** exists, M
 **Rationale:** Parent directories are created with `mkdir(parents=True, exist_ok=True)` so the Sovereign UI activity feed and Loguru rotation never fail on first write. Paths must resolve under allowed roots (`$HOME`, repo, temp) — see `src/utils/config_paths.py`.
 
 `configure_loguru()` delegates to the same helper so file sinks and bootstrap stay aligned.
+
+**Gate B impact decision (#388):** the published `2.0.0rc1`
+`read-only-external` profile uses an external cache and does not configure graph-local
+log overrides, so it cannot enter the corrected redirection branch. Existing Gate B
+credit remains evidence for the exact RC artifact and is not rewritten. A stable
+candidate that includes this fix must pass the focused MCP, CLI, UI, and daemon startup
+matrix with both graph-local and external log settings, including an unchanged
+byte-and-metadata graph manifest; the historical multi-day RC soak does not need to be
+restarted for this configuration-excluded branch.
 
 ### 2. L1 memory (when a valid graph is configured)
 

--- a/src/utils/config_paths.py
+++ b/src/utils/config_paths.py
@@ -77,10 +77,34 @@ def resolve_plumber_log_path(raw: str | None = None) -> Path:
     if raw:
         allowed = resolve_optional_path_under_allowed_roots(raw)
         if allowed is not None:
-            return allowed
+            return _read_only_safe_log_path(allowed)
     if _DEFAULT_OPS_LOG.is_absolute():
         return _DEFAULT_OPS_LOG
-    return Path(__file__).resolve().parents[2] / _DEFAULT_OPS_LOG
+    return _read_only_safe_log_path(Path(__file__).resolve().parents[2] / _DEFAULT_OPS_LOG)
+
+
+def _read_only_safe_log_path(path: Path) -> Path:
+    """Redirect a graph-local log target to this graph's external runtime cache."""
+    graph_root = _graph_root_candidate()
+    if graph_root is None:
+        return path
+
+    from ..graph.safety.write_policy import GraphReadOnlyError, RuntimeWritePolicy
+
+    policy = RuntimeWritePolicy.from_env(graph_root)
+    if not policy.read_only:
+        return path
+    try:
+        return policy.ensure_write_allowed(path, operation="create_log_path")
+    except GraphReadOnlyError as exc:
+        if exc.reason != "graph_root_mutation_blocked":
+            raise
+
+    from ..shadow.cache_location import resolve_shadow_cache_location
+
+    location = resolve_shadow_cache_location(policy.graph_root)
+    external_path = location.shadow_dir.parent / "logs" / path.name
+    return policy.ensure_write_allowed(external_path, operation="create_log_path")
 
 
 def graph_config_allowed_roots() -> list[Path]:
@@ -143,10 +167,10 @@ def resolve_loguru_log_path(raw: str | None = None) -> Path:
     if raw:
         allowed = resolve_optional_path_under_allowed_roots(raw)
         if allowed is not None:
-            return allowed
+            return _read_only_safe_log_path(allowed)
     if _DEFAULT_LOGURU_LOG.is_absolute():
         return _DEFAULT_LOGURU_LOG
-    return Path(__file__).resolve().parents[2] / _DEFAULT_LOGURU_LOG
+    return _read_only_safe_log_path(Path(__file__).resolve().parents[2] / _DEFAULT_LOGURU_LOG)
 
 
 __all__ = [

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -40,7 +40,7 @@ def configure_loguru(*, level: str = "INFO", stderr: bool = True) -> None:
 
     from .config_paths import ensure_plumber_log_directories
 
-    log_path, _ops_path = ensure_plumber_log_directories()
+    _ops_path, log_path = ensure_plumber_log_directories()
     logger.add(
         str(log_path),
         level=level,

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -21,3 +21,33 @@ def test_configure_loguru_registers_rotating_file_sink(
     assert log_path.is_file() or log_path.parent.is_dir()
 
     reset_loguru_configuration()
+
+
+@pytest.mark.parametrize("graph_local", [False, True])
+def test_configure_loguru_preserves_read_only_graph_immutability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    graph_local: bool,
+) -> None:
+    from src.shadow.cache_location import resolve_shadow_cache_location
+
+    reset_loguru_configuration()
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    cache = tmp_path / "external-cache"
+    configured_logs = graph / "logs" if graph_local else tmp_path / "external-logs"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(configured_logs / "ops.log"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(configured_logs / "app.log"))
+
+    configure_loguru(stderr=False)
+
+    expected_log = configured_logs / "app.log"
+    if graph_local:
+        expected_log = resolve_shadow_cache_location(graph).shadow_dir.parent / "logs" / "app.log"
+        assert not configured_logs.exists()
+    assert expected_log.is_file()
+
+    reset_loguru_configuration()

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from src.agent.l1_memory import collect_l1_markdown_paths, ensure_matryca_l1_dir
 from src.config import MatrycaWikiConfig
+from src.shadow.cache_location import resolve_shadow_cache_location
 from src.utils.config_paths import ensure_plumber_log_directories
 from src.utils.runtime_bootstrap import (
     ensure_graph_runtime_directories,
@@ -77,6 +78,29 @@ def test_ensure_plumber_log_directories(tmp_path: Path, monkeypatch: pytest.Monk
     assert resolved_loguru == loguru
     assert ops.parent.is_dir()
     assert loguru.parent.is_dir()
+
+
+def test_ensure_plumber_log_directories_redirects_graph_local_read_only_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "vault"
+    (graph / "pages").mkdir(parents=True)
+    cache = tmp_path / "external-cache"
+    graph_logs = graph / "logs"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(graph_logs / "ops.log"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(graph_logs / "app.log"))
+
+    resolved_ops, resolved_loguru = ensure_plumber_log_directories()
+
+    runtime_logs = resolve_shadow_cache_location(graph).shadow_dir.parent / "logs"
+    assert resolved_ops == runtime_logs / "ops.log"
+    assert resolved_loguru == runtime_logs / "app.log"
+    assert resolved_ops.parent.is_dir()
+    assert not graph_logs.exists()
 
 
 def test_collect_l1_skips_readme(tmp_path: Path) -> None:

--- a/tests/test_runtime_bootstrap_contract.py
+++ b/tests/test_runtime_bootstrap_contract.py
@@ -7,6 +7,9 @@ or L1 routing behavior changed unintentionally.
 
 from __future__ import annotations
 
+import hashlib
+import os
+import stat
 from pathlib import Path
 
 import pytest
@@ -16,6 +19,7 @@ from src.agent.l1_memory import (
     resolve_matryca_l1_directory,
 )
 from src.config import MatrycaWikiConfig
+from src.shadow.cache_location import resolve_shadow_cache_location
 from src.utils.runtime_bootstrap import (
     _patch_memory_path_in_wiki_yaml,
     ensure_matryca_wiki_config_file,
@@ -42,6 +46,27 @@ def _minimal_graph(tmp_path: Path) -> Path:
 
 def _expected_sibling_l1(graph: Path) -> Path:
     return graph.expanduser().resolve(strict=False).parent / "matryca-l1"
+
+
+def _graph_manifest(root: Path) -> dict[str, tuple[str, int, int, str]]:
+    entries: dict[str, tuple[str, int, int, str]] = {}
+    for path in sorted(root.rglob("*")):
+        metadata = path.lstat()
+        relative = path.relative_to(root).as_posix()
+        mode = stat.S_IMODE(metadata.st_mode)
+        if path.is_symlink():
+            entries[relative] = ("symlink", mode, metadata.st_size, os.readlink(path))
+        elif path.is_file():
+            payload = path.read_bytes()
+            entries[relative] = (
+                "file",
+                mode,
+                len(payload),
+                hashlib.sha256(payload).hexdigest(),
+            )
+        else:
+            entries[relative] = ("directory", mode, metadata.st_size, "")
+    return entries
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +237,33 @@ def test_prepare_matryca_runtime_skips_graph_local_bootstrap_in_read_only_mode(
     assert not (graph / "matryca-wiki.yml").exists()
     assert not _expected_sibling_l1(graph).exists()
     assert shadow_calls == [graph]
+
+
+def test_prepare_read_only_redirects_graph_local_logs_without_graph_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _minimal_graph(tmp_path)
+    page = graph / "pages" / "Alpha.md"
+    page.write_text("- Alpha\n", encoding="utf-8")
+    cache = tmp_path / "external-cache"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(graph / "logs" / "ops.log"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(graph / "logs" / "app.log"))
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.ensure_shadow_runtime_at_startup",
+        lambda _root: None,
+    )
+    before = _graph_manifest(graph)
+
+    prepare_matryca_runtime(graph_root=graph, wiki_config=MatrycaWikiConfig())
+
+    assert _graph_manifest(graph) == before
+    assert not (graph / "logs").exists()
+    external_logs = resolve_shadow_cache_location(graph).shadow_dir.parent / "logs"
+    assert external_logs.is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -20,6 +20,66 @@ def _minimal_graph(tmp_path: Path) -> Path:
     return graph
 
 
+@pytest.mark.parametrize("surface", ["mcp", "cli", "ui", "daemon"])
+@pytest.mark.parametrize("graph_local_logs", [False, True])
+def test_read_only_entrypoints_keep_log_bootstrap_external(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    surface: str,
+    graph_local_logs: bool,
+) -> None:
+    from src import cli as cli_module
+    from src import main as mcp_main
+    from src.agent import maintenance_daemon
+    from src.cli import ui_server
+    from src.config import MatrycaWikiConfig
+    from src.shadow.cache_location import resolve_shadow_cache_location
+
+    graph = _minimal_graph(tmp_path)
+    cache = tmp_path / "external-cache"
+    configured_logs = graph / "logs" if graph_local_logs else tmp_path / "external-logs"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    monkeypatch.setenv("MATRYCA_PLUMBER_LOG_PATH", str(configured_logs / "ops.log"))
+    monkeypatch.setenv("MATRYCA_LOGURU_LOG_PATH", str(configured_logs / "app.log"))
+    monkeypatch.setattr(
+        "src.utils.runtime_bootstrap.ensure_repo_dotenv_from_example",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        "src.agent.plumber_config.reload_plumber_dotenv",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "src.shadow.bootstrap.ensure_shadow_runtime_at_startup",
+        lambda _root: None,
+    )
+
+    if surface == "mcp":
+        vars(mcp_main)["prepare_matryca_runtime"](
+            graph_root=graph,
+            wiki_config=MatrycaWikiConfig(),
+            eager_graph=False,
+        )
+    elif surface == "daemon":
+        vars(maintenance_daemon)["prepare_matryca_runtime"](
+            graph_root=graph,
+            wiki_config=MatrycaWikiConfig(),
+            eager_graph=False,
+        )
+    elif surface == "ui":
+        vars(ui_server)["try_prepare_matryca_runtime_from_env"](eager_graph=False)
+    else:
+        vars(cli_module)["try_prepare_matryca_runtime_from_env"](eager_graph=False)
+
+    expected_logs = configured_logs
+    if graph_local_logs:
+        expected_logs = resolve_shadow_cache_location(graph).shadow_dir.parent / "logs"
+        assert not configured_logs.exists()
+    assert expected_logs.is_dir()
+
+
 def test_cli_main_calls_try_prepare_before_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 


### PR DESCRIPTION
## Summary

- redirect graph-local ops and Loguru paths to the validated external per-graph cache under strict read-only mode
- preserve explicitly external log locations and bind Loguru to its configured sink
- cover MCP, CLI, UI, and daemon startup with graph-local and external settings plus byte-and-metadata graph immutability
- record the Gate B impact decision and changelog entry

## Verification

- 1,616 passed, 5 skipped; 83.23% coverage
- Ruff check and format check
- mypy: 373 source files
- graph read sandbox, version, agent coherence, public metrics, documentation bundle, and generated prompt checks
- GitNexus compare: medium scoped impact, one affected process

## Gate B

The published RC read-only-external profile cannot enter the corrected branch because it uses external/default log locations. Existing evidence remains bound to the exact RC artifact; the stable candidate requires the focused startup matrix, not a restart of the historical multi-day soak.

Closes #388