### PR TITLE
feat(diagnostics): expose checkpoint recovery source (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Checkpoint recovery diagnostics (#391)** — expose a bounded recovery-source vocabulary and explicit reset event in the bootstrap status projection, distinguishing missing, primary, backup, and unreadable checkpoint states without changing recovery, Soft Gate, or read-only behavior.
 - **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation/eviction counters, aggregate uncached-scoring timing, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.
 - **Reproducible BM25 capacity evidence** — add deterministic capacity, distribution, tail-latency, RSS, row-pressure, invalidation, rebuild, concurrent-corpus, and correctness-parity benchmarks; retain the 8,192-entry and 65,536-row production defaults under an explicit synthetic-evidence boundary.
 - **OKF v0.2 documentation governance** — align the maintained knowledge bundle with the pinned portable format, separate Matryca classification from official lifecycle status, add provenance, freshness, canonical-role, link, anchor, and chronology gates, migrate the full documentation inventory to schema v2, make documentation integrity mandatory in `make check` and `make ci`, and document the repository-to-projection operating model.

--- a/docs/knowledge/architecture/graph-plane.md
+++ b/docs/knowledge/architecture/graph-plane.md
@@ -5,8 +5,8 @@ description: Markdown SSOT, parser-backed mutation plane, OCC, locks, and path s
 resource: src/graph/
 tags: [graph, occ, parser, sandbox, graph-dispatch]
 generated: { by: human:marco-porcellato, at: '2026-07-18T00:00:00Z' }
-verified: { by: human:marco-porcellato, at: '2026-08-06T00:00:00Z' }
-last_verified: 2026-08-06
+verified: { by: human:marco-porcellato, at: '2026-08-07T00:00:00Z' }
+last_verified: 2026-08-07
 stale_after: 2027-02-02
 status: stable
 classification: canonical
@@ -106,6 +106,17 @@ Canonical order: `occ_snapshot` → inference → `occ_verify_before_write` → 
 | Page lock registry | LRU cap in `page_write_lock.py`; cross-process sidecar via `platform_lock` |
 
 Full security contract: [`openspec/security-sandbox.md`](../../openspec/security-sandbox.md). Layer map: [`CLEAN_CODE_ARCHITECTURE.md`](../../CLEAN_CODE_ARCHITECTURE.md).
+
+## Checkpoint recovery diagnostics
+
+The read-only bootstrap status projection reports how the daemon checkpoint view was
+obtained through a closed `missing`, `primary`, `backup`, or `reset` vocabulary. The
+separate `checkpoint_reset_event` boolean is true only when checkpoint files exist but
+neither the primary nor backup payload is readable, so an operator can distinguish an
+ordinary first run from explicit fallback to empty gate defaults. These fields add no
+paths or checkpoint payload content and do not change backup restoration, Soft Gate
+calculation, or graph read-only behavior. The existing bootstrap envelope continues to
+carry its established `graph_root` operator field.
 
 ## Legacy deep dives
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -814,6 +814,64 @@ deprecation probe. A sandboxed first run denied the unrelated `ps` subprocess us
 one daemon-lock test; that test and the complete gate both passed with normal host
 permissions.
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-11-03
+repository: MarcoPorcellato/matryca-plumber
+base_commit: a8082df4499d695eb17187494ae41187dcb40c38
+objective: expose checkpoint recovery source and an explicit reset event
+authority: inspect | edit | commit | push | pr
+tracking_issue: 391
+allowlist:
+  - src/graph/daemon_checkpoint.py
+  - src/graph/bootstrap_status.py
+  - tests/test_daemon_checkpoint.py
+  - tests/test_bootstrap_status.py
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - docs/knowledge/architecture/graph-plane.md
+  - CHANGELOG.md
+non_goals:
+  - change checkpoint recovery, backup restoration, or graph read-only policy
+  - modify src/agent/daemon_state.py or load_daemon_state()
+  - add persistence, cumulative counters, paths, or checkpoint payload content
+  - change Shadow, watcher, fallback, capacity, concurrency, Gate B, or release state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_daemon_checkpoint.py tests/test_bootstrap_status.py
+  - make ci
+acceptance:
+  - recovery source uses only missing, primary, backup, or reset
+  - reset event is true only when existing checkpoint copies are all unreadable
+  - existing bootstrap gate fields and decisions remain identical
+  - new fields add no path or checkpoint payload content to the existing envelope
+  - read-only backup recovery does not restore the primary file
+stop_conditions:
+  - any need to change loader, persistence, recovery, Soft Gate, or write-policy behavior
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: a8082df4499d695eb17187494ae41187dcb40c38
+  impact_evidence: LOW; one direct and one indirect caller; no affected process
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: metadata | lifecycle | provenance
+residual_risks:
+  - reset_event is a current-read projection, not a persistent cumulative counter
+  - the established bootstrap envelope still includes its operator-facing graph_root field
+```
+
+**EX-11-03 implemented:** `DaemonCheckpointView` now identifies whether bootstrap fields
+came from a missing checkpoint, the primary payload, the backup payload, or empty reset
+defaults after all existing copies proved unreadable. `BootstrapStatusSnapshot` projects
+that closed vocabulary and a separate reset boolean without changing bootstrap or Soft
+Gate calculations. Focused tests cover all four sources, explicit reset, failed primary
+restoration, and read-only backup recovery without graph mutation. No loader, persistence,
+Shadow, watcher, fallback, capacity, concurrency, Gate B, tag, or publication behavior
+changed. The complete `make ci` gate passed with 1,654 tests, 5 skips, 83.43% coverage,
+Ruff, format checks, strict mypy over 377 source files, graph sandbox, version and agent
+coherence, public-metrics policy, documentation inventory, and generated prompt checks.
+The sole warning remains the pre-existing macOS multi-threaded `fork()` deprecation
+probe.
+
 Expose content-free metrics for:
 
 - Shadow sync duration, writer-lock wait, generation, fallback reason, last successful incremental sync, parser timeout count, quarantine age and retry count;

--- a/src/graph/bootstrap_status.py
+++ b/src/graph/bootstrap_status.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from .master_catalog import is_bootstrap_catalog_complete, master_index_page_path
 
@@ -25,6 +25,8 @@ class BootstrapStatusSnapshot:
     phase1_in_progress: bool
     soft_gate_active: bool
     daemon_status: str | None
+    checkpoint_recovery_source: Literal["missing", "primary", "backup", "reset"]
+    checkpoint_reset_event: bool
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -39,6 +41,8 @@ class BootstrapStatusSnapshot:
             "phase1_in_progress": self.phase1_in_progress,
             "soft_gate_active": self.soft_gate_active,
             "daemon_status": self.daemon_status,
+            "checkpoint_recovery_source": self.checkpoint_recovery_source,
+            "checkpoint_reset_event": self.checkpoint_reset_event,
         }
 
 
@@ -78,6 +82,8 @@ def collect_bootstrap_status(graph_root: str | Path) -> BootstrapStatusSnapshot:
         phase1_in_progress=phase1_in_progress,
         soft_gate_active=soft_gate_active,
         daemon_status=checkpoint.status,
+        checkpoint_recovery_source=checkpoint.recovery_source,
+        checkpoint_reset_event=checkpoint.reset_event,
     )
 
 

--- a/src/graph/daemon_checkpoint.py
+++ b/src/graph/daemon_checkpoint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 
@@ -26,6 +26,8 @@ class DaemonCheckpointView:
     bootstrap_scanned: int = 0
     bootstrap_total: int = 0
     status: str | None = None
+    recovery_source: Literal["missing", "primary", "backup", "reset"] = "missing"
+    reset_event: bool = False
 
 
 def checkpoint_path(graph_root: Path) -> Path:
@@ -54,6 +56,7 @@ def read_daemon_checkpoint(graph_root: str | Path) -> DaemonCheckpointView:
     if not path.is_file() and not bak_path.is_file():
         return DaemonCheckpointView()
 
+    recovery_source: Literal["primary", "backup"] = "primary"
     payload = _read_checkpoint_payload(path) if path.is_file() else None
     if payload is None and bak_path.is_file():
         logger.warning(
@@ -61,6 +64,7 @@ def read_daemon_checkpoint(graph_root: str | Path) -> DaemonCheckpointView:
             "attempting recovery from .bak backup."
         )
         payload = _read_checkpoint_payload(bak_path)
+        recovery_source = "backup"
         if payload is not None and not is_graph_read_only():
             try:
                 shutil.copy2(bak_path, path)
@@ -75,7 +79,7 @@ def read_daemon_checkpoint(graph_root: str | Path) -> DaemonCheckpointView:
             "[METADATA CORRUPTION DETECTED] Checkpoint and backup both unreadable; "
             "using empty bootstrap gate defaults."
         )
-        return DaemonCheckpointView()
+        return DaemonCheckpointView(recovery_source="reset", reset_event=True)
 
     reason = payload.get("bootstrap_failed_reason")
     status = payload.get("status")
@@ -86,6 +90,7 @@ def read_daemon_checkpoint(graph_root: str | Path) -> DaemonCheckpointView:
         bootstrap_scanned=int(payload.get("bootstrap_scanned", 0)),
         bootstrap_total=int(payload.get("bootstrap_total", 0)),
         status=str(status) if status not in (None, "") else None,
+        recovery_source=recovery_source,
     )
 
 

--- a/tests/test_bootstrap_status.py
+++ b/tests/test_bootstrap_status.py
@@ -48,6 +48,8 @@ def test_collect_bootstrap_status_phase1_in_progress(tmp_path: Path) -> None:
     assert snap.soft_gate_active is True
     assert snap.bootstrap_scanned == 3
     assert snap.bootstrap_total == 10
+    assert snap.checkpoint_recovery_source == "primary"
+    assert snap.checkpoint_reset_event is False
 
 
 def test_collect_bootstrap_status_green_when_catalog_complete(
@@ -94,6 +96,22 @@ def test_format_bootstrap_status_markdown_includes_json(tmp_path: Path) -> None:
     payload = json.loads(md[start:end])
     assert payload["ok"] is True
     assert "graph_root" in payload
+    assert payload["checkpoint_recovery_source"] == "missing"
+    assert payload["checkpoint_reset_event"] is False
+
+
+def test_collect_bootstrap_status_projects_checkpoint_reset_event(tmp_path: Path) -> None:
+    from src.daemon.checkpoint import CHECKPOINT_BAK_FILENAME, CHECKPOINT_FILENAME
+
+    (tmp_path / "pages").mkdir()
+    (tmp_path / CHECKPOINT_FILENAME).write_text("{not-json", encoding="utf-8")
+    (tmp_path / CHECKPOINT_BAK_FILENAME).write_text("[]", encoding="utf-8")
+
+    snapshot = collect_bootstrap_status(tmp_path)
+
+    assert snapshot.checkpoint_recovery_source == "reset"
+    assert snapshot.checkpoint_reset_event is True
+    assert snapshot.soft_gate_active is True
 
 
 def test_state_path_written(tmp_path: Path) -> None:

--- a/tests/test_daemon_checkpoint.py
+++ b/tests/test_daemon_checkpoint.py
@@ -29,6 +29,8 @@ def test_read_daemon_checkpoint_reads_bootstrap_fields(tmp_path: Path) -> None:
     assert view.bootstrap_failed is True
     assert view.bootstrap_failed_reason == "disk full"
     assert view.status == "idle"
+    assert view.recovery_source == "primary"
+    assert view.reset_event is False
 
 
 def test_read_daemon_checkpoint_empty_when_missing(tmp_path: Path) -> None:
@@ -36,6 +38,8 @@ def test_read_daemon_checkpoint_empty_when_missing(tmp_path: Path) -> None:
     view = read_daemon_checkpoint(tmp_path)
     assert view.bootstrap_complete is False
     assert view.bootstrap_total == 0
+    assert view.recovery_source == "missing"
+    assert view.reset_event is False
 
 
 def test_read_daemon_checkpoint_logs_when_bak_restore_fails(
@@ -68,6 +72,8 @@ def test_read_daemon_checkpoint_logs_when_bak_restore_fails(
     assert view.bootstrap_complete is True
     assert view.bootstrap_scanned == 2
     assert view.bootstrap_total == 5
+    assert view.recovery_source == "backup"
+    assert view.reset_event is False
     assert any("restore primary" in err for err in errors)
 
 
@@ -85,5 +91,24 @@ def test_read_daemon_checkpoint_uses_backup_without_restore_in_read_only_mode(
     before = primary.read_bytes()
     monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
 
-    assert read_daemon_checkpoint(tmp_path).bootstrap_complete is True
+    view = read_daemon_checkpoint(tmp_path)
+    assert view.bootstrap_complete is True
+    assert view.recovery_source == "backup"
+    assert view.reset_event is False
     assert primary.read_bytes() == before
+
+
+def test_read_daemon_checkpoint_reports_explicit_reset_when_all_copies_are_invalid(
+    tmp_path: Path,
+) -> None:
+    from src.daemon.checkpoint import CHECKPOINT_BAK_FILENAME, CHECKPOINT_FILENAME
+
+    (tmp_path / "pages").mkdir()
+    (tmp_path / CHECKPOINT_FILENAME).write_text("{not-json", encoding="utf-8")
+    (tmp_path / CHECKPOINT_BAK_FILENAME).write_text("[]", encoding="utf-8")
+
+    view = read_daemon_checkpoint(tmp_path)
+
+    assert view.bootstrap_complete is False
+    assert view.recovery_source == "reset"
+    assert view.reset_event is True


### PR DESCRIPTION
## Summary

- add a closed `missing` / `primary` / `backup` / `reset` recovery-source vocabulary to the daemon checkpoint view
- project the recovery source and an explicit reset event through bootstrap status diagnostics
- document the operator contract and the frozen EX-11-03 evidence manifest

## Stack

- base: `feat/bm25-scoring-diagnostics-391` (#417)
- tranche: EX-11-03
- merge after #417

## Safety boundaries

- no checkpoint loading, persistence, backup restoration, Soft Gate, or read-only policy change
- no Shadow DB, watcher, fallback, capacity, concurrency, Gate B, tag, release, or publication change
- new fields add no path or checkpoint payload content; the existing bootstrap envelope continues to expose its established `graph_root` operator field

## Validation

- focused checkpoint/bootstrap tests: 11 passed
- full `make ci`: 1,654 passed, 5 skipped, 83.43% coverage
- Ruff, format checks, strict mypy over 377 source files, graph sandbox, version/agent coherence, public-metrics policy, documentation inventory, and generated prompt checks: passed
- GitNexus staged change analysis: LOW risk, zero affected execution flows
- sole warning: pre-existing macOS multi-threaded `fork()` deprecation probe

Refs #391
