### PR TITLE
feat(diagnostics): add typed BM25 snapshot (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation counters, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.
 - **Reproducible BM25 capacity evidence** — add deterministic capacity, distribution, tail-latency, RSS, row-pressure, invalidation, rebuild, concurrent-corpus, and correctness-parity benchmarks; retain the 8,192-entry and 65,536-row production defaults under an explicit synthetic-evidence boundary.
 - **OKF v0.2 documentation governance** — align the maintained knowledge bundle with the pinned portable format, separate Matryca classification from official lifecycle status, add provenance, freshness, canonical-role, link, anchor, and chronology gates, migrate the full documentation inventory to schema v2, make documentation integrity mandatory in `make check` and `make ci`, and document the repository-to-projection operating model.
 - **Gate B public-RC soak qualification** — add separate resumable `default-on` and `read-only-external` profiles bound to the installed `2.0.0rc1` wheel, explicit opt-out controls, full graph-manifest integrity, external-cache isolation, and a terminal-aware supervisor for restart-safe multi-day evidence collection.

--- a/docs/knowledge/architecture/cache-friendly-retrieval.md
+++ b/docs/knowledge/architecture/cache-friendly-retrieval.md
@@ -233,6 +233,13 @@ entry capacity, result rows, result-row capacity, hits, misses, and invalidation
 They support local diagnostics and synthetic benchmarks without recording
 queries, paths, or document text.
 
+`bm25_diagnostics_snapshot()` is the stable machine-readable boundary for these
+in-process measurements. Its versioned payload contains aggregate integer cardinality,
+capacity, row-pressure, hit/miss/invalidation, and deterministic retained-payload
+fields only. The payload estimate counts retained lexical structures and is not a claim
+about Python object overhead or process RSS. Capturing a snapshot uses the existing
+per-corpus query lock and does not alter scoring, invalidation, capacity, or publication.
+
 This is not an FTS or semantic cache. Shadow FTS continues to execute against
 SQLite, whose own page/query machinery remains the only cache at that layer; the
 semantic index also remains unchanged. The bounded BM25 LRU accelerates repeated

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -700,6 +700,61 @@ Non-goal: no repository-wide hexagonal rewrite.
 
 #### EX-11 — Add operational diagnostics before concurrency refactors
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-11-01
+repository: MarcoPorcellato/matryca-plumber
+base_commit: b2be63a1f737ce248ca722d7cbb51c9f60a03d59
+objective: expose existing BM25 corpus and query-cache state as a typed content-free snapshot
+authority: inspect | edit | commit | push | pr
+tracking_issue: 391
+allowlist:
+  - src/graph/generational_cache.py
+  - tests/test_bm25_query_cache.py
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - docs/knowledge/architecture/cache-friendly-retrieval.md
+  - CHANGELOG.md
+non_goals:
+  - instrument scoring latency or cumulative evictions in this tranche
+  - change Bm25Corpus fields, cache capacities, scoring, locking, or invalidation behavior
+  - expose graph paths, lexical terms, raw queries, result rows, or process RSS claims
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_bm25_query_cache.py
+  - make ci
+acceptance:
+  - snapshot fields are bounded aggregate integers with an explicit schema version
+  - repeated snapshots over unchanged state are equal and machine-readable
+  - output contains no paths, terms, queries, secrets, or graph content
+  - diagnostics remain passive and use the existing per-corpus query lock
+stop_conditions:
+  - any required cache-field, scoring-path, capacity, or lock-model mutation
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: b2be63a1f737ce248ca722d7cbb51c9f60a03d59
+  bm25_corpus_impact: CRITICAL
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: lifecycle | provenance
+residual_risks:
+  - retained-payload bytes are a deterministic structural estimate, not Python object RSS
+  - scoring latency and cumulative eviction counters remain for later #391 tranches
+```
+
+**EX-11-01 implemented:** `Bm25DiagnosticsSnapshot` is an immutable schema-v1 payload
+captured under the existing per-corpus query lock. It reports document, unique-term, and
+token cardinality; query-cache entry and row pressure against both capacities; existing
+hit, miss, and invalidation counters; and a deterministic retained-payload estimate.
+`to_dict()` exposes only stable integer fields. Tests prove repeated snapshots are equal,
+the estimate grows with retained structure, and serialized output contains no paths,
+terms, or query text. No `Bm25Corpus` field or scoring/cache path changed.
+
+Focused validation passes `9/9`. The complete macOS arm64 Python 3.12 gate passes with
+`1,650` tests, `5` skips, and `83.38%` coverage; format, Ruff, strict mypy over 377 source
+files, graph sandbox, version and agent coherence, public-metrics policy, documentation
+inventory, and generated prompt checks are all green. The only warning remains the
+pre-existing macOS multi-threaded `fork()` deprecation probe.
+
 Expose content-free metrics for:
 
 - Shadow sync duration, writer-lock wait, generation, fallback reason, last successful incremental sync, parser timeout count, quarantine age and retry count;

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -334,6 +334,85 @@ class Bm25Corpus:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class Bm25DiagnosticsSnapshot:
+    """Bounded, content-free operational view of one in-process BM25 corpus."""
+
+    schema_version: int
+    corpus_documents: int
+    corpus_unique_terms: int
+    corpus_tokens: int
+    query_cache_entries: int
+    query_cache_capacity: int
+    query_cache_result_rows: int
+    query_cache_result_row_capacity: int
+    query_cache_hits: int
+    query_cache_misses: int
+    query_cache_invalidations: int
+    estimated_payload_bytes: int
+
+    def to_dict(self) -> dict[str, int]:
+        """Return a stable machine-readable mapping without paths, terms, or queries."""
+        return {
+            "schema_version": self.schema_version,
+            "corpus_documents": self.corpus_documents,
+            "corpus_unique_terms": self.corpus_unique_terms,
+            "corpus_tokens": self.corpus_tokens,
+            "query_cache_entries": self.query_cache_entries,
+            "query_cache_capacity": self.query_cache_capacity,
+            "query_cache_result_rows": self.query_cache_result_rows,
+            "query_cache_result_row_capacity": self.query_cache_result_row_capacity,
+            "query_cache_hits": self.query_cache_hits,
+            "query_cache_misses": self.query_cache_misses,
+            "query_cache_invalidations": self.query_cache_invalidations,
+            "estimated_payload_bytes": self.estimated_payload_bytes,
+        }
+
+
+def _bm25_estimated_payload_bytes(corpus: Bm25Corpus) -> int:
+    """Estimate retained lexical payload deterministically; this is not process RSS."""
+    relation_bytes = sum(len(rel.encode("utf-8")) for rel in corpus.rels)
+    corpus_term_bytes = sum(
+        len(term.encode("utf-8")) + 8 for term_freqs in corpus.doc_term_freqs for term in term_freqs
+    )
+    document_length_bytes = len(corpus.doc_lens) * 8
+    document_frequency_bytes = sum(len(term.encode("utf-8")) + 8 for term in corpus.df)
+    query_bytes = sum(
+        sum(len(token.encode("utf-8")) for token in key[0]) + 24 for key in corpus.query_cache
+    )
+    result_bytes = sum(
+        sum(len(rel.encode("utf-8")) + 8 for rel, _score in rows)
+        for rows in corpus.query_cache.values()
+    )
+    return (
+        relation_bytes
+        + corpus_term_bytes
+        + document_length_bytes
+        + document_frequency_bytes
+        + query_bytes
+        + result_bytes
+    )
+
+
+def bm25_diagnostics_snapshot(corpus: Bm25Corpus) -> Bm25DiagnosticsSnapshot:
+    """Capture existing BM25 counters and bounded structure under the query lock."""
+    with corpus._query_lock:
+        return Bm25DiagnosticsSnapshot(
+            schema_version=1,
+            corpus_documents=corpus.n_docs,
+            corpus_unique_terms=len(corpus.df),
+            corpus_tokens=sum(corpus.doc_lens),
+            query_cache_entries=len(corpus.query_cache),
+            query_cache_capacity=_DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES,
+            query_cache_result_rows=corpus.query_cache_result_rows,
+            query_cache_result_row_capacity=_DEFAULT_BM25_QUERY_CACHE_MAX_RESULT_ROWS,
+            query_cache_hits=corpus.query_cache_hits,
+            query_cache_misses=corpus.query_cache_misses,
+            query_cache_invalidations=corpus.query_cache_invalidations,
+            estimated_payload_bytes=_bm25_estimated_payload_bytes(corpus),
+        )
+
+
 def bm25_query_cache_stats(corpus: Bm25Corpus) -> dict[str, int]:
     """Return content-free, per-corpus query-cache counters for diagnostics/tests."""
     with corpus._query_lock:
@@ -481,6 +560,8 @@ def score_bm25_query(
 
 __all__ = [
     "Bm25Corpus",
+    "Bm25DiagnosticsSnapshot",
+    "bm25_diagnostics_snapshot",
     "bm25_query_cache_stats",
     "cached_build_alias_index",
     "clear_generational_caches",

--- a/tests/test_bm25_query_cache.py
+++ b/tests/test_bm25_query_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import random
 import threading
@@ -11,6 +12,7 @@ from pathlib import Path
 import pytest
 from src.graph.generational_cache import (
     Bm25Corpus,
+    bm25_diagnostics_snapshot,
     bm25_query_cache_stats,
     clear_generational_caches,
     get_cached_bm25_corpus,
@@ -224,3 +226,35 @@ def test_bm25_query_cache_keys_include_limit_and_scoring_parameters() -> None:
     result_rows = stats["result_rows"]
     score_bm25_query(corpus, "shared", limit=3, k1=2.0, b=0.5)
     assert bm25_query_cache_stats(corpus)["result_rows"] == result_rows
+
+
+def test_bm25_diagnostics_snapshot_is_typed_content_free_and_deterministic() -> None:
+    corpus = _synthetic_corpus(document_count=32)
+    score_bm25_query(corpus, "shared topic1", limit=8)
+    score_bm25_query(corpus, "shared topic1", limit=8)
+
+    first = bm25_diagnostics_snapshot(corpus)
+    second = bm25_diagnostics_snapshot(corpus)
+
+    assert first == second
+    assert first.schema_version == 1
+    assert first.corpus_documents == 32
+    assert first.corpus_unique_terms == len(corpus.df)
+    assert first.corpus_tokens == sum(corpus.doc_lens)
+    assert first.query_cache_entries == 1
+    assert first.query_cache_result_rows == 8
+    assert first.query_cache_hits == first.query_cache_misses == 1
+    assert first.query_cache_invalidations == 0
+    assert first.estimated_payload_bytes > 0
+    payload = json.dumps(first.to_dict(), sort_keys=True)
+    assert "pages/" not in payload
+    assert "shared" not in payload
+    assert "topic1" not in payload
+
+
+def test_bm25_diagnostics_payload_estimate_tracks_retained_structure() -> None:
+    small = bm25_diagnostics_snapshot(_synthetic_corpus(document_count=8))
+    large = bm25_diagnostics_snapshot(_synthetic_corpus(document_count=64))
+
+    assert large.estimated_payload_bytes > small.estimated_payload_bytes
+    assert large.corpus_documents > small.corpus_documents


### PR DESCRIPTION
## Summary

- add immutable `Bm25DiagnosticsSnapshot` with a stable schema-v1 integer payload
- expose corpus cardinality, cache capacity/row pressure, and existing hit/miss/invalidation counters
- add a deterministic retained-lexical-payload estimate with an explicit non-RSS boundary
- prove serialized diagnostics contain no paths, terms, queries, results, secrets, or graph content

## Stack

- base: `test/graph-boundary-ast-394` / PR #415
- this PR is EX-11-01, the passive BM25 snapshot slice of #391
- merge after #415, or retarget once the lower stack is merged

## Safety boundary

- no `Bm25Corpus` field changes
- no scoring, capacity, invalidation, cache publication, or lock-model changes
- snapshot capture uses the existing per-corpus query lock
- scoring latency and cumulative eviction instrumentation remain separate future #391 slices
- no Gate B evidence, releases, tags, or publication state changed

## Validation

- focused BM25 query-cache suite: `9 passed`
- GitNexus change scope: LOW, zero affected runtime processes
- documentation bundle passed with no drift
- full `make ci`: `1,650 passed, 5 skipped`, 83.38% coverage
- one pre-existing macOS multi-threaded `fork()` deprecation warning

Refs #391
