### PR TITLE
fix: keep read-only X-Ray state external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Read-only X-Ray aliases (#393)** — keep `xray_page` a graph-immutable read by routing its atomically replaced, process-locked alias map to the private per-graph external runtime cache under Strict Read Only while preserving graph-root state and UUID semantics in normal mode.
 - **Read-only startup log isolation (#388)** — redirect graph-local ops and Loguru paths to the validated external per-graph runtime cache before directory creation, preserve explicitly external paths, and bind Loguru to its configured sink rather than the ops JSONL path.
 - **Gate B RC artifact and timing binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1`, and include measured probe time so valid profile probes advance the resumable soak instead of retrying as `probe_invalid`, while preserving the historical beta collector's default contract.
 

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -1,8 +1,8 @@
 <!-- GENERATED — do not edit -->
 
-<!-- build-hash: f909741b76f285a807a873775db8235c95350fc81a24829f8f282e97c6791440 -->
+<!-- build-hash: 68de689f39ac532aaf9336a5e45b3f10b864250801ae2a3212df88fa54817860 -->
 
-<!-- package-version: v2.0.0-beta.1 -->
+<!-- package-version: v2.0.0rc1 -->
 
 
 
@@ -156,6 +156,8 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 
 **Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with `target_type="memory"`.
 
+`read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.
+
 ## Project context
 
 Matryca Plumber operates on **Logseq OG**: local pure Markdown graphs. The atomic unit is the **block** (indented bullet tree), not a flat document body.
@@ -252,7 +254,11 @@ When in doubt: `read_graph_data` / `target_type="page"` first, then `dry_run: tr
 
 ## X-Ray mode and session aliases (`[n]`)
 
-For large pages, prefer **`read_graph_data` / `target_type="xray_page"`** with `query` = page title. The tool returns an ultra-dense outline like `[0] Parent` / `  [1] Child` (properties stripped) and writes **`{graph_root}/.matryca_xray_state.json`** mapping each `[n]` to the real Logseq block UUID.
+For large pages, prefer **`read_graph_data` / `target_type="xray_page"`** with `query` = page title. The tool returns an ultra-dense outline like `[0] Parent` / `  [1] Child` (properties stripped) and writes `.matryca_xray_state.json` mapping each `[n]` to the real Logseq block UUID. Normal mode keeps the established graph-root location. With `MATRYCA_READ_ONLY=true`, state is written instead to the private per-graph external runtime cache at `<cache-root>/graphs/<graph-id>/xray/`; no graph path is created or modified. The graph identity prevents cross-vault sharing, the state file is atomically replaced under a process-safe lock, POSIX directory/file modes are `0700`/`0600`, and its lifetime follows the per-graph runtime cache.
+
+Before #393, strict read-only X-Ray parsed the requested page and only then attempted the graph-root alias write, where the shared lock/write policy raised `GraphReadOnlyError`. The external state route makes the public read classification match runtime behavior without weakening the graph boundary.
+
+**Gate B impact decision (#393):** the published `2.0.0rc1` `read-only-external` probe does not invoke `xray_page`, so it cannot exercise this corrected branch. Existing evidence remains bound to the exact RC artifact and is not rewritten. A stable candidate must pass focused X-Ray generation, subsequent alias resolution, concurrent replacement, cross-graph isolation, and full graph-manifest checks under Strict Read Only; this configuration-excluded change does not restart the historical multi-day RC soak.
 
 On later **`mutate_graph`** or **`refactor_blocks`** calls (including separate CLI invocations), pass **`[n]`** directly wherever you would use a 36-character UUID:
 
@@ -341,7 +347,7 @@ Health snapshot: page counts, `id::` tally, block-ref summary. `query` ignored.
 { "target_type": "xray_page", "query": "My Project" }
 ```
 
-X-Ray outline with `[n]` aliases; persists `.matryca_xray_state.json` at the graph root. Pass `[n]` into `target` / `target_uuid` on subsequent mutations (stateless CLI-safe).
+X-Ray outline with `[n]` aliases; persists `.matryca_xray_state.json` at the graph root in normal mode or in the private per-graph external runtime cache under Strict Read Only. Pass `[n]` into `target` / `target_uuid` on subsequent operations (stateless CLI-safe).
 
 ---
 

--- a/docs/openspec/agent/mcp-tools.md
+++ b/docs/openspec/agent/mcp-tools.md
@@ -14,3 +14,5 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 | `import_tana` | _(none — `export_path`, `dry_run`)_ | Tana workspace JSON export → `Tana/` pages + journals; **dry-run default** |
 
 **Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with `target_type="memory"`.
+
+`read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.

--- a/docs/openspec/agent/tool-reference.md
+++ b/docs/openspec/agent/tool-reference.md
@@ -64,7 +64,7 @@ Health snapshot: page counts, `id::` tally, block-ref summary. `query` ignored.
 { "target_type": "xray_page", "query": "My Project" }
 ```
 
-X-Ray outline with `[n]` aliases; persists `.matryca_xray_state.json` at the graph root. Pass `[n]` into `target` / `target_uuid` on subsequent mutations (stateless CLI-safe).
+X-Ray outline with `[n]` aliases; persists `.matryca_xray_state.json` at the graph root in normal mode or in the private per-graph external runtime cache under Strict Read Only. Pass `[n]` into `target` / `target_uuid` on subsequent operations (stateless CLI-safe).
 
 ---
 

--- a/docs/openspec/agent/xray.md
+++ b/docs/openspec/agent/xray.md
@@ -1,6 +1,10 @@
 ## X-Ray mode and session aliases (`[n]`)
 
-For large pages, prefer **`read_graph_data` / `target_type="xray_page"`** with `query` = page title. The tool returns an ultra-dense outline like `[0] Parent` / `  [1] Child` (properties stripped) and writes **`{graph_root}/.matryca_xray_state.json`** mapping each `[n]` to the real Logseq block UUID.
+For large pages, prefer **`read_graph_data` / `target_type="xray_page"`** with `query` = page title. The tool returns an ultra-dense outline like `[0] Parent` / `  [1] Child` (properties stripped) and writes `.matryca_xray_state.json` mapping each `[n]` to the real Logseq block UUID. Normal mode keeps the established graph-root location. With `MATRYCA_READ_ONLY=true`, state is written instead to the private per-graph external runtime cache at `<cache-root>/graphs/<graph-id>/xray/`; no graph path is created or modified. The graph identity prevents cross-vault sharing, the state file is atomically replaced under a process-safe lock, POSIX directory/file modes are `0700`/`0600`, and its lifetime follows the per-graph runtime cache.
+
+Before #393, strict read-only X-Ray parsed the requested page and only then attempted the graph-root alias write, where the shared lock/write policy raised `GraphReadOnlyError`. The external state route makes the public read classification match runtime behavior without weakening the graph boundary.
+
+**Gate B impact decision (#393):** the published `2.0.0rc1` `read-only-external` probe does not invoke `xray_page`, so it cannot exercise this corrected branch. Existing evidence remains bound to the exact RC artifact and is not rewritten. A stable candidate must pass focused X-Ray generation, subsequent alias resolution, concurrent replacement, cross-graph isolation, and full graph-manifest checks under Strict Read Only; this configuration-excluded change does not restart the historical multi-day RC soak.
 
 On later **`mutate_graph`** or **`refactor_blocks`** calls (including separate CLI invocations), pass **`[n]`** directly wherever you would use a 36-character UUID:
 

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -117,7 +117,7 @@ does not create, repair, lock, rename, or remove any path inside the graph.
 |----------|--------|
 | Repo **`.env`** (pre-existing) | Never overwritten; auto-created from `.env.example` only when `.env` is absent |
 | **`pages/` / `journals/`** | A valid Logseq graph must already exist; Matryca Plumber does not fabricate vault structure |
-| **`.matryca_daemon_state.json`**, **`.matryca_xray_state.json`** | Runtime ledgers — created on first checkpoint / X-Ray session |
+| **`.matryca_daemon_state.json`**, **`.matryca_xray_state.json`** | Runtime ledgers — created on first checkpoint / X-Ray session in normal mode; X-Ray state moves to the private per-graph external cache under Strict Read Only |
 | **Daemon PID / lock files** | PID sidecar written immediately after `.matryca_plumber_daemon.lock` acquisition in `start_daemon_foreground`; removed on bootstrap failure or `SIGINT`/`SIGTERM` during startup |
 | **`master_catalog.json` body** | Populated by bootstrap harvest, not empty placeholders |
 | **`.matryca_link_registry.json`** | Created on first link extract (v1.9); verification queue only — see [`link-verification.md`](link-verification.md) |

--- a/src/agent/alias_state.py
+++ b/src/agent/alias_state.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 from collections.abc import ItemsView
 from pathlib import Path
 from typing import cast
@@ -37,14 +39,72 @@ _ALIAS_TARGET_RE = re.compile(r"^\[\s*(\d+)\s*\]$")
 
 
 def alias_file_path(graph_root: str | Path) -> Path:
-    """Hidden X-Ray alias state file at the Logseq graph root."""
-    root = Path(graph_root).expanduser().resolve(strict=False)
+    """Resolve graph-local or strict-read-only external X-Ray alias state."""
+    root = _graph_root_path(graph_root)
     state_name = str(XRAY_STATE_FILENAME)
+    from ..graph.safety.write_policy import RuntimeWritePolicy
+
+    policy = RuntimeWritePolicy.from_env(root)
+    if policy.read_only:
+        from ..shadow.cache_location import (
+            ShadowCacheLocationError,
+            resolve_shadow_cache_location,
+        )
+
+        location = resolve_shadow_cache_location(root)
+        state_dir = location.shadow_dir.parent / "xray"
+        state_path = state_dir / state_name
+        if state_dir.is_symlink():
+            raise ShadowCacheLocationError("xray_directory_symlink")
+        if state_path.is_symlink():
+            raise ShadowCacheLocationError("xray_state_symlink")
+        resolved = state_path.resolve(strict=False)
+        if not resolved.is_relative_to(location.cache_root):
+            raise ShadowCacheLocationError("xray_directory_escape")
+        return resolved
     return root / state_name
 
 
 def _graph_root_path(graph_root: str | Path) -> Path:
     return Path(graph_root).expanduser().resolve(strict=False)
+
+
+def _ensure_private_parent(path: Path) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if os.name == "posix":
+        path.parent.chmod(0o700)
+
+
+def _atomic_write_private_state(path: Path, data: bytes) -> None:
+    """Atomically replace external runtime state with private permissions."""
+    _ensure_private_parent(path)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_name)
+    committed = False
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        committed = True
+        if os.name == "posix":
+            path.chmod(0o600)
+        try:
+            directory_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
+    finally:
+        if not committed:
+            tmp_path.unlink(missing_ok=True)
 
 
 def load_alias_registry(graph_root: str | Path) -> SessionAliasRegistry:
@@ -70,13 +130,18 @@ def load_alias_registry(graph_root: str | Path) -> SessionAliasRegistry:
 
 
 def save_alias_registry(graph_root: str | Path, registry: SessionAliasRegistry) -> Path:
-    """Persist ``SessionAliasRegistry`` atomically under an exclusive file lock."""
+    """Persist aliases atomically under an exclusive graph-local or external lock."""
     path = alias_file_path(graph_root)
     root = _graph_root_path(graph_root)
     payload = {str(alias): block_uuid for alias, block_uuid in safe_alias_items(registry)}
     data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
-    with page_rmw_lock(path):
-        atomic_write_bytes(path, data, graph_root=root)
+    if path.is_relative_to(root):
+        with page_rmw_lock(path):
+            atomic_write_bytes(path, data, graph_root=root)
+    else:
+        _ensure_private_parent(path)
+        with page_rmw_lock(path):
+            _atomic_write_private_state(path, data)
     return path
 
 

--- a/src/agent/graph_tool_helpers.py
+++ b/src/agent/graph_tool_helpers.py
@@ -184,11 +184,16 @@ def read_xray_page_markdown(graph_path: str, page_name: str) -> str:
         safe_update_alias(persist_registry, alias, block_uuid)
     save_alias_registry(graph_path, persist_registry)
     alias_count = len(persistable)
-    state_name = alias_file_path(graph_path).name
+    state_path = alias_file_path(graph_path)
+    state_name = state_path.name
+    graph_root = Path(graph_path).expanduser().resolve(strict=False)
+    state_location = (
+        "the graph root" if state_path.is_relative_to(graph_root) else "external runtime cache"
+    )
     header = (
         f"# X-Ray: [[{title}]]\n\n"
         f"**Aliases:** {alias_count} block(s) mapped to `[0]`…`[{alias_count - 1}]` "
-        f"in `{state_name}` at the graph root. "
+        f"in `{state_name}` in {state_location}. "
         "Pass `[n]` as `target` or in `Page Title|[n]` for `mutate_graph` / `refactor_blocks`.\n\n"
         f"{body}\n"
     )

--- a/src/agent/mcp_server.py
+++ b/src/agent/mcp_server.py
@@ -140,8 +140,9 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         page counts, ``id::`` tally, block-ref health under ``pages/``.
 
         **``target_type=xray_page``** — ``query`` = Logseq **page title**. Ultra-dense
-        ``[n]`` outline (X-Ray mode); persists alias→UUID map to ``.matryca_xray_state.json`` at
-        the graph root. Use ``[n]`` in ``target`` / ``target_uuid`` on later mutations.
+        ``[n]`` outline (X-Ray mode); persists the alias→UUID map at graph root in normal
+        mode or in the per-graph external runtime cache under Strict Read Only. Use ``[n]``
+        in ``target`` / ``target_uuid`` on later operations.
 
         **Requires:** ``LOGSEQ_GRAPH_PATH`` for every target except ``memory`` (still recommended).
 

--- a/tests/test_alias_state.py
+++ b/tests/test_alias_state.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -14,6 +17,10 @@ from src.agent.alias_state import (
     resolve_pipe_target,
     resolve_target,
     save_alias_registry,
+)
+from src.shadow.cache_location import (
+    ShadowCacheLocationError,
+    resolve_shadow_cache_location,
 )
 
 BLOCK_UUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
@@ -69,3 +76,87 @@ def test_load_alias_registry_rejects_corrupt_json(tmp_path: Path) -> None:
 def test_resolve_target_unknown_alias_with_empty_state(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match=r"\[99\]"):
         resolve_target(tmp_path, "[99]")
+
+
+def test_read_only_alias_state_is_private_external_and_graph_is_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    page = graph / "pages" / "Alpha.md"
+    page.write_text("- Alpha\n", encoding="utf-8")
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    before = page.read_bytes()
+
+    state_path = save_alias_registry(graph, _registry_with({0: BLOCK_UUID}))
+
+    expected = resolve_shadow_cache_location(graph).shadow_dir.parent / "xray" / state_path.name
+    assert state_path == expected
+    assert load_alias_registry(graph).resolve_alias(0) == BLOCK_UUID
+    assert page.read_bytes() == before
+    assert not (graph / state_path.name).exists()
+    if os.name == "posix":
+        assert stat.S_IMODE(state_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
+
+
+def test_read_only_alias_state_isolated_by_graph_and_concurrency_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    (first / "pages").mkdir(parents=True)
+    (second / "pages").mkdir(parents=True)
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(first))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(tmp_path / "cache"))
+    first_path = alias_file_path(first)
+    second_path = alias_file_path(second)
+    assert first_path != second_path
+
+    registries = [
+        _registry_with({0: BLOCK_UUID}),
+        _registry_with({1: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}),
+    ]
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(save_alias_registry, first, registries[index % 2])
+            for index in range(20)
+        ]
+        for future in futures:
+            future.result()
+
+    payload = json.loads(first_path.read_text(encoding="utf-8"))
+    assert payload in [
+        {"0": BLOCK_UUID},
+        {"1": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"},
+    ]
+    assert not second_path.exists()
+
+
+def test_read_only_alias_state_rejects_xray_directory_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(graph))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(cache))
+    location = resolve_shadow_cache_location(graph)
+    location.shadow_dir.parent.mkdir(parents=True)
+    try:
+        (location.shadow_dir.parent / "xray").symlink_to(graph, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ShadowCacheLocationError, match="xray_directory_symlink"):
+        alias_file_path(graph)
+
+    assert not (graph / XRAY_STATE_FILENAME).exists()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -261,3 +261,26 @@ def test_xray_page_persists_state_file(tmp_path: Path) -> None:
     md = read_xray_page_markdown(str(tmp_path), "Alias Demo")
     assert "[0]" in md
     assert (tmp_path / XRAY_STATE_FILENAME).is_file()
+
+
+def test_xray_page_read_only_uses_external_alias_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    block_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    page = pages / "Alias Demo.md"
+    page.write_text(f"- Parent bullet\n  id:: {block_id}\n", encoding="utf-8")
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+    monkeypatch.setenv("MATRYCA_CACHE_PATH", str(tmp_path.parent / "external-cache"))
+    before = page.read_bytes()
+
+    md = read_xray_page_markdown(str(tmp_path), "Alias Demo")
+
+    assert "[0]" in md
+    assert "external runtime cache" in md
+    assert page.read_bytes() == before
+    assert not (tmp_path / XRAY_STATE_FILENAME).exists()
+    assert block_id in read_block_ast_markdown(str(tmp_path), "Alias Demo|[0]")


### PR DESCRIPTION
## Stack

Depends on #406. Review and merge this PR after #406, or retarget it to main once #406 merges.

## Summary

- preserve xray_page as a graph-immutable read under Strict Read Only
- route alias state to the private per-graph external runtime cache while retaining the graph-root location in normal mode
- keep atomic replacement and process-safe locking, enforce private POSIX modes, and reject symlink escapes
- synchronize the MCP contract, OpenSpec fragments, generated system prompt, runtime docs, Gate B disposition, and changelog

## Verification

- 1,620 passed, 5 skipped; 83.27% coverage
- Ruff check and format check
- mypy: 373 source files
- graph read sandbox, version, agent coherence, public metrics, documentation bundle, and generated prompt checks
- focused concurrency, cross-graph isolation, symlink containment, later alias resolution, and graph immutability tests
- GitNexus compare: HIGH expected alias-resolution scope; normal mutation and refactor flows included in full regression

## Gate B

The public RC read-only-external probe does not invoke xray_page, so existing evidence remains bound to the exact RC artifact. The stable candidate requires the focused X-Ray matrix; the historical multi-day soak does not restart for this unexercised branch.

Closes #393