### PR TITLE
feat(diagnostics): measure BM25 scoring and evictions (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation counters, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.
+- **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation/eviction counters, aggregate uncached-scoring timing, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.
 - **Reproducible BM25 capacity evidence** — add deterministic capacity, distribution, tail-latency, RSS, row-pressure, invalidation, rebuild, concurrent-corpus, and correctness-parity benchmarks; retain the 8,192-entry and 65,536-row production defaults under an explicit synthetic-evidence boundary.
 - **OKF v0.2 documentation governance** — align the maintained knowledge bundle with the pinned portable format, separate Matryca classification from official lifecycle status, add provenance, freshness, canonical-role, link, anchor, and chronology gates, migrate the full documentation inventory to schema v2, make documentation integrity mandatory in `make check` and `make ci`, and document the repository-to-projection operating model.
 - **Gate B public-RC soak qualification** — add separate resumable `default-on` and `read-only-external` profiles bound to the installed `2.0.0rc1` wheel, explicit opt-out controls, full graph-manifest integrity, external-cache isolation, and a terminal-aware supervisor for restart-safe multi-day evidence collection.

--- a/docs/knowledge/architecture/cache-friendly-retrieval.md
+++ b/docs/knowledge/architecture/cache-friendly-retrieval.md
@@ -229,16 +229,20 @@ serializes scoring with corpus mutation, so a query observes either the complete
 pre-patch generation or the complete post-patch generation, never a partially
 updated corpus. A corpus rebuilt after a filesystem-signature mismatch is a new
 object with an empty cache. The counters are intentionally content-free: entries,
-entry capacity, result rows, result-row capacity, hits, misses, and invalidations.
+entry capacity, result rows, result-row capacity, hits, misses, invalidations,
+evictions, and aggregate uncached-scoring timing.
 They support local diagnostics and synthetic benchmarks without recording
 queries, paths, or document text.
 
 `bm25_diagnostics_snapshot()` is the stable machine-readable boundary for these
-in-process measurements. Its versioned payload contains aggregate integer cardinality,
-capacity, row-pressure, hit/miss/invalidation, and deterministic retained-payload
-fields only. The payload estimate counts retained lexical structures and is not a claim
-about Python object overhead or process RSS. Capturing a snapshot uses the existing
-per-corpus query lock and does not alter scoring, invalidation, capacity, or publication.
+in-process measurements. Its schema-v2 payload contains aggregate integer cardinality,
+capacity, row-pressure, hit/miss/invalidation/eviction, uncached-scoring sample/total/max
+nanoseconds, and deterministic retained-payload fields only. Timing begins after a cache
+miss has been established and covers scoring plus result ordering; it excludes query
+tokenization, lock wait, cache publication, and cache-hit latency. The payload estimate
+counts retained lexical structures and is not a claim about Python object overhead or
+process RSS. Capturing a snapshot uses the existing per-corpus query lock and does not
+alter scoring, invalidation, capacity, or publication.
 
 This is not an FTS or semantic cache. Shadow FTS continues to execute against
 SQLite, whose own page/query machinery remains the only cache at that layer; the

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -755,6 +755,65 @@ files, graph sandbox, version and agent coherence, public-metrics policy, docume
 inventory, and generated prompt checks are all green. The only warning remains the
 pre-existing macOS multi-threaded `fork()` deprecation probe.
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-11-02
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 41d9283982d8c85436ba844abd4626f707492fa6
+objective: add bounded eviction and uncached-scoring timing to the BM25 snapshot
+authority: inspect | edit | commit | push | pr
+tracking_issue: 391
+allowlist:
+  - src/graph/generational_cache.py
+  - tests/test_bm25_query_cache.py
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - docs/knowledge/architecture/cache-friendly-retrieval.md
+  - CHANGELOG.md
+non_goals:
+  - change scoring results, query-cache keys, capacities, or eviction policy
+  - change invalidation, publication, or lock behavior
+  - measure tokenization, lock wait, cache-hit latency, process RSS, or percentiles
+  - expose graph paths, terms, queries, result rows, secrets, or graph content
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_bm25_query_cache.py
+  - make ci
+acceptance:
+  - schema v2 adds only bounded aggregate integer fields
+  - deterministic tests control the monotonic clock and exact eviction count
+  - cache hits do not increment uncached-scoring samples
+  - existing scoring results, capacity, invalidation, and locking remain unchanged
+stop_conditions:
+  - any need for cache-policy, result-order, public API, or lock-model changes
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 41d9283982d8c85436ba844abd4626f707492fa6
+  impact_evidence: exact-worktree caller inventory plus diff-level graph analysis
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: lifecycle | provenance
+residual_risks:
+  - aggregate max is not a percentile and resets with the process-lifetime corpus
+  - timing excludes tokenization, lock wait, cache publication, and cache hits by contract
+```
+
+**EX-11-02 implemented:** schema v2 adds cumulative eviction count plus uncached-scoring
+sample count, total nanoseconds, and maximum nanoseconds. Timing uses a monotonic clock
+after a miss is established and stops after score ordering, before cache publication and
+eviction. Fixed-clock tests prove exact aggregation and that a cache hit adds no timing
+sample; a two-entry cache fixture proves deterministic eviction accounting. The fields
+remain content-free and bounded-cardinality. Capacity, keying, scoring, invalidation,
+publication, and lock behavior are unchanged.
+
+Focused BM25 and generational-cache validation passes `43/43`. The complete macOS
+arm64 Python 3.12 gate passes with `1,652` tests, `5` skips, and `83.42%` coverage;
+format, Ruff, strict mypy over 377 source files, graph sandbox, version and agent
+coherence, public-metrics policy, documentation inventory, and generated prompt checks
+are all green. The only warning remains the pre-existing macOS multi-threaded `fork()`
+deprecation probe. A sandboxed first run denied the unrelated `ps` subprocess used by
+one daemon-lock test; that test and the complete gate both passed with normal host
+permissions.
+
 Expose content-free metrics for:
 
 - Shadow sync duration, writer-lock wait, generation, fallback reason, last successful incremental sync, parser timeout count, quarantine age and retry count;

--- a/src/graph/generational_cache.py
+++ b/src/graph/generational_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import threading
+import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -326,7 +327,11 @@ class Bm25Corpus:
     query_cache_hits: int = 0
     query_cache_misses: int = 0
     query_cache_invalidations: int = 0
+    query_cache_evictions: int = 0
     query_cache_result_rows: int = 0
+    uncached_scoring_samples: int = 0
+    uncached_scoring_total_ns: int = 0
+    uncached_scoring_max_ns: int = 0
     _query_lock: threading.Lock = field(
         default_factory=threading.Lock,
         repr=False,
@@ -349,6 +354,10 @@ class Bm25DiagnosticsSnapshot:
     query_cache_hits: int
     query_cache_misses: int
     query_cache_invalidations: int
+    query_cache_evictions: int
+    uncached_scoring_samples: int
+    uncached_scoring_total_ns: int
+    uncached_scoring_max_ns: int
     estimated_payload_bytes: int
 
     def to_dict(self) -> dict[str, int]:
@@ -365,6 +374,10 @@ class Bm25DiagnosticsSnapshot:
             "query_cache_hits": self.query_cache_hits,
             "query_cache_misses": self.query_cache_misses,
             "query_cache_invalidations": self.query_cache_invalidations,
+            "query_cache_evictions": self.query_cache_evictions,
+            "uncached_scoring_samples": self.uncached_scoring_samples,
+            "uncached_scoring_total_ns": self.uncached_scoring_total_ns,
+            "uncached_scoring_max_ns": self.uncached_scoring_max_ns,
             "estimated_payload_bytes": self.estimated_payload_bytes,
         }
 
@@ -398,7 +411,7 @@ def bm25_diagnostics_snapshot(corpus: Bm25Corpus) -> Bm25DiagnosticsSnapshot:
     """Capture existing BM25 counters and bounded structure under the query lock."""
     with corpus._query_lock:
         return Bm25DiagnosticsSnapshot(
-            schema_version=1,
+            schema_version=2,
             corpus_documents=corpus.n_docs,
             corpus_unique_terms=len(corpus.df),
             corpus_tokens=sum(corpus.doc_lens),
@@ -409,6 +422,10 @@ def bm25_diagnostics_snapshot(corpus: Bm25Corpus) -> Bm25DiagnosticsSnapshot:
             query_cache_hits=corpus.query_cache_hits,
             query_cache_misses=corpus.query_cache_misses,
             query_cache_invalidations=corpus.query_cache_invalidations,
+            query_cache_evictions=corpus.query_cache_evictions,
+            uncached_scoring_samples=corpus.uncached_scoring_samples,
+            uncached_scoring_total_ns=corpus.uncached_scoring_total_ns,
+            uncached_scoring_max_ns=corpus.uncached_scoring_max_ns,
             estimated_payload_bytes=_bm25_estimated_payload_bytes(corpus),
         )
 
@@ -424,6 +441,10 @@ def bm25_query_cache_stats(corpus: Bm25Corpus) -> dict[str, int]:
             "hits": corpus.query_cache_hits,
             "misses": corpus.query_cache_misses,
             "invalidations": corpus.query_cache_invalidations,
+            "evictions": corpus.query_cache_evictions,
+            "uncached_scoring_samples": corpus.uncached_scoring_samples,
+            "uncached_scoring_total_ns": corpus.uncached_scoring_total_ns,
+            "uncached_scoring_max_ns": corpus.uncached_scoring_max_ns,
         }
 
 
@@ -520,6 +541,7 @@ def score_bm25_query(
             corpus.query_cache_hits += 1
             return list(cached)
         corpus.query_cache_misses += 1
+        scoring_started_ns = time.perf_counter_ns()
 
         n_docs = corpus.n_docs
         avgdl = corpus.avgdl
@@ -546,6 +568,13 @@ def score_bm25_query(
 
         scores.sort(key=lambda item: (-item[1], item[0]))
         result = tuple(scores[:capped])
+        scoring_duration_ns = max(0, time.perf_counter_ns() - scoring_started_ns)
+        corpus.uncached_scoring_samples += 1
+        corpus.uncached_scoring_total_ns += scoring_duration_ns
+        corpus.uncached_scoring_max_ns = max(
+            corpus.uncached_scoring_max_ns,
+            scoring_duration_ns,
+        )
         corpus.query_cache[cache_key] = result
         corpus.query_cache_result_rows += len(result)
         corpus.query_cache.move_to_end(cache_key)
@@ -555,6 +584,7 @@ def score_bm25_query(
         ):
             _, evicted = corpus.query_cache.popitem(last=False)
             corpus.query_cache_result_rows -= len(evicted)
+            corpus.query_cache_evictions += 1
         return list(result)
 
 

--- a/tests/test_bm25_query_cache.py
+++ b/tests/test_bm25_query_cache.py
@@ -6,6 +6,7 @@ import json
 import math
 import random
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -237,7 +238,7 @@ def test_bm25_diagnostics_snapshot_is_typed_content_free_and_deterministic() -> 
     second = bm25_diagnostics_snapshot(corpus)
 
     assert first == second
-    assert first.schema_version == 1
+    assert first.schema_version == 2
     assert first.corpus_documents == 32
     assert first.corpus_unique_terms == len(corpus.df)
     assert first.corpus_tokens == sum(corpus.doc_lens)
@@ -245,6 +246,10 @@ def test_bm25_diagnostics_snapshot_is_typed_content_free_and_deterministic() -> 
     assert first.query_cache_result_rows == 8
     assert first.query_cache_hits == first.query_cache_misses == 1
     assert first.query_cache_invalidations == 0
+    assert first.query_cache_evictions == 0
+    assert first.uncached_scoring_samples == 1
+    assert first.uncached_scoring_total_ns >= 0
+    assert first.uncached_scoring_max_ns == first.uncached_scoring_total_ns
     assert first.estimated_payload_bytes > 0
     payload = json.dumps(first.to_dict(), sort_keys=True)
     assert "pages/" not in payload
@@ -258,3 +263,40 @@ def test_bm25_diagnostics_payload_estimate_tracks_retained_structure() -> None:
 
     assert large.estimated_payload_bytes > small.estimated_payload_bytes
     assert large.corpus_documents > small.corpus_documents
+
+
+def test_bm25_diagnostics_measure_uncached_scoring_without_counting_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus = _synthetic_corpus(document_count=32)
+    ticks = iter((10_000, 10_125))
+    monkeypatch.setattr(time, "perf_counter_ns", lambda: next(ticks))
+
+    expected = _score_reference(corpus, "shared topic1", limit=8)
+    assert score_bm25_query(corpus, "shared topic1", limit=8) == expected
+    assert score_bm25_query(corpus, "shared topic1", limit=8) == expected
+
+    snapshot = bm25_diagnostics_snapshot(corpus)
+    assert snapshot.uncached_scoring_samples == 1
+    assert snapshot.uncached_scoring_total_ns == 125
+    assert snapshot.uncached_scoring_max_ns == 125
+    assert snapshot.query_cache_hits == snapshot.query_cache_misses == 1
+
+
+def test_bm25_diagnostics_count_lru_evictions_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    corpus = _synthetic_corpus(document_count=8)
+    monkeypatch.setattr(
+        "src.graph.generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES",
+        2,
+    )
+
+    score_bm25_query(corpus, "unique0", limit=1)
+    score_bm25_query(corpus, "unique1", limit=1)
+    score_bm25_query(corpus, "unique2", limit=1)
+
+    snapshot = bm25_diagnostics_snapshot(corpus)
+    assert snapshot.query_cache_entries == snapshot.query_cache_capacity == 2
+    assert snapshot.query_cache_evictions == 1
+    assert snapshot.uncached_scoring_samples == 3


### PR DESCRIPTION
## Summary

- add cumulative BM25 query-cache eviction accounting
- measure uncached scoring with bounded sample, total, and maximum nanoseconds
- bump the content-free diagnostics payload to schema v2
- document exact timing boundaries and the EX-11-02 tranche receipt

## Stack

- base: `feat/bm25-diagnostics-snapshot-391` / PR #416
- this PR is EX-11-02, the scoring/eviction diagnostics slice of #391
- merge after #416, or retarget once the lower stack is merged

## Safety boundary

- no scoring result, key, capacity, or eviction-policy change
- no invalidation, publication, or lock-model change
- no paths, terms, queries, results, secrets, or graph content in diagnostics
- timing excludes tokenization, lock wait, cache publication, and cache hits
- no Gate B evidence, releases, tags, or publication state changed

## Validation

- focused BM25 and generational-cache suite: `43 passed`
- diff-level change analysis: LOW, zero affected runtime processes
- documentation bundle passed with no drift
- full `make ci`: `1,652 passed, 5 skipped`, 83.42% coverage
- one pre-existing macOS multi-threaded `fork()` deprecation warning

Refs #391
