### PR TITLE
fix: invalidate Shadow reads after sync failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Fail-closed Shadow sync failures (#386)** — invalidate cached reads after every generic incremental, delete, callback, or watchdog failure; persist the content-free `incremental_sync_failed` reason in both Shadow metadata and a private external-cache marker when available, retain an in-process latch when storage is unavailable, and clear all invalidation only after a successful full reconciliation.
 - **Explicit Shadow read freshness (#389)** — validate requested subtree pages and every returned FTS page against the authoritative Markdown path, nanosecond mtime, and size before serving cached rows; route changed, missing, untracked, and unproven-empty reads to Markdown/generational BM25 with a bounded content-free reason, without a per-read graph scan.
 - **Read-only X-Ray aliases (#393)** — keep `xray_page` a graph-immutable read by routing its atomically replaced, process-locked alias map to the private per-graph external runtime cache under Strict Read Only while preserving graph-root state and UUID semantics in normal mode.
 - **Read-only startup log isolation (#388)** — redirect graph-local ops and Loguru paths to the validated external per-graph runtime cache before directory creation, preserve explicitly external paths, and bind Loguru to its configured sink rather than the ops JSONL path.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,6 +100,10 @@ state falls back to Markdown/BM25. `MATRYCA_CACHE_PATH` remains the explicit ext
 root override. The beta graph-local database is rebuilt externally rather than moved,
 mutated, or deleted. Decision and implementation slices:
 [`v2-external-shadow-cache-read-only.md`](quality/issue-bodies/v2-external-shadow-cache-read-only.md).
+Generic sync failures add a private content-free `shadow.sync-invalid` marker beside
+the external database and latch the generation invalid in-process. Either signal
+forces fallback until a successful full rebuild clears metadata, marker, and latch;
+authoritative Markdown writes never roll back because cache maintenance failed.
 
 **v2.0.0-rc.1 contract (Slices 1–5 complete):** an unset
 `MATRYCA_SHADOW_DB_ENABLED` now enables Shadow; explicit false remains a zero-Shadow

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -14,6 +14,14 @@ to those later bytes. Before stable promotion, bind a fresh candidate artifact a
 repeat the watcher-disabled edit/delete/rename matrix plus both Gate B profiles under
 the same fail-closed integrity rules.
 
+Issue [#386](https://github.com/MarcoPorcellato/matryca-plumber/issues/386) also
+changes post-RC generic sync-failure containment. The public RC recovery phase writes
+a controlled metadata error; it does not inject connection, schema, commit,
+disk-full-equivalent, filesystem, callback, or watchdog failures. Preserve the RC
+soak as exact-artifact history and require that focused failure/restart/full-rebuild
+matrix against the exact stable candidate; this configuration-excluded branch does
+not restart the historical multi-day RC timer by itself.
+
 ## Recorded checkpoint snapshot (public candidate `2.0.0rc1`)
 
 The recorded checkpoint for stable-promotion evidence is `RUNNING`

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -291,18 +291,34 @@ Gate B profiles again before stable promotion.
 
 #### EX-05 — Invalidate stale Shadow generations on every sync failure
 
-**Verified failure-handling gap; outcome hypothesis:** generic incremental failures roll back and propagate, but the post-write bridge catches and logs them (`src/shadow/sync.py:291-335`). Only selected parse failures persist error metadata. Some generic failures may leave old rows eligible for `READY`; others will make the next open/health operation return `ERROR`. Fault injection must establish the exact transition for each class.
+**Implemented in #386:** every generic incremental or delete failure now latches the
+current Shadow generation invalid before propagating to direct callers or being
+contained by post-write/watchdog adapters. Reads report `ERROR` and use Markdown/BM25
+fallback; the state API exposes the closed content-free reason
+`incremental_sync_failed` under `not_ready_reason=sync_error`.
 
-**Smallest slice:** persist a content-free invalid-generation/sync-error marker after any failed transaction; route reads to Markdown until successful reconciliation clears it.
+Invalidation has three fail-closed layers. The process-local latch works even when no
+cache write is possible. A private `0600` `shadow.sync-invalid` marker in the external
+per-graph cache survives process restart and SQLite writer contention. When SQLite is
+writable, `last_sync_error` stores the same bounded reason. The marker rejects symlink
+targets and contains no graph path, page title, block identifier, content, or raw
+exception. Failure to persist either durable channel never clears the runtime latch or
+masks the original sync exception.
 
-Acceptance gate:
+Focused fault injection covers connection, schema, commit, disk-full-equivalent,
+filesystem, post-write callback, and watchdog failures. The committed Markdown write
+survives callback failure; the prior generation and generation number remain intact
+but ineligible. A successful full rebuild increments the generation, clears metadata,
+removes the durable marker, clears the runtime latch, and restores `READY`.
 
-- inject generic connection, schema, commit, disk-full-equivalent, filesystem, callback, and watchdog failures;
-- authoritative Markdown writes still succeed;
-- every class either already becomes non-`READY` or is made explicitly non-`READY`, with a bounded content-free reason;
-- successful reconciliation clears the marker with defined generation semantics and restores `READY`.
+Unrelated successful incremental writes deliberately do not clear a global failure:
+only full reconciliation proves that every source page has been reconsidered.
 
-Non-goal: do not make cache failure fail the authoritative write.
+**Gate B impact:** the public RC's controlled recovery probe writes
+`last_sync_error` directly; it does not inject these generic incremental branches.
+Keep the multi-day RC result bound to the exact published wheel. The stable candidate
+must run the focused exact-wheel failure/restart/rebuild matrix, but #386 alone does
+not restart the historical RC soak clock.
 
 ### P1 — Security, operability, and architectural enforcement
 

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -41,6 +41,10 @@ Published beta path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite`
 canonical per-user external cache, isolated by versioned graph identity, with
 `MATRYCA_CACHE_PATH` as an absolute external root override. The derived Shadow
 database is rebuilt externally and never moved or mutated in place under Read Only.
+Generic sync failures additionally create a private content-free
+`shadow.sync-invalid` marker in that external per-graph directory. Health and state
+reads treat either this durable marker or the in-process invalid-generation latch as
+an error until a successful full rebuild clears both ([#386](https://github.com/MarcoPorcellato/matryca-plumber/issues/386)).
 
 ---
 
@@ -53,6 +57,7 @@ database is rebuilt externally and never moved or mutated in place under Read On
 - [x] Incremental post-write upsert — `sync_page_to_shadow` ([#182](https://github.com/MarcoPorcellato/matryca-plumber/issues/182))
 - [x] FTS5 query helper — `search_blocks_fts` ([#183](https://github.com/MarcoPorcellato/matryca-plumber/issues/183); dispatch wiring [#250](https://github.com/MarcoPorcellato/matryca-plumber/issues/250))
 - [x] Full bootstrap / reconciliation / freshness contract ([#176](https://github.com/MarcoPorcellato/matryca-plumber/issues/176), [#248](https://github.com/MarcoPorcellato/matryca-plumber/issues/248))
+- [x] Fail-closed generic sync invalidation and deterministic full-rebuild recovery ([#386](https://github.com/MarcoPorcellato/matryca-plumber/issues/386))
 - [x] `GraphRepository` read routing — `ShadowGraphRepository` + `get_graph_read_port` ([#255](https://github.com/MarcoPorcellato/matryca-plumber/issues/255))
 - [x] Recursive CTEs (`query_subtree_by_block_uuid`) ([#253](https://github.com/MarcoPorcellato/matryca-plumber/issues/253))
 - [x] Opt-in env flag `MATRYCA_SHADOW_DB_ENABLED` ([#184](https://github.com/MarcoPorcellato/matryca-plumber/issues/184))

--- a/src/shadow/bootstrap.py
+++ b/src/shadow/bootstrap.py
@@ -33,7 +33,12 @@ from .runtime_state import (
     rebuild_lock_for,
 )
 from .schema import SHADOW_SCHEMA_VERSION
-from .sync import delete_shadow_page_by_file_path, sync_page_to_shadow
+from .sync import (
+    delete_shadow_page_by_file_path,
+    record_shadow_sync_failure,
+    sync_page_to_shadow,
+)
+from .sync_failure import clear_shadow_sync_failed, is_shadow_sync_failed
 from .writer_lock import shadow_rebuild_lock
 
 _BOOTSTRAP_CHECKED: set[str] = set()
@@ -46,6 +51,8 @@ def _utc_now_iso() -> str:
 def shadow_needs_bootstrap(graph_root: Path | str) -> bool:
     """Return whether a compatible full sync generation is missing."""
     root = resolved_graph_root(graph_root)
+    if is_shadow_sync_failed(root):
+        return True
     if not shadow_db_path(root).is_file():
         return True
     conn = open_shadow_db(root)
@@ -108,6 +115,7 @@ def rebuild_shadow_from_graph(graph_root: Path | str) -> None:
                 set_meta(conn, META_QUARANTINED_PAGE_COUNT, str(quarantined))
                 set_meta(conn, META_LAST_SYNC_ERROR, "")
                 conn.commit()
+                clear_shadow_sync_failed(root)
                 if quarantined:
                     logger.warning(
                         "Shadow rebuild parked {} of {} pages outside the read cache; "
@@ -183,6 +191,7 @@ def handle_shadow_watchdog_change(
     """Sync or delete shadow rows after debounced external vault edits."""
     if not shadow_db_enabled():
         return
+    root: Path | None = None
     try:
         root = resolved_graph_root(graph_root)
         safe = assert_path_within_graph(path, root)
@@ -201,6 +210,8 @@ def handle_shadow_watchdog_change(
     except ShadowPageParseError as exc:
         logger.warning("Shadow watchdog sync rejected: {}", exc)
     except Exception:  # noqa: BLE001 — fail-safe like AST bridge
+        if root is not None:
+            record_shadow_sync_failure(root)
         logger.exception("Shadow watchdog sync failed for {} ({})", path, kind)
 
 

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -20,6 +20,7 @@ from .meta import (
 from .quarantine import quarantined_page_count
 from .runtime_state import is_shadow_bootstrapping
 from .schema import SHADOW_SCHEMA_VERSION
+from .sync_failure import is_shadow_sync_failed
 
 
 class ShadowHealthState(StrEnum):
@@ -72,6 +73,8 @@ def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
     root = resolved_graph_root(graph_root)
     if is_shadow_bootstrapping(root):
         return ShadowHealthState.BOOTSTRAPPING
+    if is_shadow_sync_failed(root):
+        return ShadowHealthState.ERROR
     try:
         db_path = shadow_db_path(root)
     except (OSError, RuntimeError, PathTraversalSecurityError):

--- a/src/shadow/runtime_state.py
+++ b/src/shadow/runtime_state.py
@@ -10,6 +10,7 @@ from ..graph.path_sandbox import resolved_graph_root
 
 _rebuild_locks: dict[str, threading.Lock] = {}
 _bootstrapping_roots: set[str] = set()
+_invalidated_roots: set[str] = set()
 _deferred_sync_paths: dict[str, set[str]] = defaultdict(set)
 _state_lock = threading.Lock()
 
@@ -38,6 +39,22 @@ def clear_bootstrapping(graph_root: Path | str) -> None:
         _bootstrapping_roots.discard(graph_root_key(graph_root))
 
 
+def mark_shadow_generation_invalid(graph_root: Path | str) -> None:
+    """Fail closed for reads when a sync failure cannot be persisted."""
+    with _state_lock:
+        _invalidated_roots.add(graph_root_key(graph_root))
+
+
+def clear_shadow_generation_invalid(graph_root: Path | str) -> None:
+    """Clear the process-local failure latch after a successful full rebuild."""
+    with _state_lock:
+        _invalidated_roots.discard(graph_root_key(graph_root))
+
+
+def is_shadow_generation_invalid(graph_root: Path | str) -> bool:
+    return graph_root_key(graph_root) in _invalidated_roots
+
+
 def defer_sync_path(graph_root: Path | str, rel_path: str) -> None:
     with _state_lock:
         _deferred_sync_paths[graph_root_key(graph_root)].add(rel_path)
@@ -54,14 +71,18 @@ def reset_shadow_runtime_state_for_tests() -> None:
     with _state_lock:
         _rebuild_locks.clear()
         _bootstrapping_roots.clear()
+        _invalidated_roots.clear()
         _deferred_sync_paths.clear()
 
 
 __all__ = [
     "clear_bootstrapping",
+    "clear_shadow_generation_invalid",
     "defer_sync_path",
     "graph_root_key",
     "is_shadow_bootstrapping",
+    "is_shadow_generation_invalid",
+    "mark_shadow_generation_invalid",
     "mark_bootstrapping",
     "pop_deferred_sync_paths",
     "rebuild_lock_for",

--- a/src/shadow/state_api.py
+++ b/src/shadow/state_api.py
@@ -25,6 +25,7 @@ from .meta import (
 )
 from .runtime_state import is_shadow_bootstrapping
 from .schema import SHADOW_SCHEMA_VERSION
+from .sync_failure import SHADOW_SYNC_FAILURE_REASON, is_shadow_sync_failed
 
 ShadowDbStateValue = Literal["disabled", "bootstrapping", "ready", "stale", "error"]
 
@@ -225,6 +226,13 @@ def resolve_shadow_db_state_for_api(graph_root: Path | str) -> ShadowDbStateResp
             enabled=True,
             state="bootstrapping",
             not_ready_reason="bootstrap_in_progress",
+        )
+    if is_shadow_sync_failed(root):
+        return ShadowDbStateResponse(
+            enabled=True,
+            state="error",
+            last_sync_error=SHADOW_SYNC_FAILURE_REASON,
+            not_ready_reason="sync_error",
         )
 
     try:

--- a/src/shadow/sync.py
+++ b/src/shadow/sync.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -39,7 +40,11 @@ from .quarantine import (
     normalize_quarantine_reason,
     record_quarantined_page,
 )
-from .runtime_state import defer_sync_path, is_shadow_bootstrapping
+from .runtime_state import (
+    defer_sync_path,
+    is_shadow_bootstrapping,
+)
+from .sync_failure import SHADOW_SYNC_FAILURE_REASON, mark_shadow_sync_failed
 from .writer_lock import shadow_writer_lock
 
 _bridge_lock = threading.Lock()
@@ -146,18 +151,22 @@ def delete_shadow_page_by_file_path(graph_root: Path | str, rel_path: str) -> No
     if not shadow_db_enabled():
         return
     root = resolved_graph_root(graph_root)
-    with shadow_writer_lock(root):
-        conn = open_shadow_db(root)
-        try:
-            conn.execute("DELETE FROM pages WHERE file_path = ?", (rel_path,))
-            clear_quarantined_page(conn, rel_path)
-            set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
-            conn.commit()
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
+    try:
+        with shadow_writer_lock(root):
+            conn = open_shadow_db(root)
+            try:
+                conn.execute("DELETE FROM pages WHERE file_path = ?", (rel_path,))
+                clear_quarantined_page(conn, rel_path)
+                set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+    except Exception:
+        record_shadow_sync_failure(root)
+        raise
 
 
 def sync_page_into_connection(
@@ -288,39 +297,51 @@ def sync_page_to_shadow(graph_root: Path | str, page_path: Path | str) -> None:
         defer_sync_path(root, rel)
         return
 
-    with shadow_writer_lock(root):
-        conn = open_shadow_db(root)
-        parse_error: ShadowPageParseError | None = None
-        try:
-            sync_page_into_connection(conn, root, path)
-            set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
-            conn.commit()
-        except ShadowPageParseError as exc:
-            conn.rollback()
-            parse_error = exc
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
-
-        if parse_error is not None:
-            _record_incremental_parse_error(root, str(parse_error))
-            raise parse_error
-
-
-def _record_incremental_parse_error(graph_root: Path, message: str) -> None:
-    """Persist a bounded parse failure after its page transaction has rolled back."""
-    conn = open_shadow_db(graph_root)
     try:
-        ensure_meta_defaults(conn)
-        set_meta(conn, META_LAST_SYNC_ERROR, message)
-        conn.commit()
-    except Exception:  # noqa: BLE001 - sync failure must still propagate to caller
-        conn.rollback()
-        logger.exception("Failed to persist bounded shadow parse error")
+        with shadow_writer_lock(root):
+            conn = open_shadow_db(root)
+            try:
+                sync_page_into_connection(conn, root, path)
+                set_meta(conn, META_LAST_INCREMENTAL_SYNC_AT, _utc_now_iso())
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+    except ShadowPageParseError as exc:
+        record_shadow_sync_failure(root, str(exc))
+        raise
+    except Exception:
+        record_shadow_sync_failure(root)
+        raise
+
+
+def record_shadow_sync_failure(
+    graph_root: Path,
+    message: str = SHADOW_SYNC_FAILURE_REASON,
+) -> None:
+    """Invalidate reads and best-effort persist one bounded failure reason."""
+    mark_shadow_sync_failed(graph_root)
+    try:
+        conn = open_shadow_db(graph_root)
+    except Exception:  # noqa: BLE001 - runtime latch still fails reads closed
+        logger.warning("Failed to open Shadow DB while persisting sync failure")
+        return
+    try:
+        try:
+            ensure_meta_defaults(conn)
+            set_meta(conn, META_LAST_SYNC_ERROR, message)
+            conn.commit()
+        except Exception:  # noqa: BLE001 - runtime latch still fails reads closed
+            with suppress(Exception):
+                conn.rollback()
+            logger.warning("Failed to persist bounded Shadow sync failure")
     finally:
-        conn.close()
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001 - runtime latch remains authoritative
+            logger.warning("Failed to close Shadow DB after sync-failure persistence")
 
 
 def _on_shadow_page_written(event: PageWrittenEvent) -> None:
@@ -331,6 +352,7 @@ def _on_shadow_page_written(event: PageWrittenEvent) -> None:
     except ShadowPageParseError as exc:
         logger.warning("Shadow sync rejected after write: {}", exc)
     except Exception:  # noqa: BLE001 — fail-safe like AST bridge
+        record_shadow_sync_failure(event.graph_root)
         logger.exception("Shadow sync failed after write to {}", event.path)
 
 
@@ -356,6 +378,7 @@ def reset_shadow_sync_bridge_for_tests() -> None:
 __all__ = [
     "delete_shadow_page_by_file_path",
     "ensure_shadow_sync_bridge",
+    "record_shadow_sync_failure",
     "reset_shadow_sync_bridge_for_tests",
     "sync_page_into_connection",
     "sync_page_to_shadow",

--- a/src/shadow/sync_failure.py
+++ b/src/shadow/sync_failure.py
@@ -1,0 +1,76 @@
+"""Durable, content-free invalidation for failed Shadow synchronization."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from loguru import logger
+
+from .cache_location import ShadowCacheLocationError, resolve_shadow_cache_location
+from .runtime_state import (
+    clear_shadow_generation_invalid,
+    is_shadow_generation_invalid,
+    mark_shadow_generation_invalid,
+)
+
+SHADOW_SYNC_FAILURE_REASON = "incremental_sync_failed"
+_FAILURE_MARKER_FILENAME = "shadow.sync-invalid"
+
+
+def _marker_path(graph_root: Path | str) -> Path:
+    location = resolve_shadow_cache_location(graph_root)
+    return location.shadow_dir / _FAILURE_MARKER_FILENAME
+
+
+def mark_shadow_sync_failed(graph_root: Path | str) -> None:
+    """Latch failure in memory and best-effort persist it outside SQLite."""
+    mark_shadow_generation_invalid(graph_root)
+    try:
+        location = resolve_shadow_cache_location(graph_root)
+        location.ensure_directory()
+        marker = location.shadow_dir / _FAILURE_MARKER_FILENAME
+        if marker.is_symlink():
+            raise ShadowCacheLocationError("sync_failure_marker_symlink")
+        flags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(marker, flags, 0o600)
+        try:
+            if os.name == "posix":
+                os.fchmod(descriptor, 0o600)
+            os.write(descriptor, SHADOW_SYNC_FAILURE_REASON.encode("ascii"))
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except (OSError, RuntimeError, ShadowCacheLocationError):
+        logger.warning("Failed to persist the content-free Shadow sync-failure marker")
+
+
+def clear_shadow_sync_failed(graph_root: Path | str) -> bool:
+    """Clear durable and in-process invalidation after full reconciliation."""
+    try:
+        marker = _marker_path(graph_root)
+        marker.unlink(missing_ok=True)
+    except (OSError, RuntimeError, ShadowCacheLocationError):
+        logger.warning("Failed to clear the content-free Shadow sync-failure marker")
+        return False
+    clear_shadow_generation_invalid(graph_root)
+    return True
+
+
+def is_shadow_sync_failed(graph_root: Path | str) -> bool:
+    """Return whether this process or the durable marker invalidates reads."""
+    if is_shadow_generation_invalid(graph_root):
+        return True
+    try:
+        marker = _marker_path(graph_root)
+    except (OSError, RuntimeError, ShadowCacheLocationError):
+        return False
+    return marker.is_symlink() or marker.exists()
+
+
+__all__ = [
+    "SHADOW_SYNC_FAILURE_REASON",
+    "clear_shadow_sync_failed",
+    "is_shadow_sync_failed",
+    "mark_shadow_sync_failed",
+]

--- a/tests/test_shadow_hardening_axis1_concurrency.py
+++ b/tests/test_shadow_hardening_axis1_concurrency.py
@@ -251,6 +251,7 @@ def test_a1_sqlite_writer_lock_blocks_incremental_without_meta_corruption(
         assert conn.execute("SELECT COUNT(*) FROM pages").fetchone()[0] == 1
     finally:
         conn.close()
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
 
 
 def _multiprocess_rebuild_worker(graph_str: str) -> None:

--- a/tests/test_shadow_hardening_axis4_fts5.py
+++ b/tests/test_shadow_hardening_axis4_fts5.py
@@ -850,5 +850,5 @@ def test_a4_fail_05_writer_lock_does_not_corrupt_fts_meta(tmp_path: Path) -> Non
     finally:
         holder.rollback()
         holder.close()
-    assert resolve_shadow_health(graph) == ShadowHealthState.READY
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
     assert shadow_db_path(graph).is_file()

--- a/tests/test_shadow_sync_failure_invalidation.py
+++ b/tests/test_shadow_sync_failure_invalidation.py
@@ -1,0 +1,239 @@
+"""Fail-closed Shadow generation invalidation for generic sync failures (#386)."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.graph.markdown_blocks import atomic_write_bytes
+from src.graph.post_write import clear_page_written_handlers
+from src.shadow.bootstrap import handle_shadow_watchdog_change, rebuild_shadow_from_graph
+from src.shadow.cache_location import resolve_shadow_cache_location
+from src.shadow.connection import open_shadow_db
+from src.shadow.health import ShadowHealthState, resolve_shadow_health
+from src.shadow.meta import META_GENERATION, META_LAST_SYNC_ERROR, get_meta
+from src.shadow.runtime_state import (
+    is_shadow_generation_invalid,
+    reset_shadow_runtime_state_for_tests,
+)
+from src.shadow.state_api import resolve_shadow_db_state_for_api
+from src.shadow.sync import (
+    ensure_shadow_sync_bridge,
+    reset_shadow_sync_bridge_for_tests,
+    sync_page_to_shadow,
+)
+from src.shadow.sync_failure import (
+    SHADOW_SYNC_FAILURE_REASON,
+    is_shadow_sync_failed,
+    mark_shadow_sync_failed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shadow(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    reset_shadow_runtime_state_for_tests()
+    clear_page_written_handlers()
+    reset_shadow_sync_bridge_for_tests()
+    yield
+    clear_page_written_handlers()
+    reset_shadow_sync_bridge_for_tests()
+
+
+def _ready_graph(tmp_path: Path) -> tuple[Path, Path, str]:
+    graph = tmp_path / "graph"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Alpha.md"
+    page.write_text(
+        "- old content\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+    rebuild_shadow_from_graph(graph)
+    conn = open_shadow_db(graph)
+    try:
+        generation = get_meta(conn, META_GENERATION) or ""
+    finally:
+        conn.close()
+    page.write_text(
+        "- current content\n  id:: aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\n",
+        encoding="utf-8",
+    )
+    return graph, page, generation
+
+
+def _assert_persisted_failure(graph: Path, generation: str) -> None:
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_GENERATION) == generation
+        assert get_meta(conn, META_LAST_SYNC_ERROR) == SHADOW_SYNC_FAILURE_REASON
+    finally:
+        conn.close()
+    assert is_shadow_generation_invalid(graph)
+    assert is_shadow_sync_failed(graph)
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    state = resolve_shadow_db_state_for_api(graph)
+    assert state.state == "error"
+    assert state.not_ready_reason == "sync_error"
+    assert state.last_sync_error == SHADOW_SYNC_FAILURE_REASON
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        sqlite3.DatabaseError("schema failure"),
+        sqlite3.OperationalError("database or disk is full"),
+        OSError("filesystem failure"),
+    ],
+    ids=["schema", "disk-full", "filesystem"],
+)
+def test_generic_transaction_failures_persist_invalidation(
+    tmp_path: Path,
+    failure: Exception,
+) -> None:
+    graph, page, generation = _ready_graph(tmp_path)
+    with (
+        patch("src.shadow.sync.sync_page_into_connection", side_effect=failure),
+        pytest.raises(type(failure)),
+    ):
+        sync_page_to_shadow(graph, page)
+
+    _assert_persisted_failure(graph, generation)
+
+
+def test_connection_failure_uses_runtime_latch_when_meta_cannot_be_written(
+    tmp_path: Path,
+) -> None:
+    graph, page, _generation = _ready_graph(tmp_path)
+    with (
+        patch(
+            "src.shadow.sync.open_shadow_db",
+            side_effect=sqlite3.OperationalError("connection failure"),
+        ),
+        pytest.raises(sqlite3.OperationalError),
+    ):
+        sync_page_to_shadow(graph, page)
+
+    assert is_shadow_generation_invalid(graph)
+    marker = resolve_shadow_cache_location(graph).shadow_dir / "shadow.sync-invalid"
+    assert marker.read_text(encoding="ascii") == SHADOW_SYNC_FAILURE_REASON
+    if os.name == "posix":
+        assert stat.S_IMODE(marker.stat().st_mode) == 0o600
+    reset_shadow_runtime_state_for_tests()
+    assert is_shadow_sync_failed(graph)
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    state = resolve_shadow_db_state_for_api(graph)
+    assert state.not_ready_reason == "sync_error"
+    assert state.last_sync_error == SHADOW_SYNC_FAILURE_REASON
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges on Windows")
+def test_failure_marker_rejects_symlink_without_touching_target(tmp_path: Path) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    location = resolve_shadow_cache_location(graph)
+    location.ensure_directory()
+    target = tmp_path / "outside.txt"
+    target.write_text("unchanged", encoding="utf-8")
+    marker = location.shadow_dir / "shadow.sync-invalid"
+    marker.symlink_to(target)
+
+    mark_shadow_sync_failed(graph)
+
+    assert marker.is_symlink()
+    assert target.read_text(encoding="utf-8") == "unchanged"
+    assert is_shadow_sync_failed(graph)
+
+
+def test_unexpected_marker_object_fails_closed_after_restart(tmp_path: Path) -> None:
+    graph = tmp_path / "graph"
+    graph.mkdir()
+    marker = resolve_shadow_cache_location(graph).shadow_dir / "shadow.sync-invalid"
+    marker.mkdir(parents=True)
+
+    reset_shadow_runtime_state_for_tests()
+
+    assert is_shadow_sync_failed(graph)
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+
+
+def test_commit_failure_rolls_back_then_persists_invalidation(tmp_path: Path) -> None:
+    graph, page, generation = _ready_graph(tmp_path)
+    transaction = open_shadow_db(graph)
+    recorder = open_shadow_db(graph)
+
+    class _CommitFailureConnection:
+        def __getattr__(self, name: str) -> object:
+            return getattr(transaction, name)
+
+        def commit(self) -> None:
+            raise sqlite3.OperationalError("commit failure")
+
+    with (
+        patch(
+            "src.shadow.sync.open_shadow_db",
+            side_effect=[_CommitFailureConnection(), recorder],
+        ),
+        pytest.raises(sqlite3.OperationalError, match="commit failure"),
+    ):
+        sync_page_to_shadow(graph, page)
+
+    _assert_persisted_failure(graph, generation)
+
+
+def test_post_write_failure_does_not_undo_authoritative_markdown(tmp_path: Path) -> None:
+    graph, page, _generation = _ready_graph(tmp_path)
+    ensure_shadow_sync_bridge()
+    body = b"- authoritative write survives\n"
+
+    with patch(
+        "src.shadow.sync.sync_page_to_shadow",
+        side_effect=RuntimeError("callback failure"),
+    ):
+        atomic_write_bytes(page, body, graph_root=graph, robot_commit_summary="test")
+
+    assert page.read_bytes() == body
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    assert resolve_shadow_db_state_for_api(graph).last_sync_error == SHADOW_SYNC_FAILURE_REASON
+
+
+def test_watchdog_failure_is_contained_and_invalidates_reads(tmp_path: Path) -> None:
+    graph, page, _generation = _ready_graph(tmp_path)
+    with patch(
+        "src.shadow.bootstrap.sync_page_to_shadow",
+        side_effect=RuntimeError("watchdog failure"),
+    ):
+        handle_shadow_watchdog_change(graph, page, "modified")
+
+    assert resolve_shadow_health(graph) == ShadowHealthState.ERROR
+    assert resolve_shadow_db_state_for_api(graph).last_sync_error == SHADOW_SYNC_FAILURE_REASON
+
+
+def test_successful_full_reconciliation_clears_failure_latch(tmp_path: Path) -> None:
+    graph, page, generation = _ready_graph(tmp_path)
+    with (
+        patch(
+            "src.shadow.sync.sync_page_into_connection",
+            side_effect=sqlite3.OperationalError("generic failure"),
+        ),
+        pytest.raises(sqlite3.OperationalError),
+    ):
+        sync_page_to_shadow(graph, page)
+    _assert_persisted_failure(graph, generation)
+
+    rebuild_shadow_from_graph(graph)
+
+    conn = open_shadow_db(graph)
+    try:
+        assert get_meta(conn, META_LAST_SYNC_ERROR) == ""
+        assert int(get_meta(conn, META_GENERATION) or "0") == int(generation) + 1
+    finally:
+        conn.close()
+    assert not is_shadow_generation_invalid(graph)
+    assert not is_shadow_sync_failed(graph)
+    assert resolve_shadow_health(graph) == ShadowHealthState.READY


### PR DESCRIPTION
## Summary

- invalidate the current Shadow generation after generic incremental, delete, callback, and watchdog sync failures
- keep a content-free process-local latch plus a private `0600` external-cache marker so stale reads remain disabled across restarts and SQLite failures
- restore `READY` only after a successful full reconciliation clears metadata, marker, and runtime state
- document the stable-candidate qualification matrix without modifying the historical `2.0.0rc1` Gate B evidence

## Test plan

- [x] `uv run pytest --no-cov -q tests/test_shadow*.py` (334 passed)
- [x] `uv run pytest -n auto -q` (1,636 passed, 5 skipped, 83.31% coverage)
- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy src/ tests/`
- [x] graph sandbox, version, agent coherence, public metrics, documentation inventory, and generated prompt checks

## Release qualification

The ongoing Gate B soak remains bound to the exact published `2.0.0rc1` wheel and is not altered by this post-RC change. The stable candidate must run the focused failure/restart/full-rebuild matrix documented in the runbook.

Closes #386
Refs #343
Refs #385
