### PR TITLE
fix: make Shadow read freshness explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Explicit Shadow read freshness (#389)** — validate requested subtree pages and every returned FTS page against the authoritative Markdown path, nanosecond mtime, and size before serving cached rows; route changed, missing, untracked, and unproven-empty reads to Markdown/generational BM25 with a bounded content-free reason, without a per-read graph scan.
 - **Read-only X-Ray aliases (#393)** — keep `xray_page` a graph-immutable read by routing its atomically replaced, process-locked alias map to the private per-graph external runtime cache under Strict Read Only while preserving graph-root state and UUID semantics in normal mode.
 - **Read-only startup log isolation (#388)** — redirect graph-local ops and Loguru paths to the validated external per-graph runtime cache before directory creation, preserve explicitly external paths, and bind Loguru to its configured sink rather than the ops JSONL path.
 - **Gate B RC artifact and timing binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1`, and include measured probe time so valid profile probes advance the resumable soak instead of retrying as `probe_invalid`, while preserving the historical beta collector's default contract.

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 <!-- GENERATED — do not edit -->
 
-<!-- build-hash: 68de689f39ac532aaf9336a5e45b3f10b864250801ae2a3212df88fa54817860 -->
+<!-- build-hash: 8e03e878d71566b61699b60828640902174aef8813e8bff3f2f7dc98367e9ed4 -->
 
 <!-- package-version: v2.0.0rc1 -->
 
@@ -158,6 +158,14 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 
 `read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.
 
+When Shadow is `ready`, subtree and BM25/FTS reads validate requested cached page
+rows against authoritative Markdown before returning them. If a row is untracked,
+missing, or changed—or an empty FTS result cannot prove freshness—the tool uses the
+Markdown/generational BM25 fallback and appends one content-free `Shadow fallback`
+code: `page_untracked`, `source_missing`, `source_changed`, or
+`empty_result_unproven`. Treat the fallback output as authoritative; do not retry the
+cache path.
+
 ## Project context
 
 Matryca Plumber operates on **Logseq OG**: local pure Markdown graphs. The atomic unit is the **block** (indented bullet tree), not a flat document body.
@@ -311,6 +319,11 @@ On-disk bullet subtree for one `id::` block (`Page Title|block-uuid`). Headless;
 
 Focused excerpt for one block; optional JSON `heading` to narrow to a single bulleted section (token-saving). Prefer over full `page` when you already know the anchor UUID.
 
+When the Shadow row cannot be proven current, the result comes from Markdown and
+ends with a bounded `Shadow fallback` code. If the authoritative page has been
+deleted, the result is an explicit subtree-unavailable envelope; stale cached content
+is never returned.
+
 ```json
 {
   "target_type": "subtree",
@@ -364,6 +377,12 @@ Okapi BM25 over `pages/**/*.md` remains the default lexical path. Optional **`me
 ```
 
 Always follow top hits with `read_graph_data` / `target_type="page"`.
+
+Shadow FTS validates each returned page row before serving it. Changed or missing
+rows, and empty cached results whose freshness cannot be proved, route to
+generational BM25 and append a content-free `Shadow fallback` code. The closed codes
+are `page_untracked`, `source_missing`, `source_changed`, and
+`empty_result_unproven`.
 
 ```json
 { "method": "regex", "query": "TODO|LATER" }

--- a/docs/openspec/agent/mcp-tools.md
+++ b/docs/openspec/agent/mcp-tools.md
@@ -16,3 +16,11 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 **Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with `target_type="memory"`.
 
 `read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.
+
+When Shadow is `ready`, subtree and BM25/FTS reads validate requested cached page
+rows against authoritative Markdown before returning them. If a row is untracked,
+missing, or changed—or an empty FTS result cannot prove freshness—the tool uses the
+Markdown/generational BM25 fallback and appends one content-free `Shadow fallback`
+code: `page_untracked`, `source_missing`, `source_changed`, or
+`empty_result_unproven`. Treat the fallback output as authoritative; do not retry the
+cache path.

--- a/docs/openspec/agent/tool-reference.md
+++ b/docs/openspec/agent/tool-reference.md
@@ -28,6 +28,11 @@ On-disk bullet subtree for one `id::` block (`Page Title|block-uuid`). Headless;
 
 Focused excerpt for one block; optional JSON `heading` to narrow to a single bulleted section (token-saving). Prefer over full `page` when you already know the anchor UUID.
 
+When the Shadow row cannot be proven current, the result comes from Markdown and
+ends with a bounded `Shadow fallback` code. If the authoritative page has been
+deleted, the result is an explicit subtree-unavailable envelope; stale cached content
+is never returned.
+
 ```json
 {
   "target_type": "subtree",
@@ -81,6 +86,12 @@ Okapi BM25 over `pages/**/*.md` remains the default lexical path. Optional **`me
 ```
 
 Always follow top hits with `read_graph_data` / `target_type="page"`.
+
+Shadow FTS validates each returned page row before serving it. Changed or missing
+rows, and empty cached results whose freshness cannot be proved, route to
+generational BM25 and append a content-free `Shadow fallback` code. The closed codes
+are `page_untracked`, `source_missing`, `source_changed`, and
+`empty_result_unproven`.
 
 ```json
 { "method": "regex", "query": "TODO|LATER" }

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -4,6 +4,16 @@ This runbook starts the two independent, fail-closed soak profiles required by
 the `v2.0.0` Gate B decision. Both profiles run against the installed public
 `matryca-plumber==2.0.0rc1` wheel, never a source checkout.
 
+## Post-RC read-path requalification boundary
+
+The public-RC soak records evidence only for the exact `2.0.0rc1` wheel. Issue
+[#389](https://github.com/MarcoPorcellato/matryca-plumber/issues/389) changes the FTS
+and subtree paths exercised by both profiles by adding requested-row freshness checks
+and explicit Markdown/BM25 fallback reasons. Do not rewrite or transfer the RC result
+to those later bytes. Before stable promotion, bind a fresh candidate artifact and
+repeat the watcher-disabled edit/delete/rename matrix plus both Gate B profiles under
+the same fail-closed integrity rules.
+
 ## Recorded checkpoint snapshot (public candidate `2.0.0rc1`)
 
 The recorded checkpoint for stable-promotion evidence is `RUNNING`

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -257,17 +257,37 @@ Non-goal: do not remove X-Ray aliases.
 
 #### EX-04 — Make Shadow freshness explicit
 
-**Verified gap; plausible stale-read risk:** `resolve_shadow_health()` validates schema, sync-error metadata, completion, and aggregate counts but not current source mtimes (`src/shadow/health.py:68-106`). Shadow rows store `file_mtime_ns`, but subtree reads do not compare it before serving (`src/agent/shadow_graph_repository.py:110-153`). A page changed while the watcher is stopped or after a missed event can remain eligible for `READY` reads despite source changes that were not reconciled. This study did not observe that outcome in production.
+**Implemented in #389:** `READY` remains an aggregate cache-health state, while each
+cached read now proves the source identity of the rows it is about to serve. Subtree
+reads validate the requested page; FTS reads validate every unique returned page.
+The check is bounded by the request (`1` page for subtree, at most the result limit for
+FTS) and compares the sandboxed graph-relative path, nanosecond mtime, and byte size
+with the persisted page row. It never performs a full graph scan.
 
-**Smallest slice:** validate freshness for the requested page or maintain a bounded dirty/freshness index; if freshness cannot be proved, use Markdown.
+Changed, missing, or untracked rows route to authoritative Markdown or generational
+BM25. A zero-hit FTS result also routes to BM25 because an empty cached result cannot
+prove that an unreconciled page has not gained the query term. Every such route adds
+one closed, content-free reason: `page_untracked`, `source_missing`, `source_changed`,
+or `empty_result_unproven`. A deleted subtree source returns an explicit unavailable
+envelope rather than stale cached content or a raw file exception.
 
-Acceptance gate:
+Watcher-disabled edit, delete, and rename fixtures pass. Fresh-hit tests reject any
+attempted `Path.rglob`, proving the read-time check is request-bounded. On macOS
+15.7.3 arm64 with Python 3.12.13, 500 warm synthetic iterations measured subtree
+p95/p99 at 9.638/12.579 ms and FTS p95/p99 at 9.265/11.343 ms. CI retains deliberately
+looser 250/500 ms p95/p99 soft ceilings to detect pathological regressions without
+turning ordinary runner jitter into failures.
 
-- edit, delete, and rename a page after a healthy rebuild with the watcher disabled, with explicit authoritative expected results for every case;
-- every read returns current Markdown or an explicit stale/fallback result;
-- healthy warm Shadow latency remains within an agreed regression budget.
+**Proof boundary:** non-empty FTS responses prove every cached row returned, not the
+global absence of a newly matching unreconciled page elsewhere in the graph. Watcher
+reconciliation remains the normal completeness mechanism; a future durable dirty
+index or platform event-journal proof would be required to strengthen that global
+negative guarantee without violating the no-scan constraint.
 
-Non-goal: do not scan the full graph on every read.
+**Gate B impact:** the published `2.0.0rc1` probes execute FTS and subtree reads, so
+their historical evidence cannot qualify these post-RC bytes. Preserve that evidence
+as exact-RC history, but run focused watcher-disabled cases and both exact-candidate
+Gate B profiles again before stable promotion.
 
 #### EX-05 — Invalidate stale Shadow generations on every sync failure
 

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -85,6 +85,21 @@ not replace the unchecked installed-wheel qualification row.
 | v2.0.0-rc.1 | External Shadow cache works under Read Only; MCP reads default to Shadow after qualification | in progress (`RUNNING` Gate B checkpoint) |
 | v2.0.0-stable | Deprecate pure in-memory BM25 as default discovery path after RC observation | planned |
 
+### Explicit read freshness after the RC
+
+Issue [#389](https://github.com/MarcoPorcellato/matryca-plumber/issues/389)
+separates aggregate Shadow health from row-level read eligibility. Before a cached
+subtree or FTS row is returned, Matryca validates its sandboxed source path,
+nanosecond mtime, and size against current Markdown. Untracked, missing, changed, and
+unproven-empty reads fail over with a closed content-free reason; the check is bounded
+to the requested page or returned result rows and never scans the full graph.
+
+This is a post-`2.0.0rc1` read-path correction. The public-RC soak remains valid only
+as evidence for those exact published bytes. Because both Gate B profiles exercise
+FTS and subtree routing, an exact stable candidate containing #389 must repeat the
+focused watcher-disabled edit/delete/rename matrix and both candidate-bound Gate B
+profiles before `v2.0.0` promotion.
+
 The beta excludes Phase 4 biological memory and Logseq DB Safe-Sync. Its completed gates and accepted evidence boundary are recorded in [`docs/quality/issue-bodies/v2-beta-readiness.md`](../quality/issue-bodies/v2-beta-readiness.md).
 The RC and stable exit criteria are fail-closed in [`docs/quality/issue-bodies/v2-rc-stable-readiness.md`](../quality/issue-bodies/v2-rc-stable-readiness.md) and tracked by [#343](https://github.com/MarcoPorcellato/matryca-plumber/issues/343). Biological memory, Logseq DB Safe-Sync, Tana merge, and independent DX tracks are deferred to `v2.1.0` or later.
 The exact public-beta wheel passed its fresh installed-wheel gate on 2026-07-30

--- a/src/agent/shadow_graph_repository.py
+++ b/src/agent/shadow_graph_repository.py
@@ -12,6 +12,7 @@ from ..graph.path_sandbox import resolved_graph_root
 from ..rag.matryca_hooks import get_page_spatial_context
 from ..shadow.config import shadow_db_enabled
 from ..shadow.connection import open_shadow_db
+from ..shadow.freshness import ShadowFreshnessError, ensure_shadow_page_fresh
 from ..shadow.health import ShadowHealthState, resolve_shadow_health
 from ..shadow.subtree import SubtreeStatus, query_subtree_by_block_uuid
 from .graph_tool_helpers import parse_optional_json_query
@@ -130,9 +131,21 @@ class ShadowGraphRepository:
         try:
             conn = open_shadow_db(root)
             try:
+                ensure_shadow_page_fresh(conn, root, title=page_ref)
                 result = query_subtree_by_block_uuid(conn, block_uuid)
             finally:
                 conn.close()
+        except ShadowFreshnessError as exc:
+            logger.bind(reason=exc.reason.value).info(
+                "Shadow subtree freshness unproven; falling back to MarkdownGraphRepository"
+            )
+            try:
+                fallback = self._markdown.read_subtree_markdown(graph_root, query)
+            except FileNotFoundError:
+                fallback = (
+                    "# Subtree unavailable\n\n_The authoritative Markdown page is unavailable._\n"
+                )
+            return f"{fallback.rstrip()}\n\n- **Shadow fallback:** `{exc.reason.value}`\n"
         except Exception:  # noqa: BLE001 — shadow backend failure → markdown fallback
             logger.exception("Shadow subtree read failed; falling back to MarkdownGraphRepository")
             return self._markdown.read_subtree_markdown(graph_root, query)

--- a/src/shadow/freshness.py
+++ b/src/shadow/freshness.py
@@ -1,0 +1,62 @@
+"""Bounded source-identity checks for requested Shadow page rows."""
+
+from __future__ import annotations
+
+import sqlite3
+from enum import StrEnum
+from pathlib import Path
+
+from ..graph.path_sandbox import assert_path_within_graph, resolved_graph_root
+
+
+class ShadowFreshnessReason(StrEnum):
+    PAGE_UNTRACKED = "page_untracked"
+    SOURCE_MISSING = "source_missing"
+    SOURCE_CHANGED = "source_changed"
+    EMPTY_RESULT_UNPROVEN = "empty_result_unproven"
+
+
+class ShadowFreshnessError(RuntimeError):
+    """Content-free signal that authoritative Markdown fallback is required."""
+
+    def __init__(self, reason: ShadowFreshnessReason) -> None:
+        self.reason = reason
+        super().__init__(reason.value)
+
+
+def ensure_shadow_page_fresh(
+    connection: sqlite3.Connection,
+    graph_root: Path | str,
+    *,
+    page_id: int | None = None,
+    title: str | None = None,
+) -> None:
+    """Validate one requested row using stored size and nanosecond mtime."""
+    if page_id is not None:
+        row = connection.execute(
+            "SELECT file_path, file_mtime_ns, file_size FROM pages WHERE page_id = ?",
+            (page_id,),
+        ).fetchone()
+    else:
+        row = connection.execute(
+            "SELECT file_path, file_mtime_ns, file_size FROM pages WHERE title = ?",
+            ((title or "").strip(),),
+        ).fetchone()
+    if row is None:
+        raise ShadowFreshnessError(ShadowFreshnessReason.PAGE_UNTRACKED)
+
+    root = resolved_graph_root(graph_root)
+    path = assert_path_within_graph(root / str(row[0]), root)
+    try:
+        current = path.stat()
+    except OSError as exc:
+        raise ShadowFreshnessError(ShadowFreshnessReason.SOURCE_MISSING) from exc
+    if current.st_mtime_ns != int(row[1]) or current.st_size != int(row[2]):
+        raise ShadowFreshnessError(ShadowFreshnessReason.SOURCE_CHANGED)
+
+
+__all__ = [
+    "ShadowFreshnessError",
+    "ShadowFreshnessReason",
+    "ensure_shadow_page_fresh",
+]

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -11,6 +11,11 @@ from ..graph.path_sandbox import resolved_graph_root
 from ..rag.local_query import format_keyword_query_markdown
 from .config import shadow_db_enabled
 from .connection import open_shadow_db
+from .freshness import (
+    ShadowFreshnessError,
+    ShadowFreshnessReason,
+    ensure_shadow_page_fresh,
+)
 from .fts_validation import (
     _FTS_VALIDATION_PREFIX,
     MAX_FTS_MATCH_QUERY_CHARS,
@@ -66,6 +71,10 @@ def format_shadow_fts_markdown(
                 ) from exc
             raise
         page_rows = _page_rows_for_hits(conn, hits)
+        if not hits:
+            raise ShadowFreshnessError(ShadowFreshnessReason.EMPTY_RESULT_UNPROVEN)
+        for page_id in page_rows:
+            ensure_shadow_page_fresh(conn, root, page_id=page_id)
     finally:
         conn.close()
 
@@ -113,6 +122,12 @@ def resolve_bm25_search_markdown(
             return format_shadow_fts_markdown(root, keyword, limit=limit)
         except FtsQueryValidationError:
             raise
+        except ShadowFreshnessError as exc:
+            logger.bind(reason=exc.reason.value).info(
+                "Shadow FTS freshness unproven; falling back to generational BM25"
+            )
+            fallback = format_keyword_query_markdown(root, keyword, limit=limit, mode="bm25")
+            return f"{fallback.rstrip()}\n\n- **Shadow fallback:** `{exc.reason.value}`\n"
         except Exception:  # noqa: BLE001 — shadow backend failure → v1 fallback
             logger.exception("Shadow FTS search failed; falling back to generational BM25")
     return format_keyword_query_markdown(root, keyword, limit=limit, mode="bm25")

--- a/tests/test_shadow_freshness.py
+++ b/tests/test_shadow_freshness.py
@@ -1,0 +1,147 @@
+"""Requested-row freshness invariants when watcher reconciliation is absent."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from src.agent.shadow_graph_repository import ShadowGraphRepository
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.fts_format import resolve_bm25_search_markdown
+
+BLOCK_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_WARM_P95_BUDGET_S = 0.250
+_WARM_P99_BUDGET_S = 0.500
+
+
+@pytest.fixture(autouse=True)
+def _shadow_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+
+
+def _ready_graph(tmp_path: Path) -> tuple[Path, Path]:
+    graph = tmp_path / "graph"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Port.md"
+    page.write_text(
+        f"- oldtoken root\n  id:: {BLOCK_UUID}\n  - old child\n",
+        encoding="utf-8",
+    )
+    rebuild_shadow_from_graph(graph)
+    return graph, page
+
+
+def _subtree(page: str = "Port") -> str:
+    return json.dumps({"page": page, "block_uuid": BLOCK_UUID})
+
+
+def _percentile(samples: list[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    rank = (len(ordered) - 1) * fraction
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    return ordered[low] + (ordered[high] - ordered[low]) * (rank - low)
+
+
+def test_subtree_edit_falls_back_to_current_markdown(tmp_path: Path) -> None:
+    graph, page = _ready_graph(tmp_path)
+    page.write_text(
+        f"- newtoken root\n  id:: {BLOCK_UUID}\n  - current child\n",
+        encoding="utf-8",
+    )
+
+    output = ShadowGraphRepository().read_subtree_markdown(graph, _subtree())
+
+    assert "current child" in output
+    assert "old child" not in output
+    assert "`source_changed`" in output
+
+
+def test_subtree_delete_and_rename_fail_closed(tmp_path: Path) -> None:
+    graph, page = _ready_graph(tmp_path)
+    renamed = page.with_name("Renamed.md")
+    page.rename(renamed)
+
+    renamed_output = ShadowGraphRepository().read_subtree_markdown(graph, _subtree("Renamed"))
+    assert "old child" in renamed_output
+    assert "`page_untracked`" in renamed_output
+
+    renamed.unlink()
+    deleted_output = ShadowGraphRepository().read_subtree_markdown(graph, _subtree())
+    assert "`source_missing`" in deleted_output
+
+
+def test_fts_edit_validates_hits_and_unproven_empty_results(tmp_path: Path) -> None:
+    graph, page = _ready_graph(tmp_path)
+    page.write_text(
+        f"- newtoken root\n  id:: {BLOCK_UUID}\n  - current child\n",
+        encoding="utf-8",
+    )
+
+    old_output = resolve_bm25_search_markdown(graph, "oldtoken")
+    new_output = resolve_bm25_search_markdown(graph, "newtoken")
+
+    assert "`source_changed`" in old_output
+    assert "block `" not in old_output
+    assert "Port.md" in new_output
+    assert "`empty_result_unproven`" in new_output
+
+
+def test_fts_delete_and_rename_return_current_results(tmp_path: Path) -> None:
+    graph, page = _ready_graph(tmp_path)
+    renamed = page.with_name("Renamed.md")
+    page.rename(renamed)
+
+    renamed_output = resolve_bm25_search_markdown(graph, "oldtoken")
+    assert "Renamed.md" in renamed_output
+    assert "`source_missing`" in renamed_output
+
+    renamed.unlink()
+    deleted_output = resolve_bm25_search_markdown(graph, "oldtoken")
+    assert "Renamed.md" not in deleted_output
+    assert "`source_missing`" in deleted_output
+
+
+def test_fresh_shadow_hit_does_not_scan_the_graph(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph, _page = _ready_graph(tmp_path)
+    monkeypatch.setattr(
+        Path,
+        "rglob",
+        lambda *_args, **_kwargs: pytest.fail("freshness must not scan the full graph"),
+    )
+
+    output = resolve_bm25_search_markdown(graph, "oldtoken")
+
+    assert "block `" in output
+    assert "Shadow fallback" not in output
+
+
+def test_warm_shadow_reads_keep_freshness_tail_latency_bounded(tmp_path: Path) -> None:
+    graph, _page = _ready_graph(tmp_path)
+    repository = ShadowGraphRepository()
+    query = _subtree()
+
+    for _ in range(10):
+        assert "Shadow fallback" not in repository.read_subtree_markdown(graph, query)
+        assert "Shadow fallback" not in resolve_bm25_search_markdown(graph, "oldtoken")
+
+    samples: list[float] = []
+    for _ in range(80):
+        started = time.perf_counter()
+        repository.read_subtree_markdown(graph, query)
+        samples.append(time.perf_counter() - started)
+
+        started = time.perf_counter()
+        resolve_bm25_search_markdown(graph, "oldtoken")
+        samples.append(time.perf_counter() - started)
+
+    p95 = _percentile(samples, 0.95)
+    p99 = _percentile(samples, 0.99)
+    assert p95 < _WARM_P95_BUDGET_S, f"warm Shadow p95={p95:.6f}s"
+    assert p99 < _WARM_P99_BUDGET_S, f"warm Shadow p99={p99:.6f}s"

--- a/tests/test_shadow_fts_routing.py
+++ b/tests/test_shadow_fts_routing.py
@@ -132,6 +132,7 @@ async def test_handle_search_bm25_zero_hits_no_fallback(
     assert "- **Matches:** 0" in out
     assert "_No lexical overlap" in out
     assert "Invalid FTS query" not in out
+    assert "`empty_result_unproven`" in out
 
 
 @pytest.mark.asyncio

--- a/tests/test_shadow_hardening_axis3_routing.py
+++ b/tests/test_shadow_hardening_axis3_routing.py
@@ -207,7 +207,7 @@ async def test_a3_health_04_error_meta_routes_generational_bm25(
 
 @pytest.mark.asyncio
 async def test_a3_fts_01_zero_hits_no_generational_fallback(tmp_path: Path) -> None:
-    """A3-FTS-01: zero FTS hits → empty shadow envelope, no BM25 fallback."""
+    """A3-FTS-01: zero FTS hits cannot prove freshness and fall back."""
     graph = _minimal_graph(tmp_path)
     _seed_shadow_ready(graph)
 
@@ -215,6 +215,7 @@ async def test_a3_fts_01_zero_hits_no_generational_fallback(tmp_path: Path) -> N
     assert "- **Matches:** 0" in out
     assert "_No lexical overlap" in out
     assert "block `" not in out
+    assert "`empty_result_unproven`" in out
 
 
 @pytest.mark.asyncio

--- a/tests/test_shadow_hardening_axis4_fts5.py
+++ b/tests/test_shadow_hardening_axis4_fts5.py
@@ -628,13 +628,14 @@ def test_a4_rank_03_limit_boundaries(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_a4_rank_04_zero_hits_no_generational_fallback(tmp_path: Path) -> None:
-    """A4-RANK-04: zero FTS hits stay on shadow envelope (no generational fallback)."""
+    """A4-RANK-04: zero FTS hits fall back because freshness is unproven."""
     graph = _minimal_graph(tmp_path)
     _seed_fts_graph(graph)
     out = await handle_search_bm25(str(graph), "zzznomatchzz")
     assert "- **Matches:** 0" in out
     assert "_No lexical overlap" in out
     assert "block `" not in out
+    assert "`empty_result_unproven`" in out
 
 
 # --- A4-SYNC ---


### PR DESCRIPTION
## Summary

- validate requested Shadow subtree pages and every returned FTS page against current authoritative Markdown metadata
- fall back with bounded content-free reasons for changed, missing, untracked, and unproven-empty reads
- cover watcher-disabled edit, delete, and rename cases without introducing a per-read graph scan
- document the warm latency budget, measured evidence, public MCP contract, and exact-candidate Gate B requalification boundary

## Stack

This PR is stacked on #407 and should be reviewed after it. Its base is `fix/xray-read-only-state-393`, not `main`.

## Verification

- 1,626 passed, 5 skipped
- 83.27% total coverage
- Ruff formatting and lint: pass
- mypy: pass
- sandbox, version, agent, public-metrics, documentation, and generated-prompt checks: pass
- local 500-iteration warm benchmark: subtree p95/p99 9.638/12.579 ms; FTS p95/p99 9.265/11.343 ms

Closes #389
