### PR TITLE
feat(diagnostics): add Shadow operational snapshot (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Typed Shadow operational snapshot (#391)** — expose content-free generation, validated last-incremental-sync time, quarantine retry/reason pressure, maximum attempts, and oldest age from an existing SQLite connection without changing schema, synchronization, locks, routing, or fallback.
 - **Typed watcher operational snapshot (#391)** — expose path-free pending depth, coalescing, dispatch/failure counters, oldest-event age, and last/maximum convergence latency under the existing debounce lock without changing scheduling, callback routing, or backlog policy.
 - **Checkpoint recovery diagnostics (#391)** — expose a bounded recovery-source vocabulary and explicit reset event in the bootstrap status projection, distinguishing missing, primary, backup, and unreadable checkpoint states without changing recovery, Soft Gate, or read-only behavior.
 - **Typed BM25 operational snapshot (#391)** — expose a versioned, content-free per-corpus snapshot of document/token cardinality, query-cache capacity and row pressure, hit/miss/invalidation/eviction counters, aggregate uncached-scoring timing, and a deterministic retained-payload estimate for machine-readable diagnostics without changing scoring or cache behavior.

--- a/docs/knowledge/architecture/shadow-db.md
+++ b/docs/knowledge/architecture/shadow-db.md
@@ -5,8 +5,8 @@ description: SQLite read cache, external-cache RC direction, synchronization, he
 resource: src/shadow/
 tags: [shadow-db, sqlite, fts5, cte, concurrency]
 generated: { by: human:marco-porcellato, at: '2026-07-18T00:00:00Z' }
-verified: { by: human:marco-porcellato, at: '2026-08-06T00:00:00Z' }
-last_verified: 2026-08-06
+verified: { by: human:marco-porcellato, at: '2026-08-07T00:00:00Z' }
+last_verified: 2026-08-07
 stale_after: 2027-02-02
 status: stable
 classification: canonical
@@ -114,6 +114,22 @@ Cross-process writers serialize through advisory **`shadow.writer.flock`** (`sha
 | Full rebuild | `shadow_rebuild_lock` | `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` (120s) |
 
 `MATRYCA_SHADOW_DB_BUSY_TIMEOUT_MS` sets SQLite `busy_timeout` on connections.
+
+## Operational diagnostics
+
+`shadow_diagnostics_snapshot()` reads an existing Shadow connection and returns a
+schema-versioned, content-free snapshot for benchmark and operator adapters. It reports
+the committed generation, a strictly validated last-incremental-sync timestamp, current
+quarantine cardinality, retries, reason-weighted attempts, maximum attempts, and oldest
+age. Invalid timestamps become `None`; graph-relative paths and row content are never
+projected.
+
+The timeout/error attempt fields reflect each currently quarantined row's latest reason
+weighted by its attempt count. The schema does not retain a reason-transition history,
+so these fields are operational pressure indicators rather than lifetime incident
+counters. The snapshot performs only aggregate `SELECT` operations and works with a
+query-only connection. It does not open a database, alter metadata/schema, instrument
+writer-lock wait or sync duration, or change health, routing, and Markdown fallback.
 
 ## Operator surfaces
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -931,6 +931,67 @@ multi-threaded `fork()` deprecation probe. A sandboxed first run denied the unre
 `ps` subprocess used by one daemon-lock test; the complete gate passed with normal host
 permissions.
 
+**Tranche manifest (frozen 2026-08-07):**
+
+```yaml
+tranche_id: EX-11-05
+repository: MarcoPorcellato/matryca-plumber
+base_commit: 3f1ff3bcc39ebb58af18404e9c150545da06bf47
+objective: expose read-only Shadow generation and quarantine pressure diagnostics
+authority: inspect | edit | commit | push | pr
+tracking_issue: 391
+allowlist:
+  - src/shadow/diagnostics.py
+  - tests/test_shadow_diagnostics.py
+  - docs/knowledge/architecture/shadow-db.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - CHANGELOG.md
+non_goals:
+  - modify generation helpers, schema, sync, writer locks, health, state API, UI, or fallback
+  - expose graph-relative paths, row content, queries, or unvalidated metadata strings
+  - instrument sync duration, lock wait, persistence, Gate B, tags, releases, or publication
+deterministic_preflight:
+  - uv run pytest --no-cov -q tests/test_shadow_diagnostics.py
+  - make ci
+acceptance:
+  - immutable schema-versioned snapshot is machine-readable and content-free
+  - aggregate reads work after PRAGMA query_only is enabled and add zero connection changes
+  - generation and validated incremental-sync time are projected from existing metadata
+  - quarantine count, retries, current reason-weighted attempts, maximum attempts, and age are explicit
+  - invalid or naive timestamps cannot enter the serialized snapshot
+stop_conditions:
+  - any need for schema migration, write-path instrumentation, state API, UI, or routing changes
+rollback: revert the single stacked commit before merge
+provenance:
+  evidence_commit: 3f1ff3bcc39ebb58af18404e9c150545da06bf47
+  new_module_impact: no pre-existing callers or execution flows
+  referenced_generation_helper: HIGH if modified; imported read-only and left unchanged
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: metadata | lifecycle | provenance
+residual_risks:
+  - reason-weighted attempts reflect current row classification, not reason-transition history
+  - oldest age depends on valid timezone-aware persisted timestamps
+  - writer-lock wait, sync duration, and fallback counts remain for later tranches
+```
+
+**EX-11-05 implemented:** `ShadowDiagnosticsSnapshot` projects committed generation,
+strictly validated incremental-sync time, quarantine cardinality and retries, current
+reason-weighted attempt pressure, maximum attempts, and oldest age. Its aggregate SQL
+runs on a caller-owned query-only connection, adds no changes, and serializes no paths,
+queries, row content, or invalid metadata strings. Focused tests cover empty state,
+multi-row retry/reason aggregation, exact age, query-only operation, content exclusion,
+invalid timestamps, and naive-clock rejection. No existing generation helper, schema,
+sync, writer lock, health, state API, UI, fallback, Gate B, tag, or publication behavior
+changed.
+Focused diagnostics tests pass `3/3`. The complete `make ci` gate passes with 1,658
+tests, 5 skips, and 83.46% coverage; format, Ruff, strict mypy over 379 source files,
+graph sandbox, version and agent coherence, public-metrics policy, documentation
+inventory, and generated prompt checks are green. The only warning remains the
+pre-existing macOS multi-threaded `fork()` deprecation probe. A sandboxed first run
+denied the unrelated `ps` subprocess used by one daemon-lock test; the complete gate
+passed unchanged with normal host permissions.
+
 Expose content-free metrics for:
 
 - Shadow sync duration, writer-lock wait, generation, fallback reason, last successful incremental sync, parser timeout count, quarantine age and retry count;

--- a/src/shadow/diagnostics.py
+++ b/src/shadow/diagnostics.py
@@ -1,0 +1,102 @@
+"""Content-free operational diagnostics for an existing Shadow connection."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+
+from .meta import META_LAST_INCREMENTAL_SYNC_AT, current_generation, get_meta
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDiagnosticsSnapshot:
+    """Bounded-cardinality Shadow metadata and quarantine pressure."""
+
+    schema_version: int
+    generation: int
+    last_incremental_sync_at: str | None
+    quarantined_page_count: int
+    quarantine_retry_count: int
+    current_timeout_attempt_count: int
+    current_error_attempt_count: int
+    max_quarantine_attempt_count: int
+    oldest_quarantine_age_seconds: int | None
+
+    def to_dict(self) -> dict[str, int | str | None]:
+        """Return a stable machine-readable payload with no paths or content."""
+        return asdict(self)
+
+
+def _parse_aware_timestamp(raw: str | None) -> datetime | None:
+    text = (raw or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _normalized_timestamp(raw: str | None) -> str | None:
+    parsed = _parse_aware_timestamp(raw)
+    return parsed.isoformat() if parsed is not None else None
+
+
+def _non_negative(value: object) -> int:
+    try:
+        return max(0, int(str(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def shadow_diagnostics_snapshot(
+    connection: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+) -> ShadowDiagnosticsSnapshot:
+    """Aggregate diagnostics without changing the connection or Shadow state."""
+    observed_at = now or datetime.now(UTC)
+    if observed_at.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    observed_at = observed_at.astimezone(UTC)
+
+    row = connection.execute(
+        """
+        SELECT
+            COUNT(*),
+            COALESCE(SUM(MAX(attempt_count - 1, 0)), 0),
+            COALESCE(SUM(CASE WHEN reason = 'parse_timeout' THEN attempt_count ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN reason = 'parse_error' THEN attempt_count ELSE 0 END), 0),
+            COALESCE(MAX(attempt_count), 0),
+            MIN(first_quarantined_at)
+        FROM quarantined_pages
+        """
+    ).fetchone()
+    values = row or (0, 0, 0, 0, 0, None)
+    first_quarantined_at = _parse_aware_timestamp(str(values[5]) if values[5] is not None else None)
+    oldest_age = (
+        max(0, int((observed_at - first_quarantined_at).total_seconds()))
+        if first_quarantined_at is not None
+        else None
+    )
+
+    return ShadowDiagnosticsSnapshot(
+        schema_version=1,
+        generation=current_generation(connection),
+        last_incremental_sync_at=_normalized_timestamp(
+            get_meta(connection, META_LAST_INCREMENTAL_SYNC_AT)
+        ),
+        quarantined_page_count=_non_negative(values[0]),
+        quarantine_retry_count=_non_negative(values[1]),
+        current_timeout_attempt_count=_non_negative(values[2]),
+        current_error_attempt_count=_non_negative(values[3]),
+        max_quarantine_attempt_count=_non_negative(values[4]),
+        oldest_quarantine_age_seconds=oldest_age,
+    )
+
+
+__all__ = ["ShadowDiagnosticsSnapshot", "shadow_diagnostics_snapshot"]

--- a/tests/test_shadow_diagnostics.py
+++ b/tests/test_shadow_diagnostics.py
@@ -1,0 +1,103 @@
+"""Tests for content-free Shadow operational diagnostics."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+
+import pytest
+from src.shadow.diagnostics import shadow_diagnostics_snapshot
+from src.shadow.meta import META_GENERATION, META_LAST_INCREMENTAL_SYNC_AT, set_meta
+from src.shadow.quarantine import record_quarantined_page
+from src.shadow.schema import apply_shadow_schema
+
+
+def _connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    apply_shadow_schema(connection)
+    return connection
+
+
+def test_shadow_diagnostics_empty_snapshot_is_deterministic() -> None:
+    connection = _connection()
+    snapshot = shadow_diagnostics_snapshot(connection, now=datetime(2026, 8, 7, 10, tzinfo=UTC))
+
+    assert snapshot.to_dict() == {
+        "schema_version": 1,
+        "generation": 0,
+        "last_incremental_sync_at": None,
+        "quarantined_page_count": 0,
+        "quarantine_retry_count": 0,
+        "current_timeout_attempt_count": 0,
+        "current_error_attempt_count": 0,
+        "max_quarantine_attempt_count": 0,
+        "oldest_quarantine_age_seconds": None,
+    }
+
+
+def test_shadow_diagnostics_aggregate_quarantine_pressure_without_paths() -> None:
+    connection = _connection()
+    set_meta(connection, META_GENERATION, "7")
+    set_meta(connection, META_LAST_INCREMENTAL_SYNC_AT, "2026-08-07T09:45:00Z")
+    record_quarantined_page(
+        connection,
+        "pages/private.md",
+        reason="parse_timeout",
+        byte_count=100,
+        line_count=5,
+        now="2026-08-07T08:00:00+00:00",
+    )
+    record_quarantined_page(
+        connection,
+        "pages/private.md",
+        reason="parse_timeout",
+        byte_count=100,
+        line_count=5,
+        now="2026-08-07T09:00:00+00:00",
+    )
+    record_quarantined_page(
+        connection,
+        "journals/hidden.md",
+        reason="parse_error",
+        byte_count=200,
+        line_count=10,
+        now="2026-08-07T09:30:00+00:00",
+    )
+
+    before = connection.total_changes
+    connection.execute("PRAGMA query_only = ON")
+    snapshot = shadow_diagnostics_snapshot(connection, now=datetime(2026, 8, 7, 10, tzinfo=UTC))
+    payload = snapshot.to_dict()
+
+    assert snapshot.generation == 7
+    assert snapshot.last_incremental_sync_at == "2026-08-07T09:45:00+00:00"
+    assert snapshot.quarantined_page_count == 2
+    assert snapshot.quarantine_retry_count == 1
+    assert snapshot.current_timeout_attempt_count == 2
+    assert snapshot.current_error_attempt_count == 1
+    assert snapshot.max_quarantine_attempt_count == 2
+    assert snapshot.oldest_quarantine_age_seconds == 7200
+    assert connection.total_changes == before
+    assert not ({"path", "graph_root", "query", "content"} & payload.keys())
+    assert "private" not in repr(payload)
+    assert "hidden" not in repr(payload)
+
+
+def test_shadow_diagnostics_reject_naive_now_and_invalid_timestamps() -> None:
+    connection = _connection()
+    set_meta(connection, META_LAST_INCREMENTAL_SYNC_AT, "not-a-timestamp /private/leak")
+    record_quarantined_page(
+        connection,
+        "pages/private.md",
+        reason="parse_error",
+        byte_count=0,
+        line_count=0,
+        now="not-a-timestamp",
+    )
+
+    snapshot = shadow_diagnostics_snapshot(connection, now=datetime(2026, 8, 7, 10, tzinfo=UTC))
+    assert snapshot.last_incremental_sync_at is None
+    assert snapshot.oldest_quarantine_age_seconds is None
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        shadow_diagnostics_snapshot(connection, now=datetime(2026, 8, 7, 10))


### PR DESCRIPTION
## Summary

- add a typed, content-free Shadow operational diagnostics snapshot
- aggregate committed generation, validated incremental-sync time, quarantine retries/reason pressure, maximum attempts, and oldest age
- keep the snapshot read-only on a caller-owned existing SQLite connection

## Stack

- base: `feat/watcher-diagnostics-snapshot-391` (#419)
- tranche: EX-11-05
- merge after #419

## Safety boundaries

- no generation-helper, schema, synchronization, writer-lock, health, state API, UI, routing, or fallback change
- no graph paths, queries, row content, or unvalidated metadata strings in the payload
- no Gate B, tag, release, or publication change
- reason-weighted attempts reflect current quarantine-row classification, not historical reason transitions

## Validation

- focused Shadow diagnostics tests: 3 passed
- full `make ci`: 1,658 passed, 5 skipped, 83.46% coverage
- Ruff, format, strict mypy over 379 source files, graph sandbox, version/agent coherence, public-metrics policy, documentation inventory, and generated prompt checks: passed
- staged local static analysis: LOW risk, zero affected existing execution flows
- sole warning: pre-existing macOS multi-threaded `fork()` deprecation probe

Refs #391
