### PR TITLE
feat(diagnostics): expose watcher convergence snapshot (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Typed watcher operational snapshot (#391)** — expose path-free pending depth, coalescing, dispatch/failure counters, oldest-event age, and last/maximum convergence latency under the existing debounce lock without changing scheduling, callback routing, or backlog policy.
 - **Checkpoint recovery diagnostics (#391)** — expose a bounded recovery-source vocabulary and explicit reset event in the bootstrap status projection, distinguishing missing, primary, backup, and unreadable checkpoint states without changing recovery, Soft Gate, or read-only behavior.
 - **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation/eviction counters, aggregate uncached-scoring timing, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.
 - **Reproducible BM25 capacity evidence** — add deterministic capacity, distribution, tail-latency, RSS, row-pressure, invalidation, rebuild, concurrent-corpus, and correctness-parity benchmarks; retain the 8,192-entry and 65,536-row production defaults under an explicit synthetic-evidence boundary.

--- a/docs/knowledge/architecture/system-overview.md
+++ b/docs/knowledge/architecture/system-overview.md
@@ -5,8 +5,8 @@ description: Three-surface runtime, shared mutation plane, vault topology, and d
 resource: src/
 tags: [architecture, daemon, mcp, sovereign-ui, graph-dispatch]
 generated: { by: human:marco-porcellato, at: '2026-07-18T00:00:00Z' }
-verified: { by: human:marco-porcellato, at: '2026-08-06T00:00:00Z' }
-last_verified: 2026-08-06
+verified: { by: human:marco-porcellato, at: '2026-08-07T00:00:00Z' }
+last_verified: 2026-08-07
 stale_after: 2027-02-02
 status: stable
 classification: canonical
@@ -83,6 +83,16 @@ flowchart TB
 ```
 
 **Quality bar:** Mypy strict on `src` and `tests`, Ruff lint/format clean via `make ci`; maintainer gates include `make agents-check` and `make check-system-prompt`.
+
+### Watcher diagnostics
+
+`GraphFileWatcher.diagnostics_snapshot()` exposes a schema-versioned, content-free view
+of debounce pressure and convergence: pending depth, schedule/coalescing and
+dispatch/failure counters, oldest pending age, and last/maximum callback-completion
+latency. The snapshot is captured under the existing condition lock and contains no graph
+paths or event content. It does not cap pending paths, coalesce overflow into a rescan, or
+change scheduler deadlines and callback routing; those resilience policies remain tracked
+separately by issue #398.
 
 ## Separation of concerns
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -872,6 +872,65 @@ coherence, public-metrics policy, documentation inventory, and generated prompt 
 The sole warning remains the pre-existing macOS multi-threaded `fork()` deprecation
 probe.
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-11-04
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 2bc6217512404208eb8c9e98720ed5a4cea319d5
+objective: expose bounded watcher debounce and convergence diagnostics
+authority: inspect | edit | commit | push | pr
+tracking_issue: 391
+allowlist:
+  - src/daemon/file_watcher.py
+  - tests/test_file_watcher.py
+  - docs/knowledge/architecture/system-overview.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - CHANGELOG.md
+non_goals:
+  - cap pending paths or implement overflow/rescan policy from issue 398
+  - change debounce deadlines, event filtering, callback routing, or daemon state
+  - change Shadow, Gate B, tags, releases, or publication state
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_file_watcher.py
+  - make ci
+acceptance:
+  - typed snapshot contains no paths, queries, or graph content
+  - pending, scheduled, coalesced, dispatched, and callback-failure counts are explicit
+  - oldest pending age and last/maximum callback-completion latency use monotonic time
+  - counters are captured under the existing condition lock
+  - existing debounce and callback behavior remains unchanged
+stop_conditions:
+  - any need for backlog caps, rescan policy, persistence, or daemon/API integration
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 2bc6217512404208eb8c9e98720ed5a4cea319d5
+  handler_impact: MEDIUM; five direct import dependents; no affected process
+  schedule_and_worker_impact: LOW
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: metadata | lifecycle | provenance
+residual_risks:
+  - counters reset with the process and are not persisted
+  - maximum latency is not a percentile
+  - overflow remains unimplemented until issue 398
+```
+
+**EX-11-04 implemented:** `WatcherDiagnosticsSnapshot` reports current pending depth,
+process-lifetime schedule/coalescing and dispatch/failure counters, oldest pending age,
+and last/maximum callback-completion latency. The handler preserves the first-seen time
+when repeated events reset a debounce deadline, captures state under its existing
+condition lock, and exposes no path or event content. The public watcher delegates to the
+active handler or returns an explicit stopped zero snapshot. No backlog cap, rescan,
+persistence, daemon/API integration, Shadow, Gate B, or release behavior changed.
+Focused watcher tests pass `2/2`. The complete `make ci` gate passes with 1,655 tests,
+5 skips, and 83.45% coverage; format, Ruff, strict mypy over 377 source files, graph
+sandbox, version and agent coherence, public-metrics policy, documentation inventory,
+and generated prompt checks are green. The only warning remains the pre-existing macOS
+multi-threaded `fork()` deprecation probe. A sandboxed first run denied the unrelated
+`ps` subprocess used by one daemon-lock test; the complete gate passed with normal host
+permissions.
+
 Expose content-free metrics for:
 
 - Shadow sync duration, writer-lock wait, generation, fallback reason, last successful incremental sync, parser timeout count, quarantine age and retry count;

--- a/src/daemon/file_watcher.py
+++ b/src/daemon/file_watcher.py
@@ -6,6 +6,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Protocol
 
@@ -40,6 +41,22 @@ FileEventKind = Literal["created", "modified", "deleted"]
 _DEFAULT_DEBOUNCE_MS = 750
 _MIN_DEBOUNCE_MS = 500
 _MAX_DEBOUNCE_MS = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class WatcherDiagnosticsSnapshot:
+    """Content-free process-lifetime debounce diagnostics."""
+
+    schema_version: int
+    pending_count: int
+    scheduled_count: int
+    coalesced_count: int
+    dispatched_count: int
+    callback_failure_count: int
+    oldest_pending_age_ns: int
+    last_convergence_latency_ns: int
+    max_convergence_latency_ns: int
+    stopped: bool
 
 
 def _debounce_ms_from_env() -> float:
@@ -79,10 +96,16 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
         # threading.Timer per file: a bulk change (sync-client re-download, mass tag
         # rewrite) touching thousands of files would otherwise spawn thousands of OS
         # threads at once (F5, TRIZ Principle 20: continuous action / partial-excessive).
-        self._pending: dict[str, tuple[float, Path, FileEventKind]] = {}
+        self._pending: dict[str, tuple[float, float, Path, FileEventKind]] = {}
         self._lock = threading.Lock()
         self._wake = threading.Condition(self._lock)
         self._stopped = False
+        self._scheduled_count = 0
+        self._coalesced_count = 0
+        self._dispatched_count = 0
+        self._callback_failure_count = 0
+        self._last_convergence_latency_ns = 0
+        self._max_convergence_latency_ns = 0
         self._worker = threading.Thread(
             target=self._run, name="matryca-watch-debounce", daemon=True
         )
@@ -90,9 +113,15 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
 
     def _schedule(self, path: Path, kind: FileEventKind) -> None:
         key = str(path)
-        deadline = time.monotonic() + self._debounce_s
+        now = time.monotonic()
+        deadline = now + self._debounce_s
         with self._wake:
-            self._pending[key] = (deadline, path, kind)
+            previous = self._pending.get(key)
+            first_seen = previous[1] if previous is not None else now
+            self._scheduled_count += 1
+            if previous is not None:
+                self._coalesced_count += 1
+            self._pending[key] = (deadline, first_seen, path, kind)
             self._wake.notify_all()
 
     def _run(self) -> None:
@@ -102,28 +131,41 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
                     self._wake.wait()
                     continue
                 now = time.monotonic()
-                next_deadline = min(deadline for deadline, _, _ in self._pending.values())
+                next_deadline = min(deadline for deadline, _, _, _ in self._pending.values())
                 if next_deadline > now:
                     self._wake.wait(timeout=next_deadline - now)
                     continue
                 due = [
-                    (key, path, kind)
-                    for key, (deadline, path, kind) in self._pending.items()
+                    (key, first_seen, path, kind)
+                    for key, (deadline, first_seen, path, kind) in self._pending.items()
                     if deadline <= now
                 ]
-                for key, _, _ in due:
+                for key, _, _, _ in due:
                     del self._pending[key]
                 if not due:
                     continue
                 self._wake.release()
+                completed: list[tuple[int, bool]] = []
                 try:
-                    for _, path, kind in due:
+                    for _, first_seen, path, kind in due:
+                        failed = False
                         try:
                             self._on_debounced(path, kind)
                         except Exception:  # noqa: BLE001
+                            failed = True
                             logger.exception("Debounced file watcher callback failed for {}", path)
+                        finally:
+                            latency_ns = max(0, int((time.monotonic() - first_seen) * 1e9))
+                            completed.append((latency_ns, failed))
                 finally:
                     self._wake.acquire()
+                    for latency_ns, failed in completed:
+                        self._dispatched_count += 1
+                        self._callback_failure_count += int(failed)
+                        self._last_convergence_latency_ns = latency_ns
+                        self._max_convergence_latency_ns = max(
+                            self._max_convergence_latency_ns, latency_ns
+                        )
 
     def on_created(self, event: FileSystemEvent) -> None:
         self._handle(event)
@@ -166,6 +208,30 @@ class _DebouncedMarkdownHandler(FileSystemEventHandler):
             self._pending.clear()
             self._wake.notify_all()
         self._worker.join(timeout=2.0)
+
+    def diagnostics_snapshot(self) -> WatcherDiagnosticsSnapshot:
+        """Return a path-free snapshot under the existing scheduler lock."""
+        now = time.monotonic()
+        with self._wake:
+            oldest_age_ns = max(
+                (
+                    max(0, int((now - first_seen) * 1e9))
+                    for _, first_seen, _, _ in self._pending.values()
+                ),
+                default=0,
+            )
+            return WatcherDiagnosticsSnapshot(
+                schema_version=1,
+                pending_count=len(self._pending),
+                scheduled_count=self._scheduled_count,
+                coalesced_count=self._coalesced_count,
+                dispatched_count=self._dispatched_count,
+                callback_failure_count=self._callback_failure_count,
+                oldest_pending_age_ns=oldest_age_ns,
+                last_convergence_latency_ns=self._last_convergence_latency_ns,
+                max_convergence_latency_ns=self._max_convergence_latency_ns,
+                stopped=self._stopped,
+            )
 
 
 class GraphFileWatcher:
@@ -211,5 +277,11 @@ class GraphFileWatcher:
             self._observer.join(timeout=5.0)
             self._observer = None
 
+    def diagnostics_snapshot(self) -> WatcherDiagnosticsSnapshot:
+        """Return current debounce diagnostics without exposing graph paths."""
+        if self._handler is None:
+            return WatcherDiagnosticsSnapshot(1, 0, 0, 0, 0, 0, 0, 0, 0, True)
+        return self._handler.diagnostics_snapshot()
 
-__all__ = ["FileEventKind", "GraphFileWatcher"]
+
+__all__ = ["FileEventKind", "GraphFileWatcher", "WatcherDiagnosticsSnapshot"]

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import threading
 import time
+from dataclasses import asdict
 from pathlib import Path
 
-from src.daemon.file_watcher import _DebouncedMarkdownHandler
+from src.daemon.file_watcher import GraphFileWatcher, _DebouncedMarkdownHandler
 
 
 def test_debounce_coalesces_rapid_events(tmp_path: Path) -> None:
@@ -35,9 +36,41 @@ def test_debounce_coalesces_rapid_events(tmp_path: Path) -> None:
 
     handler.on_modified(_Ev())  # type: ignore[arg-type]
     handler.on_modified(_Ev())  # type: ignore[arg-type]
+    pending = handler.diagnostics_snapshot()
+    assert pending.pending_count == 1
+    assert pending.scheduled_count == 2
+    assert pending.coalesced_count == 1
+    assert pending.dispatched_count == 0
+    assert pending.oldest_pending_age_ns >= 0
     time.sleep(0.2)
     handler.cancel_all()
 
     with lock:
         assert len(events) == 1
         assert events[0][1] == "modified"
+
+    complete = handler.diagnostics_snapshot()
+    assert complete.schema_version == 1
+    assert complete.pending_count == 0
+    assert complete.dispatched_count == 1
+    assert complete.callback_failure_count == 0
+    assert complete.last_convergence_latency_ns > 0
+    assert complete.max_convergence_latency_ns == complete.last_convergence_latency_ns
+    assert complete.stopped is True
+    assert not ({"path", "graph_root", "query", "content"} & asdict(complete).keys())
+
+
+def test_watcher_diagnostics_are_empty_before_start(tmp_path: Path) -> None:
+    watcher = GraphFileWatcher(tmp_path, on_debounced_change=lambda _path, _kind: None)
+
+    snapshot = watcher.diagnostics_snapshot()
+
+    assert snapshot.pending_count == 0
+    assert snapshot.scheduled_count == 0
+    assert snapshot.coalesced_count == 0
+    assert snapshot.dispatched_count == 0
+    assert snapshot.callback_failure_count == 0
+    assert snapshot.oldest_pending_age_ns == 0
+    assert snapshot.last_convergence_latency_ns == 0
+    assert snapshot.max_convergence_latency_ns == 0
+    assert snapshot.stopped is True


### PR DESCRIPTION
## Summary

- add a typed, content-free watcher debounce diagnostics snapshot
- report pending depth, scheduling/coalescing, dispatch/failure, oldest age, and convergence latency
- preserve existing scheduling, callback routing, and backlog policy

## Stack

- base: `feat/checkpoint-recovery-diagnostics-391` (#418)
- tranche: EX-11-04
- merge after #418

## Safety boundaries

- no pending-path cap, overflow/rescan policy, persistence, or daemon/API integration
- no Shadow DB, Gate B, tag, release, or publication change
- no graph paths, queries, or event content in the snapshot

## Validation

- focused watcher tests: 2 passed
- full `make ci`: 1,655 passed, 5 skipped, 83.45% coverage
- Ruff, format, strict mypy over 377 source files, graph sandbox, version/agent coherence, public-metrics policy, docs inventory, and generated prompt checks: passed
- GitNexus staged analysis: LOW risk, zero affected execution flows
- sole warning: pre-existing macOS multi-threaded `fork()` deprecation probe

Refs #391
