### PR TITLE
fix(security): make UI API keys write-only (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Security
 
+- **Write-only UI API keys (#390)** — stop returning configured LLM credentials from `/api/config` or retaining legacy readback in React state; expose only configured status while preserving omitted keys and supporting write-only replacement or explicit clearing.
 - **First-run UI token policy (#395)** — materialize and reload the safe `.env.example` defaults before evaluating UI host and explicit-token policy, so a clean installation refuses insecure startup before browser scheduling or Uvicorn bind just like an existing `.env` installation.
 
 ## [2.0.0-rc.1] - 2026-08-03

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,7 +384,7 @@ These commands start the **control room only** — not the maintenance daemon. O
 
 A **monolithic** Uvicorn process serves:
 
-- **REST API** — `/api/state`, `/api/logs`, `/api/config`, daemon control, LM model discovery (SSRF-hardened)
+- **REST API** — `/api/state`, `/api/logs`, `/api/config`, daemon control, LM model discovery (SSRF-hardened). Config responses expose only whether an LLM API key is configured; replacement and explicit clearing use a write-only request field that is never echoed to browser state.
 - **Static SPA** — `frontend/dist/` built from Vite; polls on a **5s distributed cycle** via `usePlumberPolling` (`/api/state` every cycle — including a background **5s** poll when `daemon_pid` is live but logs are frozen; `/api/logs` staggered; `/api/graph-analytics` ~every 20s)
 - **Zero-Trust auth** — `X-Matryca-Token` on protected routes (`ui_auth.py`)
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -338,6 +338,58 @@ Acceptance gate:
 
 #### EX-07 — Stop returning LLM secrets from `/api/config`
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-07-01
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 34deb3bc02d82f3675c9e1dd50b61319e20ab9b2
+objective: make the UI LLM API key write-only across backend and frontend configuration surfaces
+authority: inspect | edit | commit | push | pr
+allowlist:
+  - src/cli/ui_server.py
+  - tests/test_ui_server.py
+  - frontend/src/types/daemon.ts
+  - frontend/src/hooks/usePlumberPolling.ts
+  - frontend/src/components/SettingsDrawer.tsx
+  - frontend/src/components/MasterHeader.tsx
+  - frontend/src/utils/plumberConfigDefaults.ts
+  - frontend/src/utils/plumberConfigSecrets.ts
+  - frontend/src/utils/plumberConfigSecrets.test.ts
+  - docs/ARCHITECTURE.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - CHANGELOG.md
+non_goals:
+  - change UI authentication, inference-provider behavior, or unrelated configuration fields
+  - serialize dotenv writers or implement optimistic concurrency reserved for EX-08
+  - modify Gate B evidence, release artifacts, tags, releases, or publication state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_ui_server.py
+  - npm run test -- src/utils/plumberConfigSecrets.test.ts
+  - npm run build
+  - npm run lint
+acceptance:
+  - GET and POST responses never serialize the configured key
+  - omission preserves, a supplied string replaces, and explicit null clears the key
+  - legacy readback is removed before any configuration payload reaches React state
+  - frontend errors and operational logs never include the configured key
+stop_conditions:
+  - any required change to authentication, another secret, or dotenv concurrency
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 34deb3bc02d82f3675c9e1dd50b61319e20ab9b2
+  evidence_paths:
+    - src/cli/ui_server.py
+    - frontend/src/hooks/usePlumberPolling.ts
+    - frontend/src/components/SettingsDrawer.tsx
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: lifecycle | provenance
+residual_risks:
+  - a newly entered replacement exists transiently in the password control and request until submission settles
+  - dotenv lost-update protection remains owned by EX-08
+```
+
 **Verified secret readback:** `PlumberConfigResponse` contains `llm_api_key` and the GET route returns the live model (`src/cli/ui_server.py:180-228`, `src/cli/ui_server.py:855-876`). Authentication reduces exposure but does not justify echoing a secret to browser state. This is a design-level exposure, not evidence that credentials have been compromised.
 
 **Smallest slice:** return `llm_api_key_configured: bool`; accept key changes through a write-only nullable field and never echo the value.
@@ -347,6 +399,28 @@ Acceptance gate:
 - serialized GET responses, frontend state, exception paths, and logs contain no configured key;
 - update, preserve-without-resending, and explicit clear all work;
 - frontend contract tests cover the new shape.
+
+**Implemented in #390:** read and write schemas are now separate. `GET /api/config`
+and every config response expose only `llm_api_key_configured`; `POST /api/config`
+accepts an optional write-only `llm_api_key`, preserving it when omitted, replacing it
+when supplied, and clearing it only when explicitly `null`. Response-model filtering
+and frontend sanitization independently prevent legacy secret readback from entering
+React configuration state.
+
+The settings drawer keeps the password control empty, reports only configured/not
+configured status, offers an explicit clear action, and removes a replacement from
+component state after submission. Focused API tests assert that response bodies and
+error details do not contain configured values, while frontend contract tests cover
+legacy-response sanitization and all three write operations. Authentication, provider
+behavior, dotenv concurrency, Gate B evidence, and release state remain unchanged.
+
+Candidate validation passed 64 focused Python API/security tests and all 20 frontend
+tests, plus the frontend TypeScript build and lint gates. The complete `make ci` gate
+also passed (format, Ruff, strict mypy over 377 files, graph sandbox, version and agent
+coherence, public-metrics policy, documentation inventory, generated prompt, and the
+full parallel Python suite). The suite retained one pre-existing macOS `fork()`
+deprecation warning in `test_fork_child_clears_flock_depth_state`; this tranche adds no
+new warning.
 
 #### EX-08 — Serialize `.env` read/merge/write updates
 

--- a/frontend/src/components/MasterHeader.tsx
+++ b/frontend/src/components/MasterHeader.tsx
@@ -2,7 +2,12 @@ import { Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useSyncExternalStore, useState } from 'react'
 
-import type { ConnectionStatus, DaemonStateResponse, PlumberConfig } from '../types/daemon'
+import type {
+  ConnectionStatus,
+  DaemonStateResponse,
+  PlumberConfig,
+  PlumberConfigUpdate,
+} from '../types/daemon'
 import { isEngineActive } from '../types/daemon'
 import { useUpdateCheck } from '../hooks/useUpdateCheck'
 import { basenameFromPath } from '../utils/metrics'
@@ -24,7 +29,7 @@ interface MasterHeaderProps {
   engineError: string | null
   onStartEngine: () => Promise<void>
   onStopEngine: () => Promise<void>
-  onSaveConfig: (payload: PlumberConfig) => Promise<PlumberConfig | null>
+  onSaveConfig: (payload: PlumberConfigUpdate) => Promise<PlumberConfig | null>
   onConfigRefreshed?: (config: PlumberConfig) => void
 }
 

--- a/frontend/src/components/SettingsDrawer.tsx
+++ b/frontend/src/components/SettingsDrawer.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import type { LmModelsResponse, PlumberConfig } from '../types/daemon'
+import type { LmModelsResponse, PlumberConfig, PlumberConfigUpdate } from '../types/daemon'
 import { MATRYCA_API_BASE, matrycaAuthenticatedFetch } from '../utils/matrycaApiAuth'
 import { emptyPlumberConfig } from '../utils/plumberConfigDefaults'
+import { buildPlumberConfigUpdate } from '../utils/plumberConfigSecrets'
 
 interface SettingsDrawerProps {
   open: boolean
   config: PlumberConfig | null
   onClose: () => void
-  onSave: (payload: PlumberConfig) => Promise<PlumberConfig | null>
+  onSave: (payload: PlumberConfigUpdate) => Promise<PlumberConfig | null>
 }
 
 interface FieldSpec {
@@ -74,13 +75,6 @@ const INFRA_FIELDS: FieldSpec[] = [
     label: 'LLM Model',
     description: 'Exact model id from your provider (Ollama requires the precise tag, e.g. llama3:8b).',
     type: 'lm-model',
-  },
-  {
-    key: 'llm_api_key',
-    label: 'API Token',
-    description:
-      'Bearer token sent as Authorization on cloud OpenAI-compatible endpoints. Required only for CLOUD; local LM Studio / Ollama may use dummy-key.',
-    type: 'password',
   },
   {
     key: 'thermal_delay_bootstrap',
@@ -489,6 +483,64 @@ function ConfigField({
   )
 }
 
+function ApiKeyField({
+  configured,
+  value,
+  clearPending,
+  onChange,
+  onClear,
+}: {
+  configured: boolean
+  value: string
+  clearPending: boolean
+  onChange: (value: string) => void
+  onClear: () => void
+}) {
+  const status = clearPending
+    ? 'Saved token will be cleared.'
+    : configured
+      ? 'A token is configured. Leave this field empty to keep it.'
+      : 'No explicit token is configured.'
+
+  return (
+    <div className="block space-y-1.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-medium text-theme-text">API Token</span>
+        <RiskBadge
+          label={configured && !clearPending ? 'Configured' : 'Not configured'}
+          className={
+            configured && !clearPending
+              ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-500'
+              : 'border-theme-border text-theme-muted'
+          }
+        />
+      </div>
+      <p className="text-[11px] leading-relaxed text-theme-muted">
+        Write-only bearer token for cloud OpenAI-compatible endpoints. Existing values are never read back into the browser.
+      </p>
+      <input
+        type="password"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={configured ? 'Enter a replacement token' : 'Enter a token'}
+        autoComplete="off"
+        className={INPUT_CLASS}
+      />
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[10px] text-theme-muted">{status}</p>
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={!configured && !value}
+          className="shrink-0 rounded-lg border border-theme-border/60 px-2.5 py-1 text-[10px] font-medium text-theme-muted transition hover:border-red-500/50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Clear saved token
+        </button>
+      </div>
+    </div>
+  )
+}
+
 function TrustSectionCard({
   section,
   draft,
@@ -558,6 +610,8 @@ export function SettingsDrawer({ open, config, onClose, onSave }: SettingsDrawer
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [apiKeyDraft, setApiKeyDraft] = useState('')
+  const [clearApiKey, setClearApiKey] = useState(false)
   const [invalidFields, setInvalidFields] = useState<Partial<Record<keyof PlumberConfig, string>>>({})
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
     safe: true,
@@ -576,6 +630,8 @@ export function SettingsDrawer({ open, config, onClose, onSave }: SettingsDrawer
     setSaved(false)
     setIsDirty(false)
     setSaveError(null)
+    setApiKeyDraft('')
+    setClearApiKey(false)
     setInvalidFields({})
     onClose()
   }
@@ -599,6 +655,25 @@ export function SettingsDrawer({ open, config, onClose, onSave }: SettingsDrawer
         return next
       })
     }
+  }
+
+  const prepareSecretEdit = () => {
+    setDraft((prev) => (isDirty ? prev : (config ?? emptyPlumberConfig())))
+    setIsDirty(true)
+    setSaved(false)
+    setSaveError(null)
+  }
+
+  const updateApiKey = (value: string) => {
+    prepareSecretEdit()
+    setApiKeyDraft(value)
+    setClearApiKey(false)
+  }
+
+  const markApiKeyForClear = () => {
+    prepareSecretEdit()
+    setApiKeyDraft('')
+    setClearApiKey(true)
   }
 
   const validateDraft = (): boolean => {
@@ -625,22 +700,29 @@ export function SettingsDrawer({ open, config, onClose, onSave }: SettingsDrawer
     setSaving(true)
     setSaveError(null)
     try {
-      const result = await onSave(effectiveDraft)
-      setSaving(false)
+      const apiKeyChange = clearApiKey
+        ? ({ kind: 'clear' } as const)
+        : apiKeyDraft
+          ? ({ kind: 'replace', value: apiKeyDraft } as const)
+          : ({ kind: 'preserve' } as const)
+      const result = await onSave(buildPlumberConfigUpdate(effectiveDraft, apiKeyChange))
       if (result) {
         setSaved(true)
         setIsDirty(false)
+        setClearApiKey(false)
         setSaveError(null)
         return
       }
       setSaveError('Could not save settings. Check the API connection and try again.')
     } catch (error) {
-      setSaving(false)
       const message =
         error instanceof Error && error.message.trim()
           ? error.message
           : 'Could not save settings. Check the API connection and try again.'
       setSaveError(message)
+    } finally {
+      setSaving(false)
+      setApiKeyDraft('')
     }
   }
 
@@ -751,6 +833,13 @@ export function SettingsDrawer({ open, config, onClose, onSave }: SettingsDrawer
                       />
                     ),
                   )}
+                  <ApiKeyField
+                    configured={effectiveDraft.llm_api_key_configured}
+                    value={apiKeyDraft}
+                    clearPending={clearApiKey}
+                    onChange={updateApiKey}
+                    onClear={markApiKeyForClear}
+                  />
                 </div>
               </div>
 

--- a/frontend/src/hooks/usePlumberPolling.ts
+++ b/frontend/src/hooks/usePlumberPolling.ts
@@ -6,6 +6,7 @@ import type {
   DaemonStateResponse,
   GraphAnalytics,
   PlumberConfig,
+  PlumberConfigUpdate,
   PlumberPollSnapshot,
 } from '../types/daemon'
 import { normalizeDaemonState, normalizeGraphAnalytics } from '../types/daemon'
@@ -14,6 +15,7 @@ import {
   MATRYCA_GRAPH_ANALYTICS_TIMEOUT_MS,
   matrycaFetchJson,
 } from '../utils/matrycaApiAuth'
+import { sanitizePlumberConfigResponse } from '../utils/plumberConfigSecrets'
 
 /** Base interval between telemetry poll cycles (distributed requests within each cycle). */
 const POLL_CYCLE_MS = 5000
@@ -294,7 +296,9 @@ export function usePlumberPolling(cycleMs = POLL_CYCLE_MS): PlumberPollSnapshot 
 
   const refreshConfig = useCallback(async () => {
     try {
-      const payload = await matrycaFetchJson<PlumberConfig>(`${MATRYCA_API_BASE}/api/config`)
+      const payload = sanitizePlumberConfigResponse(
+        await matrycaFetchJson<PlumberConfig>(`${MATRYCA_API_BASE}/api/config`),
+      )
       if (mountedRef.current) {
         setConfig(payload)
         setConnectionError(null)
@@ -312,7 +316,7 @@ export function usePlumberPolling(cycleMs = POLL_CYCLE_MS): PlumberPollSnapshot 
 
   const applyConfig = useCallback((payload: PlumberConfig) => {
     if (mountedRef.current) {
-      setConfig(payload)
+      setConfig(sanitizePlumberConfigResponse(payload))
       setConnectionError(null)
     }
   }, [])
@@ -371,13 +375,15 @@ export function usePlumberPolling(cycleMs = POLL_CYCLE_MS): PlumberPollSnapshot 
     }
   }, [pollFrozenSnapshot, setTelemetryLive])
 
-  const saveConfig = useCallback(async (payload: PlumberConfig): Promise<PlumberConfig | null> => {
+  const saveConfig = useCallback(async (payload: PlumberConfigUpdate): Promise<PlumberConfig | null> => {
     try {
-      const updated = await matrycaFetchJson<PlumberConfig>(`${MATRYCA_API_BASE}/api/config`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
+      const updated = sanitizePlumberConfigResponse(
+        await matrycaFetchJson<PlumberConfig>(`${MATRYCA_API_BASE}/api/config`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        }),
+      )
       if (mountedRef.current) {
         setConfig(updated)
       }

--- a/frontend/src/types/daemon.ts
+++ b/frontend/src/types/daemon.ts
@@ -423,7 +423,7 @@ export interface PlumberConfig {
   shadow_db_enabled: boolean
   lm_studio_url: string
   lm_model: string
-  llm_api_key: string
+  llm_api_key_configured: boolean
   low_priority_mode: boolean
   thermal_delay_bootstrap: number
   thermal_delay_cognitive: number
@@ -440,6 +440,11 @@ export interface PlumberConfig {
   backpropagate_links: boolean
   enable_inline_semantic_corrections: boolean
   auto_split: boolean
+}
+
+/** Full settings write; the optional API key is write-only. */
+export type PlumberConfigUpdate = Omit<PlumberConfig, 'llm_api_key_configured'> & {
+  llm_api_key?: string | null
 }
 
 /** Mirrors ``LmModelsResponse`` from ``src/cli/ui_server.py``. */
@@ -478,7 +483,7 @@ export interface PlumberPollSnapshot {
   engineError: string | null
   startEngine: () => Promise<void>
   stopEngine: () => Promise<void>
-  saveConfig: (payload: PlumberConfig) => Promise<PlumberConfig | null>
+  saveConfig: (payload: PlumberConfigUpdate) => Promise<PlumberConfig | null>
   refreshConfig: () => Promise<PlumberConfig | null>
   applyConfig: (payload: PlumberConfig) => void
 }

--- a/frontend/src/utils/plumberConfigDefaults.ts
+++ b/frontend/src/utils/plumberConfigDefaults.ts
@@ -8,7 +8,7 @@ export function emptyPlumberConfig(): PlumberConfig {
     shadow_db_enabled: true,
     lm_studio_url: 'http://localhost:1234/v1',
     lm_model: 'local-model',
-    llm_api_key: 'dummy-key',
+    llm_api_key_configured: false,
     low_priority_mode: true,
     thermal_delay_bootstrap: 2,
     thermal_delay_cognitive: 2,

--- a/frontend/src/utils/plumberConfigSecrets.test.ts
+++ b/frontend/src/utils/plumberConfigSecrets.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PlumberConfig } from '../types/daemon'
+import { emptyPlumberConfig } from './plumberConfigDefaults'
+import { buildPlumberConfigUpdate, sanitizePlumberConfigResponse } from './plumberConfigSecrets'
+
+describe('Plumber configuration secret contract', () => {
+  it('drops legacy API-key readback before configuration enters frontend state', () => {
+    const payload = {
+      ...emptyPlumberConfig(),
+      llm_api_key_configured: true,
+      llm_api_key: 'configured-secret',
+    } as PlumberConfig
+
+    const sanitized = sanitizePlumberConfigResponse(payload)
+
+    expect(sanitized.llm_api_key_configured).toBe(true)
+    expect(sanitized).not.toHaveProperty('llm_api_key')
+    expect(JSON.stringify(sanitized)).not.toContain('configured-secret')
+  })
+
+  it('omits the API key to preserve the configured value', () => {
+    const payload = buildPlumberConfigUpdate(emptyPlumberConfig(), { kind: 'preserve' })
+
+    expect(payload).not.toHaveProperty('llm_api_key')
+    expect(payload).not.toHaveProperty('llm_api_key_configured')
+  })
+
+  it('sends a replacement only in the write request', () => {
+    const payload = buildPlumberConfigUpdate(emptyPlumberConfig(), {
+      kind: 'replace',
+      value: 'replacement-secret',
+    })
+
+    expect(payload.llm_api_key).toBe('replacement-secret')
+    expect(payload).not.toHaveProperty('llm_api_key_configured')
+  })
+
+  it('uses explicit null to clear the configured key', () => {
+    const payload = buildPlumberConfigUpdate(emptyPlumberConfig(), { kind: 'clear' })
+
+    expect(payload.llm_api_key).toBeNull()
+    expect(payload).not.toHaveProperty('llm_api_key_configured')
+  })
+})

--- a/frontend/src/utils/plumberConfigSecrets.ts
+++ b/frontend/src/utils/plumberConfigSecrets.ts
@@ -1,0 +1,31 @@
+import type { PlumberConfig, PlumberConfigUpdate } from '../types/daemon'
+
+export type ApiKeyChange =
+  | { kind: 'preserve' }
+  | { kind: 'replace'; value: string }
+  | { kind: 'clear' }
+
+/** Drop legacy secret readback before a configuration payload reaches React state. */
+export function sanitizePlumberConfigResponse(payload: PlumberConfig): PlumberConfig {
+  const sanitized = { ...payload } as PlumberConfig & { llm_api_key?: unknown }
+  delete sanitized.llm_api_key
+  return sanitized
+}
+
+/** Build the write contract without echoing response-only key status. */
+export function buildPlumberConfigUpdate(
+  config: PlumberConfig,
+  apiKeyChange: ApiKeyChange,
+): PlumberConfigUpdate {
+  const update: Partial<PlumberConfig> = { ...sanitizePlumberConfigResponse(config) }
+  delete update.llm_api_key_configured
+  const payload = update as Omit<PlumberConfig, 'llm_api_key_configured'> & {
+    llm_api_key?: string | null
+  }
+  if (apiKeyChange.kind === 'replace') {
+    payload.llm_api_key = apiKeyChange.value
+  } else if (apiKeyChange.kind === 'clear') {
+    payload.llm_api_key = null
+  }
+  return payload
+}

--- a/src/cli/ui_server.py
+++ b/src/cli/ui_server.py
@@ -15,7 +15,7 @@ import urllib.error
 import urllib.request
 import webbrowser
 from collections import defaultdict, deque
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, Any, Literal
@@ -177,15 +177,14 @@ class DaemonStateResponse(BaseModel):
         return cls.model_validate(payload)
 
 
-class PlumberConfigResponse(BaseModel):
-    """Live Plumber configuration exposed to the React control room."""
+class PlumberConfigValues(BaseModel):
+    """Non-secret Plumber configuration shared by UI reads and writes."""
 
     logseq_graph_path: str
     read_only: bool = False
     shadow_db_enabled: bool = True
     lm_studio_url: str
     lm_model: str
-    llm_api_key: str
     low_priority_mode: bool
     thermal_delay_bootstrap: float
     thermal_delay_cognitive: float
@@ -203,6 +202,12 @@ class PlumberConfigResponse(BaseModel):
     enable_inline_semantic_corrections: bool
     auto_split: bool
 
+
+class PlumberConfigResponse(PlumberConfigValues):
+    """Live Plumber configuration exposed to the React control room."""
+
+    llm_api_key_configured: bool
+
     @classmethod
     def from_lint_config(
         cls,
@@ -211,6 +216,7 @@ class PlumberConfigResponse(BaseModel):
         logseq_graph_path: str | None = None,
         read_only: bool | None = None,
         shadow_db_enabled_value: bool | None = None,
+        llm_api_key_configured_value: bool | None = None,
     ) -> PlumberConfigResponse:
         if isinstance(logseq_graph_path, str):
             graph_path = logseq_graph_path.strip()
@@ -224,7 +230,11 @@ class PlumberConfigResponse(BaseModel):
             ),
             lm_studio_url=config.lm_base_url,
             lm_model=config.lm_model,
-            llm_api_key=config.llm_api_key,
+            llm_api_key_configured=(
+                _llm_api_key_is_configured(os.environ)
+                if llm_api_key_configured_value is None
+                else llm_api_key_configured_value
+            ),
             low_priority_mode=config.low_priority_mode,
             thermal_delay_bootstrap=config.thermal_delay_bootstrap,
             thermal_delay_cognitive=config.thermal_delay_cognitive,
@@ -242,6 +252,12 @@ class PlumberConfigResponse(BaseModel):
             enable_inline_semantic_corrections=not config.disable_semantic_corrections,
             auto_split=config.auto_split,
         )
+
+
+class PlumberConfigUpdateRequest(PlumberConfigValues):
+    """Full UI settings update with an optional write-only LLM API key."""
+
+    llm_api_key: str | None = None
 
 
 class DaemonControlResponse(BaseModel):
@@ -373,7 +389,6 @@ _ENV_KEY_MAP: dict[str, str] = {
     "logseq_graph_path": "LOGSEQ_GRAPH_PATH",
     "lm_studio_url": "LLM_BASE_URL",
     "lm_model": "LLM_MODEL_NAME",
-    "llm_api_key": "LLM_API_KEY",
     "low_priority_mode": "MATRYCA_PLUMBER_LOW_PRIORITY_MODE",
     "thermal_delay_bootstrap": "MATRYCA_THERMAL_DELAY_BOOTSTRAP",
     "thermal_delay_cognitive": "MATRYCA_THERMAL_DELAY_COGNITIVE",
@@ -390,6 +405,11 @@ _ENV_KEY_MAP: dict[str, str] = {
     "backpropagate_links": "MATRYCA_LINT_BACKPROPAGATE_LINKS",
     "auto_split": "MATRYCA_LINT_AUTO_SPLIT",
 }
+
+
+def _llm_api_key_is_configured(env: Mapping[str, str]) -> bool:
+    """Return whether an explicit non-empty LLM API key is present."""
+    return bool((env.get("LLM_API_KEY") or "").strip())
 
 
 def _resolve_dotenv_path() -> Path:
@@ -576,7 +596,7 @@ def _apply_dotenv_updates(updates: dict[str, str], *, env_path: Path | None = No
     return target
 
 
-def _update_dotenv(payload: PlumberConfigResponse) -> None:
+def _update_dotenv(payload: PlumberConfigUpdateRequest) -> None:
     """Persist configuration updates to ``.env`` and the active process environment."""
     validated_lm_url = assert_safe_lm_proxy_url(payload.lm_studio_url)
     updates: dict[str, str] = {}
@@ -586,6 +606,12 @@ def _update_dotenv(payload: PlumberConfigResponse) -> None:
     updates["MATRYCA_LINT_DISABLE_SEMANTIC_CORRECTIONS"] = (
         "false" if payload.enable_inline_semantic_corrections else "true"
     )
+    if "llm_api_key" in payload.model_fields_set:
+        updates["LLM_API_KEY"] = (
+            ""
+            if payload.llm_api_key is None
+            else serialize_plumber_config_field_for_dotenv("llm_api_key", payload.llm_api_key)
+        )
     _apply_dotenv_updates(updates)
 
 
@@ -612,7 +638,7 @@ def _persist_graph_path_update(payload: GraphPathUpdateRequest) -> PlumberConfig
     return PlumberConfigResponse.from_lint_config(load_plumber_lint_config())
 
 
-def _persist_config_update(payload: PlumberConfigResponse) -> PlumberConfigResponse:
+def _persist_config_update(payload: PlumberConfigUpdateRequest) -> PlumberConfigResponse:
     """Persist settings to ``.env`` and re-bootstrap runtime (blocking; off event loop)."""
     try:
         _update_dotenv(payload)
@@ -872,6 +898,7 @@ def _load_config_response() -> PlumberConfigResponse:
             logseq_graph_path=graph_path,
             read_only=is_graph_read_only(merged),
             shadow_db_enabled_value=shadow_db_enabled(merged),
+            llm_api_key_configured_value=_llm_api_key_is_configured(merged),
         )
     return PlumberConfigResponse.from_lint_config(load_plumber_lint_config())
 
@@ -911,7 +938,7 @@ async def save_graph_path(
 
 @app.post("/api/config", response_model=PlumberConfigResponse)
 async def post_config(
-    payload: PlumberConfigResponse,
+    payload: PlumberConfigUpdateRequest,
     _: None = Depends(_require_ui_token),
 ) -> PlumberConfigResponse:
     """Update ``.env`` and in-process settings from the control-room form."""
@@ -1172,6 +1199,7 @@ __all__ = [
     "GraphAnalyticsResponse",
     "LmModelsResponse",
     "PlumberConfigResponse",
+    "PlumberConfigUpdateRequest",
     "UpdateCheckResponse",
     "assert_safe_lm_proxy_url",
     "app",

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -36,6 +36,34 @@ def graph_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
+def _ui_config_update_payload(graph: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "logseq_graph_path": str(graph),
+        "lm_studio_url": "http://localhost:1234/v1",
+        "lm_model": "qwen3-8b",
+        "low_priority_mode": True,
+        "thermal_delay_bootstrap": 2.5,
+        "thermal_delay_cognitive": 1.25,
+        "mapreduce_trigger_chars": 20_000,
+        "mapreduce_chunk_chars": 10_000,
+        "context_compression": False,
+        "compression_trigger": 90_000,
+        "compression_target": 25_000,
+        "semantic_routing": True,
+        "entity_consolidation": False,
+        "property_hygiene": True,
+        "marpa_framework": False,
+        "backpropagate_links": True,
+        "heal_dangling": False,
+        "enable_inline_semantic_corrections": True,
+        "auto_split": False,
+        "read_only": True,
+        "shadow_db_enabled": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_get_state_returns_daemon_checkpoint(
     graph_root: Path,
     auth_headers: dict[str, str],
@@ -336,7 +364,9 @@ def test_get_config_returns_live_lint_settings(
     assert payload["logseq_graph_path"] == str(graph_root)
     assert payload["lm_studio_url"] == "http://localhost:9999/v1"
     assert payload["lm_model"] == "gemma-4-e4b-it"
-    assert payload["llm_api_key"] == "sk-test-cloud-key"
+    assert payload["llm_api_key_configured"] is True
+    assert "llm_api_key" not in payload
+    assert "sk-test-cloud-key" not in response.text
     assert payload["low_priority_mode"] is False
     assert payload["thermal_delay_bootstrap"] == 3.5
     assert payload["thermal_delay_cognitive"] == 1.5
@@ -368,30 +398,7 @@ def test_post_config_updates_dotenv(
     (graph / "pages").mkdir(parents=True)
     monkeypatch.setattr("src.cli.ui_server._REPO_ROOT", tmp_path)
 
-    body = {
-        "logseq_graph_path": str(graph),
-        "lm_studio_url": "http://localhost:1234/v1",
-        "lm_model": "qwen3-8b",
-        "llm_api_key": "sk-saved-from-ui",
-        "low_priority_mode": True,
-        "thermal_delay_bootstrap": 2.5,
-        "thermal_delay_cognitive": 1.25,
-        "mapreduce_trigger_chars": 20000,
-        "mapreduce_chunk_chars": 10000,
-        "context_compression": False,
-        "compression_trigger": 90000,
-        "compression_target": 25000,
-        "semantic_routing": True,
-        "entity_consolidation": False,
-        "property_hygiene": True,
-        "marpa_framework": False,
-        "backpropagate_links": True,
-        "heal_dangling": False,
-        "enable_inline_semantic_corrections": True,
-        "auto_split": False,
-        "read_only": True,
-        "shadow_db_enabled": True,
-    }
+    body = _ui_config_update_payload(graph, llm_api_key="sk-saved-from-ui")
 
     with TestClient(app) as client:
         response = client.post("/api/config", json=body, headers=auth_headers)
@@ -404,6 +411,9 @@ def test_post_config_updates_dotenv(
     assert payload["compression_trigger"] == 90_000
     assert payload["compression_target"] == 25_000
     assert payload["enable_inline_semantic_corrections"] is True
+    assert payload["llm_api_key_configured"] is True
+    assert "llm_api_key" not in payload
+    assert "sk-saved-from-ui" not in response.text
     written = env_path.read_text(encoding="utf-8")
     assert "LOGSEQ_GRAPH_PATH=" in written
     assert str(graph) in written
@@ -418,6 +428,56 @@ def test_post_config_updates_dotenv(
     assert "MATRYCA_SHADOW_DB_ENABLED=true" in written
 
 
+def test_post_config_preserves_api_key_when_omitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    auth_headers: dict[str, str],
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_API_KEY=existing-secret\n", encoding="utf-8")
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    monkeypatch.setattr("src.cli.ui_server._REPO_ROOT", tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/config",
+            json=_ui_config_update_payload(graph),
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["llm_api_key_configured"] is True
+    assert "llm_api_key" not in response.json()
+    assert "existing-secret" not in response.text
+    assert "LLM_API_KEY=existing-secret" in env_path.read_text(encoding="utf-8")
+
+
+def test_post_config_clears_api_key_only_on_explicit_null(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    auth_headers: dict[str, str],
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("LLM_API_KEY=existing-secret\n", encoding="utf-8")
+    graph = tmp_path / "graph"
+    (graph / "pages").mkdir(parents=True)
+    monkeypatch.setattr("src.cli.ui_server._REPO_ROOT", tmp_path)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/config",
+            json=_ui_config_update_payload(graph, llm_api_key=None),
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["llm_api_key_configured"] is False
+    assert "llm_api_key" not in response.json()
+    assert "existing-secret" not in response.text
+    assert "LLM_API_KEY=" in env_path.read_text(encoding="utf-8").splitlines()
+
+
 def test_post_config_rejects_unsafe_lm_studio_url(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -429,34 +489,18 @@ def test_post_config_rejects_unsafe_lm_studio_url(
     (graph / "pages").mkdir(parents=True)
     monkeypatch.setattr("src.cli.ui_server._REPO_ROOT", tmp_path)
 
-    body = {
-        "logseq_graph_path": str(graph),
-        "lm_studio_url": "http://169.254.169.254/latest/meta-data/",
-        "lm_model": "qwen3-8b",
-        "llm_api_key": "dummy-key",
-        "low_priority_mode": True,
-        "thermal_delay_bootstrap": 2.5,
-        "thermal_delay_cognitive": 1.25,
-        "mapreduce_trigger_chars": 20000,
-        "mapreduce_chunk_chars": 10000,
-        "context_compression": False,
-        "compression_trigger": 90000,
-        "compression_target": 25000,
-        "semantic_routing": True,
-        "entity_consolidation": False,
-        "property_hygiene": True,
-        "marpa_framework": False,
-        "backpropagate_links": True,
-        "heal_dangling": False,
-        "enable_inline_semantic_corrections": True,
-        "auto_split": False,
-    }
+    body = _ui_config_update_payload(
+        graph,
+        lm_studio_url="http://169.254.169.254/latest/meta-data/",
+        llm_api_key="dummy-key",
+    )
 
     with TestClient(app) as client:
         response = client.post("/api/config", json=body, headers=auth_headers)
 
     assert response.status_code == 400
     assert "not allowed" in response.json()["detail"]
+    assert "dummy-key" not in response.text
     assert env_path.read_text(encoding="utf-8") == 'LOGSEQ_GRAPH_PATH="/old/path"\n'
 
 


### PR DESCRIPTION
## Summary

- separate UI configuration read and write schemas so configured LLM API keys are never serialized
- preserve omitted keys, replace supplied values, and clear only on explicit null
- sanitize legacy responses before React state and provide configured-status, replacement, and clear controls
- document the frozen EX-07 tranche, architecture contract, validation, and changelog entry

## Test plan

- [x] focused UI/API and output-sanitization matrix (64 passed)
- [x] frontend tests (20 passed)
- [x] frontend TypeScript production build
- [x] frontend ESLint
- [x] `make ci` (format, Ruff, strict mypy, graph sandbox, version, agent coherence, public metrics, documentation inventory, generated prompt, full parallel Python suite)

## Release boundary

This security slice does not modify UI authentication, inference-provider behavior, dotenv concurrency, the published `2.0.0rc1` wheel, Gate B profiles or evidence, tags, releases, or publication state. The existing macOS fork deprecation warning remains pre-existing and unchanged.

Closes #390
Refs #343
Refs #385
Refs #384