### PR TITLE
fix: enforce UI token policy before bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - **Read-only startup log isolation (#388)** — redirect graph-local ops and Loguru paths to the validated external per-graph runtime cache before directory creation, preserve explicitly external paths, and bind Loguru to its configured sink rather than the ops JSONL path.
 - **Gate B RC artifact and timing binding** — verify the public wheel SHA-256 and installed RECORD against `2.0.0rc1`, and include measured probe time so valid profile probes advance the resumable soak instead of retrying as `probe_invalid`, while preserving the historical beta collector's default contract.
 
+### Security
+
+- **First-run UI token policy (#395)** — materialize and reload the safe `.env.example` defaults before evaluating UI host and explicit-token policy, so a clean installation refuses insecure startup before browser scheduling or Uvicorn bind just like an existing `.env` installation.
+
 ## [2.0.0-rc.1] - 2026-08-03
 
 ### Fixed

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -362,14 +362,56 @@ Acceptance gate:
 
 #### EX-09 — Close first-run token ordering
 
-**Verified first-run policy-order defect:** token policy is checked before the UI lifespan may create `.env` from `.env.example` (`src/cli/ui_server.py:649-655`, `src/cli/ui_server.py:1126-1140`). On a clean first run, example defaults can therefore be applied after enforcement. This is not evidence of a remote authentication bypass; LAN binding still has a separate explicit-token requirement.
+**Tranche manifest (frozen 2026-08-07):**
 
-**Smallest slice:** materialize/load defaults before token policy evaluation and before binding.
+```yaml
+tranche_id: EX-09-01
+repository: MarcoPorcellato/matryca-plumber
+base_commit: bac65e6820002ffda65fd3fbbeb5e20ac7b6d36f
+objective: enforce materialized UI token defaults before every network-bind decision
+authority: inspect | edit | commit | push | pr
+allowlist:
+  - src/cli/ui_server.py::run_ui_server
+  - tests/test_ui_server.py
+  - CHANGELOG.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+non_goals:
+  - change token generation, LAN policy, API response shapes, or dotenv write concurrency
+  - modify Gate B evidence, release artifacts, tags, releases, or publication state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_ui_server.py tests/test_ui_explicit_token.py tests/test_ui_auth_lan.py tests/test_runtime_bootstrap.py
+acceptance:
+  - clean and existing dotenv states enforce explicit-token defaults before Uvicorn bind
+  - loopback bootstrap and explicit LAN protection remain unchanged
+  - failure remains typed and secret-free
+stop_conditions:
+  - any required change outside the composition-root allowlist or existing auth contract
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: bac65e6820002ffda65fd3fbbeb5e20ac7b6d36f
+  evidence_paths:
+    - src/cli/ui_server.py
+    - src/cli/ui_auth.py
+    - src/utils/runtime_bootstrap.py
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: lifecycle | provenance
+residual_risks:
+  - startup policy remains process-environment driven after deterministic dotenv loading
+```
 
-Acceptance gate:
+**Implemented in #395:** `run_ui_server()` now materializes `.env` from the safe
+template when needed and reloads it before evaluating either LAN binding or explicit
+token policy. The same sequence applies when `.env` already exists, so startup no
+longer depends on installation history. Policy failure remains a typed, secret-free
+`ValueError` and occurs before browser scheduling, frontend preparation, or
+`uvicorn.run()`.
 
-- clean first run with explicit-token-required defaults refuses startup before Uvicorn binds;
-- loopback bootstrap and explicit LAN protection remain intact.
+Parameterized composition-root tests use isolated temporary repositories to exercise
+both clean and existing dotenv states with the real copy-and-reload helpers. The
+template's explicit-token requirement refuses both before bind, while the established
+loopback bootstrap and explicit LAN tests remain green. No token generation, LAN
+policy, endpoint shape, dotenv writer, or Gate B behavior changes in this tranche.
 
 #### EX-10 — Replace string-based architecture tests with AST enforcement
 

--- a/src/cli/ui_server.py
+++ b/src/cli/ui_server.py
@@ -1127,12 +1127,15 @@ def run_ui_server(*, host: str = "127.0.0.1", port: int = DEFAULT_UI_PORT) -> No
     """Start Uvicorn and open the Plumber control-room dashboard in the default browser."""
     import uvicorn
 
+    from ..utils.runtime_bootstrap import ensure_repo_dotenv_from_example
+
+    ensure_repo_dotenv_from_example()
+    reload_plumber_dotenv()
     if host == "0.0.0.0" and not _ui_allow_lan():
         raise ValueError(
             "Refusing to bind UI server to 0.0.0.0 without MATRYCA_UI_ALLOW_LAN=1 "
             "(LAN clients could reach authenticated API routes if they obtain a token)."
         )
-    reload_plumber_dotenv()
     from .ui_auth import require_explicit_ui_token_if_configured, warn_if_ephemeral_ui_token
 
     require_explicit_ui_token_if_configured()

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -885,6 +885,37 @@ def test_run_ui_server_opens_dashboard_and_starts_uvicorn() -> None:
     )
 
 
+@pytest.mark.parametrize("dotenv_preexists", [False, True])
+def test_run_ui_server_enforces_explicit_token_after_startup_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dotenv_preexists: bool,
+) -> None:
+    from src.cli import ui_server
+
+    policy = "MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN=true\nMATRYCA_UI_TOKEN=\n"
+    if dotenv_preexists:
+        (tmp_path / ".env").write_text(policy, encoding="utf-8")
+    else:
+        (tmp_path / ".env.example").write_text(policy, encoding="utf-8")
+    monkeypatch.delenv("MATRYCA_UI_TOKEN", raising=False)
+    monkeypatch.delenv("MATRYCA_UI_REQUIRE_EXPLICIT_TOKEN", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr("src.utils.runtime_bootstrap._REPO_ROOT", tmp_path)
+    monkeypatch.setattr("src.agent.plumber_config._REPO_ROOT", tmp_path)
+
+    with (
+        patch("src.cli.ui_server._schedule_browser_open") as mock_schedule,
+        patch("uvicorn.run") as mock_run,
+        pytest.raises(ValueError, match="MATRYCA_UI_TOKEN"),
+    ):
+        ui_server.run_ui_server()
+
+    assert (tmp_path / ".env").read_text(encoding="utf-8") == policy
+    mock_schedule.assert_not_called()
+    mock_run.assert_not_called()
+
+
 def test_ui_server_serves_frontend_index_when_dist_exists(
     tmp_path: Path,
     auth_headers: dict[str, str],


### PR DESCRIPTION
## Summary

- materialize `.env` from `.env.example` before evaluating UI host or token policy
- make clean and existing installations follow the same deterministic startup sequence
- refuse explicit-token policy failures before browser scheduling, frontend preparation, or Uvicorn bind
- preserve loopback bootstrap, LAN token requirements, token generation, and API contracts

## Test plan

- [x] focused UI/auth/runtime-bootstrap/env matrix (82 passed)
- [x] `uv run pytest -n auto -q` (1,638 passed, 5 skipped, 83.31% coverage)
- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy src/ tests/`
- [x] graph sandbox, version, agent coherence, public metrics, documentation inventory, and generated prompt checks

## Release qualification

This composition-root change does not modify the published `2.0.0rc1` wheel, Shadow profiles, Gate B evidence, tags, releases, or publication state.

Closes #395
Refs #343
Refs #385
