### PR TITLE
fix(shadow): separate query-only read connections (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- **Query-only Shadow read connections (#413)** — separate health, state, FTS, and subtree queries from the schema-capable writer opener by requiring an existing SQLite database in `mode=ro` with `PRAGMA query_only=ON`; missing or unreadable caches continue through established stale/error and Markdown/BM25 fallback paths without creating cache directories, databases, or schema.
 - **Serialized dotenv updates with OCC (#387)** — serialize cooperating UI configuration writers across the complete read/merge/atomic-replace transaction; bind each source snapshot to device, inode, nanosecond mtime, size, and SHA-256; and return the typed `dotenv_conflict` HTTP 409 response when an external edit intervenes, while preserving comments, unknown keys, ordering, and failed-replace cleanup.
 - **Fail-closed Shadow sync failures (#386)** — invalidate cached reads after every generic incremental, delete, callback, or watchdog failure; persist the content-free `incremental_sync_failed` reason in both Shadow metadata and a private external-cache marker when available, retain an in-process latch when storage is unavailable, and clear all invalidation only after a successful full reconciliation.
 - **Explicit Shadow read freshness (#389)** — validate requested subtree pages and every returned FTS page against the authoritative Markdown path, nanosecond mtime, and size before serving cached rows; route changed, missing, untracked, and unproven-empty reads to Markdown/generational BM25 with a bounded content-free reason, without a per-read graph scan.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,6 +104,13 @@ Generic sync failures add a private content-free `shadow.sync-invalid` marker be
 the external database and latch the generation invalid in-process. Either signal
 forces fallback until a successful full rebuild clears metadata, marker, and latch;
 authoritative Markdown writes never roll back because cache maintenance failed.
+Pure health, state, FTS, and subtree reads open the existing database with SQLite URI
+`mode=ro` and `PRAGMA query_only=ON`; they never create the cache directory, apply DDL,
+or migrate schema. Because the live database uses WAL mode, SQLite may create or reuse
+`-wal` and `-shm` sidecars for read coordination; declaring the database `immutable`
+would be unsafe while reconciliation can update it. Bootstrap and synchronization
+retain the separate schema-capable writer opener because the external derived cache
+remains daemon-owned and rebuildable.
 
 **v2.0.0-rc.1 contract (Slices 1–5 complete):** an unset
 `MATRYCA_SHADOW_DB_ENABLED` now enables Shadow; explicit false remains a zero-Shadow

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -324,6 +324,50 @@ not restart the historical RC soak clock.
 
 #### EX-06 — Separate query-only cache connections from schema application
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-06-01
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 791fbd8b8e1af0c7ff766f82c5ca694618deaaa8
+objective: make every pure Shadow SQLite read physically query-only without changing writer ownership
+authority: inspect | edit | commit | push | pr
+tracking_issue: 413
+allowlist:
+  - src/shadow/connection.py
+  - src/shadow/health.py
+  - src/agent/shadow_graph_repository.py
+  - src/shadow/fts_format.py
+  - src/shadow/state_api.py
+  - tests/test_shadow_connection.py
+  - tests/test_shadow_hardening_axis6_security.py
+  - docs/ARCHITECTURE.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - CHANGELOG.md
+non_goals:
+  - change the external cache location, graph read-only policy, schema, or migration rules
+  - change FTS, subtree, health, state, or fallback response contracts
+  - modify Gate B evidence, services, artifacts, tags, releases, or publication state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_shadow_connection.py
+  - uv run pytest --no-cov -q tests/test_shadow_state_api.py tests/test_shadow_fts_routing.py tests/test_shadow_read_port.py
+  - uv run pytest --no-cov -q tests/test_shadow_hardening_axis6_security.py
+  - make ci
+acceptance:
+  - missing query targets create no cache directory, database, schema, WAL, or SHM
+  - every pure reader uses mode=ro with PRAGMA query_only=ON
+  - writer/bootstrap/sync schema ownership and existing fallback contracts remain unchanged
+stop_conditions:
+  - any required schema, cache-location, graph-write-policy, or public response change
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 791fbd8b8e1af0c7ff766f82c5ca694618deaaa8
+  gitnexus_open_writer_impact: CRITICAL
+  gitnexus_health_impact: HIGH
+  gitnexus_subtree_impact: LOW
+  gitnexus_fts_impact: MEDIUM
+```
+
 **Priority:** P2 operational hygiene and defense in depth, not evidence of a graph-write bypass.
 
 **Finding:** `open_shadow_db()` always creates/opens, applies DDL, and commits (`src/shadow/connection.py:34-65`). Health and subtree reads call it. External cache writes are allowed under graph read-only, but a nominal read path is still write-capable.
@@ -335,6 +379,36 @@ Acceptance gate:
 - health and subtree queries do not create a missing database, DDL, WAL, or SHM;
 - missing/stale/corrupt databases fall back cleanly;
 - writer paths retain schema migration behavior.
+
+**Implemented in #413:** the schema-capable opener remains unchanged for bootstrap,
+reconciliation, and sync. Health, state telemetry, FTS, and subtree reads now share a
+separate opener that requires an existing database through SQLite URI `mode=ro` and
+enables `PRAGMA query_only=ON`. The query path does not create the external cache
+directory, apply pragmas that change persistent journal state, run DDL, or commit.
+Missing and unreadable databases retain the existing stale/error and Markdown/BM25
+fallback contracts.
+
+The side-effect boundary is intentionally precise: when no database exists, the query
+opener creates no directory, database, WAL, or SHM. For an existing live WAL database,
+SQLite may create or reuse `-wal` and `-shm` sidecars to coordinate a current read. The
+`immutable=1` URI option is rejected because reconciliation can update this derived
+cache concurrently; asserting immutability could serve a stale snapshot. This follows
+SQLite's documented [read-only WAL contract](https://www.sqlite.org/wal.html#read_only_databases).
+
+**Validation:** the focused connection primitive suite passes `8/8`; health/state/FTS/
+subtree routing and fallback suites pass `49/49`; the Axis-6 security suite passes
+`24/24`; strict typing passes for all five changed source modules; and the documentation
+bundle reports no drift. The complete macOS arm64 Python 3.12 gate passes with `1,649`
+tests, `5` skips, and `83.33%` coverage. Its only warning is the pre-existing macOS
+multi-threaded `fork()` deprecation probe. An initial sandboxed run also demonstrated
+that the Windows-fallback process-lock test needs `ps`; that exact test passed separately
+and the authoritative full gate passed outside the sandbox restriction.
+
+**Gate B impact:** the public `2.0.0rc1` wheel used the schema-capable opener for these
+reads, so its exact-artifact soak remains valid historical RC evidence but does not
+qualify this post-RC implementation. The stable candidate requires focused exact-wheel
+query-only/fallback probes and both candidate Gate B profiles; #413 does not rewrite or
+restart the historical RC evidence chain.
 
 #### EX-07 — Stop returning LLM secrets from `/api/config`
 

--- a/src/agent/shadow_graph_repository.py
+++ b/src/agent/shadow_graph_repository.py
@@ -11,7 +11,7 @@ from loguru import logger
 from ..graph.path_sandbox import resolved_graph_root
 from ..rag.matryca_hooks import get_page_spatial_context
 from ..shadow.config import shadow_db_enabled
-from ..shadow.connection import open_shadow_db
+from ..shadow.connection import open_shadow_db_query_only
 from ..shadow.freshness import ShadowFreshnessError, ensure_shadow_page_fresh
 from ..shadow.health import ShadowHealthState, resolve_shadow_health
 from ..shadow.subtree import SubtreeStatus, query_subtree_by_block_uuid
@@ -129,7 +129,7 @@ class ShadowGraphRepository:
             raise ValueError(msg)
 
         try:
-            conn = open_shadow_db(root)
+            conn = open_shadow_db_query_only(root)
             try:
                 ensure_shadow_page_fresh(conn, root, title=page_ref)
                 result = query_subtree_by_block_uuid(conn, block_uuid)

--- a/src/shadow/connection.py
+++ b/src/shadow/connection.py
@@ -65,7 +65,30 @@ def open_shadow_db(graph_root: Path | str) -> sqlite3.Connection:
     return connection
 
 
+def open_shadow_db_query_only(graph_root: Path | str) -> sqlite3.Connection:
+    """Open an existing Shadow DB for queries without creating or migrating it.
+
+    Caller owns the connection lifetime (``close()``).
+    """
+    if not shadow_db_enabled():
+        raise RuntimeError("Shadow DB disabled via MATRYCA_SHADOW_DB_ENABLED=false")
+
+    root = resolved_graph_root(graph_root)
+    db_path = _resolve_shadow_location_for_graph(root).database_path
+    connection = sqlite3.connect(f"{db_path.as_uri()}?mode=ro", uri=True)
+    try:
+        busy_timeout_ms = shadow_db_busy_timeout_ms()
+        if busy_timeout_ms > 0:
+            connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+        connection.execute("PRAGMA query_only = ON")
+    except Exception:
+        connection.close()
+        raise
+    return connection
+
+
 __all__ = [
     "open_shadow_db",
+    "open_shadow_db_query_only",
     "shadow_db_path",
 ]

--- a/src/shadow/fts_format.py
+++ b/src/shadow/fts_format.py
@@ -10,7 +10,7 @@ from loguru import logger
 from ..graph.path_sandbox import resolved_graph_root
 from ..rag.local_query import format_keyword_query_markdown
 from .config import shadow_db_enabled
-from .connection import open_shadow_db
+from .connection import open_shadow_db_query_only
 from .freshness import (
     ShadowFreshnessError,
     ShadowFreshnessReason,
@@ -52,7 +52,7 @@ def format_shadow_fts_markdown(
     """Format shadow FTS block hits using the BM25 search_graph markdown envelope."""
     validate_fts_match_query(keyword)
     root = resolved_graph_root(graph_root)
-    conn = open_shadow_db(root)
+    conn = open_shadow_db_query_only(root)
     try:
         try:
             hits = search_blocks_fts(conn, keyword, limit=limit)

--- a/src/shadow/health.py
+++ b/src/shadow/health.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from ..graph.path_sandbox import PathTraversalSecurityError, resolved_graph_root
 from .config import shadow_db_enabled
-from .connection import open_shadow_db, shadow_db_path
+from .connection import open_shadow_db_query_only, shadow_db_path
 from .meta import (
     META_INDEXED_PAGE_COUNT,
     META_LAST_FULL_SYNC_COMPLETED,
@@ -83,7 +83,7 @@ def resolve_shadow_health(graph_root: Path | str) -> ShadowHealthState:
         return ShadowHealthState.STALE
 
     try:
-        conn = open_shadow_db(root)
+        conn = open_shadow_db_query_only(root)
     except (OSError, RuntimeError, sqlite3.Error, PathTraversalSecurityError):
         return ShadowHealthState.ERROR
     try:

--- a/src/shadow/state_api.py
+++ b/src/shadow/state_api.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from ..graph.path_sandbox import PathTraversalSecurityError, resolved_graph_root
 from ..utils.console_sanitize import sanitize_for_console
 from .config import shadow_db_enabled
-from .connection import shadow_db_path
+from .connection import open_shadow_db_query_only, shadow_db_path
 from .health import shadow_meta_matches_page_rows
 from .meta import (
     META_INDEXED_PAGE_COUNT,
@@ -157,8 +157,8 @@ def _read_quarantined_count(connection: sqlite3.Connection) -> int:
     return int(row[0]) if row else 0
 
 
-def _read_meta_readonly(db_path: Path) -> tuple[dict[str, str | None], int, int]:
-    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+def _read_meta_readonly(graph_root: Path) -> tuple[dict[str, str | None], int, int]:
+    connection = open_shadow_db_query_only(graph_root)
     try:
         meta = {
             META_SCHEMA_VERSION: get_meta(connection, META_SCHEMA_VERSION),
@@ -252,7 +252,7 @@ def resolve_shadow_db_state_for_api(graph_root: Path | str) -> ShadowDbStateResp
         )
 
     try:
-        meta, page_count, quarantined = _read_meta_readonly(db_path)
+        meta, page_count, quarantined = _read_meta_readonly(root)
     except sqlite3.Error as exc:
         return ShadowDbStateResponse(
             enabled=True,

--- a/tests/test_shadow_connection.py
+++ b/tests/test_shadow_connection.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 from src.shadow.cache_location import resolve_shadow_cache_location
-from src.shadow.connection import open_shadow_db, shadow_db_path
+from src.shadow.connection import open_shadow_db, open_shadow_db_query_only, shadow_db_path
 from src.shadow.schema import SHADOW_SCHEMA_VERSION
 
 
@@ -57,6 +58,46 @@ def test_open_shadow_db_idempotent(tmp_path: Path) -> None:
         assert "blocks" in tables
     finally:
         second.close()
+
+
+def test_open_shadow_db_query_only_requires_existing_database(
+    tmp_path: Path,
+    _cache_root: Path,
+) -> None:
+    location = resolve_shadow_cache_location(
+        tmp_path,
+        env={"MATRYCA_CACHE_PATH": str(_cache_root)},
+    )
+
+    with pytest.raises(sqlite3.OperationalError):
+        open_shadow_db_query_only(tmp_path)
+
+    assert not location.shadow_dir.exists()
+    assert not location.database_path.exists()
+    assert not location.shadow_db_wal_path.exists()
+    assert not location.shadow_db_shm_path.exists()
+
+
+def test_open_shadow_db_query_only_cannot_write_application_data(tmp_path: Path) -> None:
+    writer = open_shadow_db(tmp_path)
+    writer.close()
+    location = resolve_shadow_cache_location(tmp_path)
+    before = {path.name for path in location.shadow_dir.iterdir()}
+
+    reader = open_shadow_db_query_only(tmp_path)
+    try:
+        assert reader.execute("PRAGMA query_only").fetchone() == (1,)
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            reader.execute("CREATE TABLE query_path_must_not_write (id INTEGER)")
+        schema = reader.execute(
+            "SELECT value FROM shadow_meta WHERE key = 'schema_version'"
+        ).fetchone()
+        assert schema == (str(SHADOW_SCHEMA_VERSION),)
+    finally:
+        reader.close()
+
+    after = {path.name for path in location.shadow_dir.iterdir()}
+    assert after - before <= {"shadow.sqlite-wal", "shadow.sqlite-shm"}
 
 
 def test_open_shadow_db_uses_only_external_cache_in_read_only_mode(

--- a/tests/test_shadow_hardening_axis6_security.py
+++ b/tests/test_shadow_hardening_axis6_security.py
@@ -237,7 +237,7 @@ def test_a6_errors_02_subtree_sqlite_failure_fallback_omits_injected_path(
     leak_token = f"SENSITIVE-DB-PATH::{shadow_db_path(graph)}"
 
     with patch(
-        "src.agent.shadow_graph_repository.open_shadow_db",
+        "src.agent.shadow_graph_repository.open_shadow_db_query_only",
         side_effect=sqlite3.OperationalError(f"database is locked: {leak_token}"),
     ):
         out = ShadowGraphRepository().read_subtree_markdown(
@@ -442,12 +442,18 @@ async def test_a6_flag_05_false_flag_leaves_preexisting_db_untouched(
     reset_shadow_runtime_state_for_tests()
 
     def _forbid_open(*_args: object, **_kwargs: object) -> sqlite3.Connection:
-        raise AssertionError("open_shadow_db must not be called when shadow flag is false")
+        raise AssertionError("Shadow DB must not be opened when its flag is false")
 
     with (
         patch("src.shadow.connection.open_shadow_db", side_effect=_forbid_open),
-        patch("src.agent.shadow_graph_repository.open_shadow_db", side_effect=_forbid_open),
-        patch("src.shadow.fts_format.open_shadow_db", side_effect=_forbid_open),
+        patch("src.shadow.connection.open_shadow_db_query_only", side_effect=_forbid_open),
+        patch(
+            "src.agent.shadow_graph_repository.open_shadow_db_query_only",
+            side_effect=_forbid_open,
+        ),
+        patch("src.shadow.fts_format.open_shadow_db_query_only", side_effect=_forbid_open),
+        patch("src.shadow.health.open_shadow_db_query_only", side_effect=_forbid_open),
+        patch("src.shadow.state_api.open_shadow_db_query_only", side_effect=_forbid_open),
         patch("src.shadow.bootstrap.open_shadow_db", side_effect=_forbid_open),
         patch("src.shadow.sync.open_shadow_db", side_effect=_forbid_open),
     ):


### PR DESCRIPTION
## Summary

- add a dedicated Shadow query opener using SQLite URI `mode=ro` and `PRAGMA query_only=ON`
- route health, state telemetry, FTS, and subtree reads through it while leaving the schema-capable writer opener unchanged
- preserve stale/error and Markdown/BM25 fallback contracts for missing, corrupt, or incompatible caches
- document the live-WAL boundary: SQLite may create or reuse WAL/SHM coordination sidecars, so `immutable=1` would be unsafe while reconciliation can update the cache

## Stack

- base: `fix/dotenv-occ-serialization-387` / PR #412
- this PR contains only EX-06 / issue #413
- merge after #412, or retarget to `main` once the lower stack is merged

## Safety boundary

- no changes to Shadow schema, cache location, graph read-only policy, bootstrap, reconciliation, sync, tags, releases, or publication state
- a missing query target creates no cache directory, database, schema, WAL, or SHM
- an existing WAL database remains live and coordinated; application DDL/data writes fail with SQLite `readonly database`
- the public `2.0.0rc1` soak remains exact-artifact historical evidence and does not qualify these post-RC bytes

## Validation

- `8 passed` — connection primitive tests
- `49 passed` — health/state/FTS/subtree routing and fallback tests
- `24 passed` — Axis-6 security tests
- strict mypy passed for all five changed source modules
- documentation bundle passed with no drift
- full `make ci`: `1,649 passed, 5 skipped`, 83.33% coverage
- one pre-existing macOS multi-threaded `fork()` deprecation warning

Closes #413
