### PR TITLE
test(architecture): enforce graph boundaries with AST (#394)

### DIFF
--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -633,6 +633,57 @@ policy, endpoint shape, dotenv writer, or Gate B behavior changes in this tranch
 
 #### EX-10 — Replace string-based architecture tests with AST enforcement
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-10-01
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 44fab70d358ecc6f5f40cdf33619a57d5b32ac91
+objective: replace broad graph-layer string/file exemptions with exact AST-enforced import boundaries
+authority: inspect | edit | commit | push | pr
+tracking_issue: 394
+allowlist:
+  - tests/test_graph_layer_boundary.py
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+non_goals:
+  - move the CRITICAL shared tokenizer or prompt compiler in this tranche
+  - change runtime imports, behavior, Gate B evidence, releases, tags, or publication state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_graph_layer_boundary.py
+  - make ci
+acceptance:
+  - absolute imports and every relative depth resolve through the Python AST
+  - comments and strings cannot trigger false positives
+  - exceptions identify the exact path, module, imported names, issue, and expiry criterion
+  - stale exceptions fail the gate when their production import disappears
+stop_conditions:
+  - any production symbol move or new exception without an issue-bound expiry criterion
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 44fab70d358ecc6f5f40cdf33619a57d5b32ac91
+  tokenizer_impact: CRITICAL
+  boundary_test_impacts: LOW
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: lifecycle | provenance
+residual_risks:
+  - two exact production imports remain until later #394 tranches prove safe extraction
+```
+
+**EX-10-01 implemented:** the boundary gate now parses every Python import with the
+standard-library AST, resolves absolute imports and arbitrary relative depth against the
+source package, and ignores import-shaped text in comments and strings. The previous
+whole-file exemptions are replaced by two exact records that bind path, resolved module,
+imported names, issue #394, and a concrete expiry criterion. The gate fails both on any
+new graph-to-agent/daemon/rag import and when a recorded exception becomes stale.
+
+Focused validation passes `2/2`. The complete macOS arm64 Python 3.12 gate passes with
+`1,648` tests, `5` skips, and `83.33%` coverage; format, Ruff, strict mypy over 377 source
+files, graph sandbox, version and agent coherence, public-metrics policy, documentation
+inventory, and generated prompt checks are all green. The only warning remains the
+pre-existing macOS multi-threaded `fork()` deprecation probe. No changelog entry is
+required because this tranche changes test enforcement and its evidence record only.
+
 **Finding:** the current graph boundary test misses deeper relative imports and exempts an entire production file (`tests/test_graph_layer_boundary.py:8-44`). The live violations are visible at `src/graph/insights/prompts.py:8` and `src/graph/generational_cache.py:225-255`.
 
 **Smallest slice:** first reconcile the absolute `graph`-must-not-import-`agent` rule with the documented Tier-1 prompt-core exception. Then parse imports with the standard-library AST, extract tokenization and prompt compilation behind domain-owned helpers/protocols where appropriate, and remove broad exemptions.

--- a/tests/test_graph_layer_boundary.py
+++ b/tests/test_graph_layer_boundary.py
@@ -1,44 +1,135 @@
-"""Graph layer must not import agent orchestration modules."""
+"""AST-enforced dependency direction for the graph layer."""
 
 from __future__ import annotations
 
+import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 
-def test_graph_modules_do_not_import_agent() -> None:
-    graph_dir = Path(__file__).resolve().parents[1] / "src" / "graph"
-    offenders: list[str] = []
+@dataclass(frozen=True, order=True, slots=True)
+class _BoundaryImport:
+    path: str
+    module: str
+    names: tuple[str, ...]
+
+
+_KNOWN_EXCEPTIONS: dict[_BoundaryImport, str] = {
+    _BoundaryImport(
+        "src/graph/generational_cache.py",
+        "src.rag.local_query",
+        ("tokenize",),
+    ): "#394: expires when lexical tokenization moves to a graph-owned leaf module",
+    _BoundaryImport(
+        "src/graph/insights/prompts.py",
+        "src.agent.prompts.core",
+        ("PromptContext", "compile_tier1a_prompt"),
+    ): "#394: expires when shared prompt compilation moves below agent and graph",
+}
+_FORBIDDEN_LAYERS = frozenset({"agent", "daemon", "rag"})
+
+
+def _package_for_path(path: Path, src_dir: Path) -> tuple[str, ...]:
+    relative = path.relative_to(src_dir).with_suffix("")
+    module = ("src", *relative.parts)
+    return module if path.name == "__init__.py" else module[:-1]
+
+
+def _resolve_from_module(node: ast.ImportFrom, package: tuple[str, ...]) -> str:
+    imported = tuple((node.module or "").split(".")) if node.module else ()
+    if node.level == 0:
+        return ".".join(imported)
+    retained = len(package) - node.level + 1
+    if retained < 0:
+        return ""
+    return ".".join((*package[:retained], *imported))
+
+
+def _imports_from_source(
+    source: str,
+    *,
+    package: tuple[str, ...],
+    relative_path: str,
+) -> set[_BoundaryImport]:
+    imports: set[_BoundaryImport] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ImportFrom):
+            imports.add(
+                _BoundaryImport(
+                    relative_path,
+                    _resolve_from_module(node, package),
+                    tuple(alias.name for alias in node.names),
+                )
+            )
+        elif isinstance(node, ast.Import):
+            imports.update(_BoundaryImport(relative_path, alias.name, ()) for alias in node.names)
+    return imports
+
+
+def _forbidden_layer(module: str) -> str | None:
+    parts = module.split(".")
+    if parts and parts[0] in _FORBIDDEN_LAYERS:
+        return parts[0]
+    if len(parts) >= 2 and parts[0] == "src" and parts[1] in _FORBIDDEN_LAYERS:
+        return parts[1]
+    return None
+
+
+def _graph_boundary_imports(graph_dir: Path) -> set[_BoundaryImport]:
+    src_dir = graph_dir.parent
+    imports: set[_BoundaryImport] = set()
     for path in sorted(graph_dir.rglob("*.py")):
-        text = path.read_text(encoding="utf-8")
-        if "from ..agent" in text or "from src.agent" in text:
-            offenders.append(str(path.relative_to(graph_dir.parents[1])))
-    assert offenders == []
+        relative_path = path.relative_to(src_dir.parent).as_posix()
+        imports.update(
+            _imports_from_source(
+                path.read_text(encoding="utf-8"),
+                package=_package_for_path(path, src_dir),
+                relative_path=relative_path,
+            )
+        )
+    return {item for item in imports if _forbidden_layer(item.module) is not None}
 
 
-def test_graph_modules_do_not_import_daemon() -> None:
+def _format_import(item: _BoundaryImport) -> str:
+    imported = f" import {', '.join(item.names)}" if item.names else ""
+    return f"{item.path}: {item.module}{imported}"
+
+
+def test_ast_import_resolution_covers_absolute_and_relative_forms() -> None:
+    source = """
+from src.agent.absolute import alpha
+from ...daemon.relative import beta
+import src.rag.local_query
+import rag
+text = 'from src.agent.not_an_import import ignored'
+"""
+
+    imports = _imports_from_source(
+        source,
+        package=("src", "graph", "nested"),
+        relative_path="src/graph/nested/example.py",
+    )
+
+    assert {item.module for item in imports} == {
+        "src.agent.absolute",
+        "src.daemon.relative",
+        "src.rag.local_query",
+        "rag",
+    }
+
+
+def test_graph_layer_import_boundaries_are_ast_enforced() -> None:
     graph_dir = Path(__file__).resolve().parents[1] / "src" / "graph"
-    offenders: list[str] = []
-    for path in sorted(graph_dir.rglob("*.py")):
-        if path.name == "daemon_checkpoint.py":
-            continue
-        text = path.read_text(encoding="utf-8")
-        if "from ..daemon" in text or "from src.daemon" in text:
-            offenders.append(str(path.relative_to(graph_dir.parents[1])))
-    assert offenders == []
+    observed = _graph_boundary_imports(graph_dir)
+    expected = set(_KNOWN_EXCEPTIONS)
+    unexpected = sorted(observed - expected)
+    stale = sorted(expected - observed)
 
-
-def test_graph_modules_do_not_import_rag() -> None:
-    graph_dir = Path(__file__).resolve().parents[1] / "src" / "graph"
-    offenders: list[str] = []
-    for path in sorted(graph_dir.rglob("*.py")):
-        # generational_cache.py uses lazy `from src.rag.local_query import
-        # tokenize` inside functions — tracked for clean-up in a follow-up PR.
-        if path.name == "generational_cache.py":
-            continue
-        text = path.read_text(encoding="utf-8")
-        if "from ..rag" in text or "from src.rag" in text or "import rag" in text:
-            offenders.append(str(path.relative_to(graph_dir.parents[1])))
-    assert offenders == [], (
-        "src/graph/ must not import src/rag/ (domain should not depend on "
-        "retrieval adapters). Offending files:\n" + "\n".join(offenders)
+    assert unexpected == [], (
+        "src/graph must not import agent, daemon, or rag. Unexpected imports:\n"
+        + "\n".join(_format_import(item) for item in unexpected)
+    )
+    assert stale == [], (
+        "Remove resolved graph-boundary exceptions and their expiry notes:\n"
+        + "\n".join(f"{_format_import(item)} — {_KNOWN_EXCEPTIONS[item]}" for item in stale)
     )


### PR DESCRIPTION
## Summary

- replace graph-layer dependency string searches with standard-library AST parsing
- resolve absolute imports and arbitrary relative depth against each source package
- replace whole-file exemptions with exact path/module/import-name records
- fail when a new forbidden dependency appears or when an exception becomes stale

## Stack

- base: `fix/shadow-query-only-connections-413` / PR #414
- this PR is EX-10-01, the enforcement-only slice of #394
- merge after #414, or retarget once the lower stack is merged

## Scope

- test and programme-evidence changes only; no production imports or runtime behavior change
- the two live exceptions identify their exact symbols and expiry criteria
- the shared tokenizer remains a CRITICAL hub and is intentionally deferred to a separately benchmarked tranche
- no Gate B evidence, releases, tags, or publication state changed

## Validation

- focused boundary suite: `2 passed`
- GitNexus change scope: LOW, zero affected runtime processes
- documentation bundle passed with no drift
- full `make ci`: `1,648 passed, 5 skipped`, 83.33% coverage
- one pre-existing macOS multi-threaded `fork()` deprecation warning

Refs #394
