### PR TITLE
docs(openspec): retire obsolete Shadow migration guidance (#396)

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 <!-- GENERATED — do not edit -->
 
-<!-- build-hash: 8e03e878d71566b61699b60828640902174aef8813e8bff3f2f7dc98367e9ed4 -->
+<!-- build-hash: 8aba43147560d95c7cbb6c856f75e4fe9beec99215dbc8435cbd5acfb43a86b9 -->
 
 <!-- package-version: v2.0.0rc1 -->
 
@@ -63,7 +63,10 @@ You operate in a **strictly decoupled** Matryca stack. Violating tier boundaries
 
 **Terminology guard:** Repo **L1 memory** (`matryca-l1/*.md`) is session deploy rules — not the Gardener. Always disambiguate "L1 memory" vs "Tier-1 Gardener".
 
-**v2.0 note (maintainers):** When Shadow DB SQLite + FTS5 ships, replace JSON-catalog references in this section with Shadow DB query paths. The compiled `[[Matryca Master Index]]` page remains the human-readable catalog; machine retrieval moves to FTS5.
+**Shadow retrieval boundary:** Shadow DB is a derived read cache and does not replace
+this Master Index Soft Gate. Current activation, health, fallback, and storage guidance
+is owned by the [canonical Shadow operator contract](docs/knowledge/architecture/shadow-db.md).
+The compiled `[[Matryca Master Index]]` page remains the human-readable catalog.
 
 ### Master Index Soft Gate (Human-in-the-Loop)
 

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-07
 
+- **OpenSpec authority:** Retired the pre-ship Shadow migration trigger, corrected generated-prompt ownership, and routed current operator behavior to its canonical contract.
 - **Roadmap authority:** Replaced duplicated current Shadow defaults and live Gate B state with canonical operator and readiness links while preserving milestone history.
 - **Architecture authority:** Removed mutable Shadow defaults, release status, and exact test-count ownership from the system architecture document while preserving its internal design role.
 - **Operator authority:** Established one canonical v2 runtime/operator path and explicit roles for README, architecture, release, roadmap, quality, changelog, and release-note surfaces.

--- a/docs/openspec/README.md
+++ b/docs/openspec/README.md
@@ -15,7 +15,7 @@ Trimmed behavioral specs aligned with [MehmetGoekce/llm-wiki](https://github.com
 | [`agent-ax-robustness.md`](agent-ax-robustness.md) | v1.9.7+ lenient page resolution, safe `write_outline` fallback, `heading_level` coercion, chaos tests. |
 | [`security-sandbox.md`](security-sandbox.md) | v1.9.9 path sandbox reads, bounded JSON checkpoints, CI `sandbox-read-check`; v1.10.0 flock + atomic JSON sidecars ([#35](https://github.com/MarcoPorcellato/matryca-plumber/issues/35)–[#37](https://github.com/MarcoPorcellato/matryca-plumber/issues/37), [#41](https://github.com/MarcoPorcellato/matryca-plumber/issues/41)); v1.10.3 flock sidecar `0o600`. |
 | [`../integrations/hermes-agent.md`](../integrations/hermes-agent.md) | v1.9.6 Hermes Agent MCP: lazy AST handshake, `connect_timeout` vs tool `timeout`, verified config. |
-| [`llm-os-instructions.md`](llm-os-instructions.md) | Two-tier LLM OS, Master Index Soft Gate, `bootstrap_status`, Safe-Sync, v2.0 SQLite migration trigger. |
+| [`llm-os-instructions.md`](llm-os-instructions.md) | Two-tier LLM OS, Master Index Soft Gate, `bootstrap_status`, Safe-Sync, and Shadow post-migration ownership. |
 | [`link-verification.md`](link-verification.md) | v1.9 zero-LLM URL/asset hygiene, `.matryca_link_registry.json`, `dead-link::` / `missing-asset::`; v1.10.0 atomic registry save (#41). |
 | [`agent-dx.md`](agent-dx.md) | v1.9 CLI `--json`, `context load`, `read subtree`, Journey Log (single cumulative bullet per day). |
 | [`dual-embedding.md`](dual-embedding.md) | Phase 3 dual vectors (content + applicability) and `search_graph` / `method=semantic`. |
@@ -27,8 +27,9 @@ Trimmed behavioral specs aligned with [MehmetGoekce/llm-wiki](https://github.com
 | [`runtime-bootstrap.md`](runtime-bootstrap.md) | Startup directory/config provisioning (logs, L1, cache, wiki YAML); master catalog flock/merge persistence (v1.10.0). |
 | [`llm-performance.md`](llm-performance.md) | v1.8 KV-cache layout, RAM caps, cooperative bootstrap I/O; v1.12 Tier-1 builders + L0 safety; journal Phase-2 semantic bypass. |
 | [`../PROMPT_ARCHITECTURE.md`](../PROMPT_ARCHITECTURE.md) | **v1.12** — Clean Architecture map for prompts (plan v3), semver recommendation, mermaid/ASCII flows. |
-| [`../roadmaps/ROADMAP_V2_PREPARATION.md`](../roadmaps/ROADMAP_V2_PREPARATION.md) | **v2 visitor SSOT** — five phases, Safe-Sync, contribute guide |
-| [`../roadmaps/ROADMAP_V2_SHADOW_DB.md`](../roadmaps/ROADMAP_V2_SHADOW_DB.md) | v2.0 `shadow.sqlite` read cache (FTS5, CTEs, `src/shadow/schema.py`) |
+| [`../knowledge/architecture/shadow-db.md`](../knowledge/architecture/shadow-db.md) | Canonical current Shadow runtime and operator contract. |
+| [`../roadmaps/ROADMAP_V2_PREPARATION.md`](../roadmaps/ROADMAP_V2_PREPARATION.md) | v2 sequencing, contribution guidance, and milestone history. |
+| [`../roadmaps/ROADMAP_V2_SHADOW_DB.md`](../roadmaps/ROADMAP_V2_SHADOW_DB.md) | Shadow read-path sequencing and completed implementation history. |
 | [`../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) | Nacre-inspired decay/recall/procedure memory |
 | [`biological-memory.md`](biological-memory.md) | Planned env vars, `search_graph(method=recall)`, Safe-Sync contract |
 | [`../v1.8-SOFTWARE-EDGE-PLAN.md`](../v1.8-SOFTWARE-EDGE-PLAN.md) | CPU sandbox, frozen KV prefix, adaptive LLM, mmap reads. |

--- a/docs/openspec/agent-onboarding.md
+++ b/docs/openspec/agent-onboarding.md
@@ -97,7 +97,9 @@ When adding or renaming CLI subcommands:
 3. Cross-check [`agent-dx.md`](agent-dx.md), [`agent-ax-robustness.md`](agent-ax-robustness.md), [`security-sandbox.md`](security-sandbox.md) (when touching graph reads or JSON sidecars), [`SYSTEM_PROMPT.md`](../../SYSTEM_PROMPT.md), and [`llm-os-instructions.md`](llm-os-instructions.md) if MCP discriminators or agent contracts change.
 4. Ship a **patch release** so `uvx` consumers pick up accurate instructions on PyPI.
 
-When Shadow DB SQLite + FTS5 ships (v2.0), follow the migration trigger in [`llm-os-instructions.md`](llm-os-instructions.md).
+For Shadow-related agent-contract changes, follow the post-migration ownership rules in
+[`llm-os-instructions.md`](llm-os-instructions.md). Current operator behavior belongs to
+the [canonical Shadow operator contract](../knowledge/architecture/shadow-db.md).
 
 ---
 

--- a/docs/openspec/agent/soft-gate.md
+++ b/docs/openspec/agent/soft-gate.md
@@ -11,7 +11,10 @@ You operate in a **strictly decoupled** Matryca stack. Violating tier boundaries
 
 **Terminology guard:** Repo **L1 memory** (`matryca-l1/*.md`) is session deploy rules — not the Gardener. Always disambiguate "L1 memory" vs "Tier-1 Gardener".
 
-**v2.0 note (maintainers):** When Shadow DB SQLite + FTS5 ships, replace JSON-catalog references in this section with Shadow DB query paths. The compiled `[[Matryca Master Index]]` page remains the human-readable catalog; machine retrieval moves to FTS5.
+**Shadow retrieval boundary:** Shadow DB is a derived read cache and does not replace
+this Master Index Soft Gate. Current activation, health, fallback, and storage guidance
+is owned by the [canonical Shadow operator contract](docs/knowledge/architecture/shadow-db.md).
+The compiled `[[Matryca Master Index]]` page remains the human-readable catalog.
 
 ### Master Index Soft Gate (Human-in-the-Loop)
 

--- a/docs/openspec/llm-os-instructions.md
+++ b/docs/openspec/llm-os-instructions.md
@@ -62,18 +62,28 @@ uvx matryca-plumber --json read bootstrap_status
 
 When changing agent contracts:
 
-1. Update **`SYSTEM_PROMPT.md`** (full law) and **`llms.txt`** + **`.well-known/llms.txt`** (byte-identical pointer) in the same PR.
-2. Sync MCP docstrings in [`src/agent/mcp_server.py`](../../src/agent/mcp_server.py) (`read_graph_data`, `search_graph`).
-3. Cross-check [`agent-onboarding.md`](agent-onboarding.md) and [`agent-dx.md`](agent-dx.md) if CLI discriminators change.
-4. Run `tests/test_bootstrap_status.py` and `tests/test_mcp_server.py`.
+1. Edit the source fragments under [`agent/`](agent/) and regenerate
+   **`SYSTEM_PROMPT.md`** with `make build-system-prompt`; never edit the generated
+   output directly.
+2. Update **`llms.txt`** + **`.well-known/llms.txt`** together only when the external
+   agent contract changes; the two files must remain byte-identical.
+3. Sync MCP docstrings in [`src/agent/mcp_server.py`](../../src/agent/mcp_server.py)
+   only when the MCP tool contract changes.
+4. Cross-check [`agent-onboarding.md`](agent-onboarding.md) and
+   [`agent-dx.md`](agent-dx.md) if CLI discriminators change.
+5. Run `make check-system-prompt`, `make agents-check`, and the focused contract tests.
 
-### v2.0 SQLite Shadow DB migration trigger
+### Shadow DB post-migration ownership
 
-When Shadow DB SQLite + FTS5 + recursive CTEs ship:
+Shadow DB SQLite, FTS5, and recursive CTE reads have shipped as a derived read cache.
+They do not replace the Tier-1 Gardener or the human-readable Master Index.
 
-1. Update `SYSTEM_PROMPT.md` § "LLM OS" — replace JSON catalog / BM25 wording with Shadow DB + FTS5 paths.
-2. Update Tier-1 Gardener embedded prompts (`semantic_lint_prompts.py`, harvest map-reduce).
-3. Document CONTRIBUTING carve-out: Matryca Shadow DB is a daemon cache — not Logseq native storage.
+1. Keep current activation, storage, health, and fallback guidance in the
+   [canonical Shadow operator contract](../knowledge/architecture/shadow-db.md).
+2. Change the assembled Tier-2 law only through [`agent/`](agent/) fragments and the
+   prompt builder.
+3. Change Tier-1 Gardener prompts only when Gardener behavior changes, not when Shadow
+   operator defaults or release status changes.
 4. Keep `[[Matryca Master Index]]` as the human-readable hub page.
 
 ---

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -1250,6 +1250,78 @@ and navigation only, with no runtime, setting, command, or public product-contra
 change. Rollback remains one documentation-only revert; Gate B evidence, release state,
 tags, and publication were not touched.
 
+##### EX-16-04 — Retire the shipped-Shadow migration trigger
+
+```yaml
+tranche_id: EX-16-04
+repository: MarcoPorcellato/matryca-plumber
+base_commit: f525b0655aaad66f621c5cf27d7f2e72125b4de6
+objective: remove obsolete pre-ship Shadow instructions while preserving one generated-prompt ownership path
+authority: inspect | edit | commit | push | pr
+allowlist:
+  - docs/openspec/agent/soft-gate.md
+  - docs/openspec/llm-os-instructions.md
+  - docs/openspec/agent-onboarding.md
+  - docs/openspec/README.md
+  - SYSTEM_PROMPT.md
+  - docs/knowledge/log.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+non_goals:
+  - no runtime, configuration, Python, MCP tool-contract, llms, release, Gate B, tag, or publication change
+  - no direct edit of generated SYSTEM_PROMPT.md
+  - no historical evidence rewrite or Matryca Knowledge projection update
+deterministic_preflight:
+  - make build-system-prompt
+  - make check-system-prompt
+  - make agents-check
+  - make docs-check
+acceptance:
+  - no active OpenSpec instruction waits for Shadow DB to ship
+  - Tier-2 law changes route through source fragments and the prompt builder
+  - current Shadow operator behavior links to the canonical maintained contract
+  - Master Index and Tier-1 Gardener responsibilities remain unchanged
+  - generated prompt hash and documentation inventory remain coherent
+stop_conditions:
+  - any required runtime, MCP docstring, llms, release-status, or Gate B evidence edit
+  - any change to Master Index or Gardener runtime behavior
+rollback: revert the documentation and generated-prompt commit
+provenance:
+  evidence_commit: f525b0655aaad66f621c5cf27d7f2e72125b4de6
+  evidence_paths:
+    - docs/openspec/agent/soft-gate.md
+    - docs/openspec/llm-os-instructions.md
+    - docs/PROMPT_ARCHITECTURE.md
+    - docs/knowledge/architecture/shadow-db.md
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: navigation | lifecycle | provenance
+residual_risks:
+  - llms and agent-onboarding release-status wording requires a separate issue 396 slice
+  - planned biological-memory version language requires a separate future-design review
+```
+
+This slice changes prompt ownership and documentation routing, not agent behavior,
+runtime behavior, release qualification, or the external distribution contract.
+
+**EX-16-04 implementation receipt (2026-08-07):** an independent read-only review
+and primary source audit classified the remaining OpenSpec and generated-surface
+occurrences before editing. The seven-file allowlist above is the complete diff.
+Obsolete pre-ship instructions now describe post-migration ownership, Tier-2 law
+changes route through source fragments and the prompt builder, and current Shadow
+operator behavior links to the canonical maintained contract. The Master Index soft
+gate, Tier-1 Gardener behavior, `llms.txt` distribution contract, and release evidence
+remain unchanged.
+
+Validation passed with generated-prompt rebuild and hash verification, agent coherence,
+`make docs-check`, 29 focused prompt/documentation tests, and full `make ci`: formatting,
+Ruff, strict mypy over 379 source files, safety/version/public-metrics checks, and 1,658
+tests with 5 skipped at 83.49% exact-worktree coverage. Parent and subprocess imports
+were explicitly bound to this worktree before the final gate. The changelog gate selected
+**no entry** because this corrects documentation ownership and stale maintainer guidance
+without changing runtime, configuration, commands, or agent behavior. Rollback remains
+one documentation/generated-prompt revert; Gate B evidence, release state, tags, and
+publication were not touched.
+
 #### EX-17 — Make dual-layer documentation checks mandatory
 
 `docs-check` currently passes but is not part of `make ci`. Add it to the


### PR DESCRIPTION
## Summary

- retire the obsolete pre-ship Shadow migration trigger from active OpenSpec guidance
- route Tier-2 law changes through source fragments and the generated-prompt builder
- preserve the Master Index soft gate and Tier-1 Gardener responsibilities
- route current Shadow operator behavior to the canonical maintained contract
- record the EX-16-04 manifest, verification receipt, rollback, and residual scope

## Stack

- Base branch: `docs/v2-roadmap-authority-396`
- Base commit: `f525b0655aaad66f621c5cf27d7f2e72125b4de6`
- Head commit: `05ff6de51ba23eea6a74fa66220be3104b828fb2`

## Safety boundaries

- no runtime, configuration, Python, MCP tool-contract, `llms.txt`, release, Gate B, tag, or publication change
- `SYSTEM_PROMPT.md` was regenerated from its source fragment, not edited directly
- no historical evidence rewrite or Matryca Knowledge projection update

## Validation

- generated-prompt rebuild and hash verification passed
- agent coherence and documentation inventory checks passed
- focused prompt/documentation tests: 29 passed
- full repository gate: 1,658 passed, 5 skipped, 83.49% exact-worktree coverage
- graph-based local static analysis: LOW risk, 7 changed files, 0 affected execution flows
- changelog decision: no entry

Refs #396
