### PR TITLE
docs(v2): align biological memory with v2.1 delivery (#396)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,7 +145,7 @@ Promotion therefore remains deliberately sequential:
 
 **Tag:** [`v2.0.0-alpha`](https://github.com/MarcoPorcellato/matryca-plumber/releases/tag/v2.0.0-alpha) · PyPI `matryca-plumber==2.0.0a0` · **superseded by v2.0.0-alpha.1** for new installs.
 
-**Next v2 slice:** Phase 4 biological memory + Logseq DB Safe-Sync ([#178](https://github.com/MarcoPorcellato/matryca-plumber/issues/178), [#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)).
+**Next post-v2.0 slice:** Phase 4 biological memory + Logseq DB Safe-Sync ([#178](https://github.com/MarcoPorcellato/matryca-plumber/issues/178), [#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)).
 
 ---
 
@@ -269,7 +269,7 @@ Promotion therefore remains deliberately sequential:
 | Initiative | Issue | Goal | Status |
 |------------|-------|------|--------|
 | Shadow DB read path | [#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24) | `shadow.sqlite`, FTS5, CTEs, background sync from Markdown | **shipped** (`v2.0.0-alpha`) |
-| Biological memory layer | Epic [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20) | Nacre-inspired decay/recall in `shadow.sqlite` — [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) | Phase 4 |
+| Biological memory layer | [#178](https://github.com/MarcoPorcellato/matryca-plumber/issues/178) (historical epic [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)) | Nacre-inspired decay/recall in `shadow.sqlite` — [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) | v2.1+ Phase 4 |
 | GraphRepository abstraction | [#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17) | Coexistent Markdown / SQLite backends | read port **done** |
 | Hardware Profiler & LLM Recommender | [#23](https://github.com/MarcoPorcellato/matryca-plumber/issues/23) | Sovereign UI guidance for 16 GB CPU-only laptops | planned |
 | **v2.0.0-alpha.5** | Epic [#20](https://github.com/MarcoPorcellato/matryca-plumber/issues/20) | Experimental `shadow.sqlite` behind opt-in env flag | **published** |
@@ -282,17 +282,17 @@ Deeper maintainer checklists (completed or in flight):
 - [`docs/roadmaps/ROADMAP_LLM_WIKI.md`](docs/roadmaps/ROADMAP_LLM_WIKI.md) — LLM-Wiki baseline (done)
 - [`docs/roadmaps/ROADMAP_IRONCLAD_SHIELD.md`](docs/roadmaps/ROADMAP_IRONCLAD_SHIELD.md) — resilience and safety hardening
 - [`docs/roadmaps/ROADMAP_V2_SHADOW_DB.md`](docs/roadmaps/ROADMAP_V2_SHADOW_DB.md) — v2.0 Shadow DB read path ([#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24))
-- [`docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) — v2.0 biological memory layer (Nacre-inspired, depends on Shadow DB)
+- [`docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) — v2.1+ biological memory layer (Nacre-inspired, depends on Shadow DB)
 
 ---
 
-## Long-term (v2.0 stable)
+## Long-term (v2.0 stable and post-v2.0)
 
 | Track | Target |
 |-------|--------|
 | **v2.0.0-rc** | MCP read traffic routed to Shadow DB by default |
 | **v2.0.0-stable** | Deprecate pure in-memory BM25 as default discovery path |
-| **Safe-Sync** | Logseq DB write path via official CLI only ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)) |
+| **Safe-Sync (v2.1+)** | Logseq DB write path via official CLI only ([#25](https://github.com/MarcoPorcellato/matryca-plumber/issues/25)) |
 
 Safe-Sync contract (read/write decoupling):
 

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-07
 
+- **Biological-memory scope authority:** Aligned OpenSpec, roadmaps, and issue templates on v2.1+ delivery while preserving v2.0 as the Shadow DB read-path release.
 - **Distribution authority:** Preserved the versioned RC agent contract while routing mutable qualification and stable-promotion status to the readiness record.
 - **OpenSpec authority:** Retired the pre-ship Shadow migration trigger, corrected generated-prompt ownership, and routed current operator behavior to its canonical contract.
 - **Roadmap authority:** Replaced duplicated current Shadow defaults and live Gate B state with canonical operator and readiness links while preserving milestone history.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -1,7 +1,11 @@
-# Biological memory layer — OpenSpec (planned v2.0)
+# Biological memory layer — OpenSpec (planned v2.1+)
 
-**Status:** planned — algorithms partially scaffolded in [`src/memory/`](../../src/memory/); persistence in [`src/shadow/schema.py`](../../src/shadow/schema.py) memory tables  
-**Parent epic:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
+**Status:** planned for v2.1+ — algorithms partially scaffolded in [`src/memory/`](../../src/memory/); schema-only tables exist in [`src/shadow/schema.py`](../../src/shadow/schema.py), but no memory read/write path is shipped
+
+**Historical architecture context:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
+
+**Active delivery tracker:** [#178 — Biological memory + Logseq DB Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/178)
+
 **Maintainer roadmap:** [`docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md)  
 **Preparation index:** [`docs/roadmaps/ROADMAP_V2_PREPARATION.md`](../roadmaps/ROADMAP_V2_PREPARATION.md) § Phase 4
 
@@ -9,26 +13,31 @@ Nacre-inspired decay, recall, and consolidation **inside** Matryca's Logseq-nati
 
 ---
 
-## Environment variables (planned)
+## Future feature gate
 
-| Variable | Default (planned) | Role |
-|----------|-------------------|------|
-| `MATRYCA_MEMORY_GRAPH_ENABLED` | `false` | Opt-in alpha — memory graph read/write in `shadow.sqlite` |
-| `MATRYCA_SHADOW_DB_ENABLED` | `false` | **Shipped in v2.0.0-alpha** — prerequisite for memory graph persistence; enables Shadow DB read cache (FTS5/CTE) when healthy |
+| Variable | Contract status | Role |
+|----------|-----------------|------|
+| `MATRYCA_MEMORY_GRAPH_ENABLED` | Not yet a public configuration contract | Future feature gate for memory graph reads and writes in `shadow.sqlite`; its default and rollout policy require a separately qualified v2.1+ design slice |
 
-When implemented, document in [`.env.example`](../../.env.example) under **Advanced / high impact** per [`07-env-example.mdc`](../../.cursor/rules/07-env-example.mdc).
+When implemented, document the complete contract in [`.env.example`](../../.env.example)
+under **Advanced / high impact** per
+[`07-env-example.mdc`](../../.cursor/rules/07-env-example.mdc). Current Shadow DB
+behavior and defaults remain owned by the
+[v2 operator contract](../knowledge/architecture/shadow-db.md).
 
 ---
 
 ## MCP / CLI surface (planned)
 
-| Today (v1.12) | v2 target |
-|---------------|-----------|
-| `search_graph(method=bm25\|semantic\|…)` | `bm25` prefers shadow FTS5 when `MATRYCA_SHADOW_DB_ENABLED=true` and health is `ready` (**shipped v2.0.0-alpha**); add `method=recall` in Phase 4 |
+| Existing surface | Planned memory extension |
+|------------------|--------------------------|
+| `search_graph(method=bm25\|semantic\|…)` | Add `method=recall` in the v2.1+ Phase 4 work |
 | `store_fact` | Episodic / procedural memory nodes (extends identity plane) |
 | — | `nacre_forget` / feedback analogues — TBD in Phase 4 issues |
 
-Contract changes ship with semver **v2.0.0-alpha.1** minimum; update [`llms.txt`](../../llms.txt) in the same PR.
+The target version and rollout policy belong to the separately qualified v2.1+
+implementation slice. Update [`llms.txt`](../../llms.txt) in the same PR only if
+that slice changes the external agent contract.
 
 ---
 
@@ -44,9 +53,9 @@ Contract changes ship with semver **v2.0.0-alpha.1** minimum; update [`llms.txt`
 
 See [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md):
 
-1. **Fase A** — decay + schema tables (`memory_nodes`, `memory_edges`, …)
-2. **Fase B** — `search_graph(method=recall)` + consolidation idle batch
-3. **Fase C** — MCP memory-native tools
+1. **Phase A** — decay + schema tables (`memory_nodes`, `memory_edges`, …)
+2. **Phase B** — `search_graph(method=recall)` + consolidation idle batch
+3. **Phase C** — MCP memory-native tools
 
 **Shipped scaffold:** `src/memory/decay.py` (decay formulas + tests).
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -1389,6 +1389,49 @@ removes mutable status narration without changing any distributed command, setti
 agent behavior, runtime behavior, or product contract. Rollback remains one documentation-
 only revert; Gate B evidence, release state, tags, and publication were not touched.
 
+##### EX-16-06 — Restore biological-memory delivery scope
+
+```yaml
+tranche_id: EX-16-06
+objective: Align active biological-memory documentation on v2.1+ without changing v2.0 runtime or release qualification.
+allowed_files:
+  - docs/openspec/biological-memory.md
+  - docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+  - docs/quality/issue-bodies/v2-phase4-memory-safesync.md
+  - docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+  - ROADMAP.md
+  - docs/knowledge/log.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+documentation_impact: update
+official_okf_conformance_impact: none
+matryca_quality_impact: navigation | provenance
+residual_risks:
+  - ROADMAP.md is a high-fan-out navigation surface and requires focused inbound-link validation
+  - feature defaults and rollout policy remain intentionally undecided until a qualified v2.1+ implementation slice
+```
+
+This slice makes issue #178 the active delivery tracker while retaining issue #20 as
+historical architecture context. It labels the memory tables as schema-only, removes
+obsolete alpha-era version and default promises, and keeps the current Shadow DB
+operator contract under its canonical owner. It does not rename documents, alter
+runtime/configuration/prompt surfaces, edit Gate B evidence, or mutate GitHub issues.
+
+**EX-16-06 implementation receipt (2026-08-07):** the seven-file allowlist above is
+the complete diff. An independent read-only audit and primary review agreed that
+biological memory is a v2.1+ initiative, issue #178 is its active delivery tracker,
+and issue #20 remains historical architecture context. The review additionally
+corrected the high-fan-out `ROADMAP.md` navigation label and separated Safe-Sync from
+the v2.0 stable heading without changing historical release facts.
+
+Whitespace validation, stale-language scanning, agent coherence, and the documentation
+knowledge gate passed. Full exact-worktree `make ci` passed formatting, Ruff, strict
+mypy over 379 source files, sandbox/version/public-metrics checks, documentation and
+generated-prompt verification, and 1,658 tests with 5 skipped at 83.47% coverage. The
+changelog gate selected **no entry** because the slice corrects planning authority and
+future scope without changing shipped behavior, configuration, architecture, or public
+runtime contracts. Gate B evidence, release state, tags, publication, and GitHub issue
+state were not touched.
+
 #### EX-17 — Make dual-layer documentation checks mandatory
 
 `docs-check` currently passes but is not part of `make ci`. Add it to the

--- a/docs/quality/issue-bodies/v2-phase4-memory-safesync.md
+++ b/docs/quality/issue-bodies/v2-phase4-memory-safesync.md
@@ -16,11 +16,11 @@ OpenSpec: [`docs/openspec/biological-memory.md`](../../openspec/biological-memor
 
 Child slice: `v2-phase4-recall-search-method.md`.
 
-**Depends on:** Phase 3 alpha stable on maintainer test vaults.
+**Depends on:** a stabilized and qualified v2.0 Shadow DB read-path baseline.
 
 ## Estimated Impact
 
-**Alto** — v2.0.0-stable differentiators; not required for first alpha.
+**High** — planned v2.1+ deliverables; explicitly excluded from v2.0 stable.
 
 ## Files Involved
 

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -1,7 +1,11 @@
-# v2.0 — Biological Memory Layer (Nacre-inspired)
+# v2.1+ — Biological Memory Layer (Nacre-inspired)
 
-**Parent epic:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  
-**Status:** planned — schema in [`src/shadow/schema.py`](../../src/shadow/schema.py); decay in [`src/memory/decay.py`](../../src/memory/decay.py)  
+**Historical architecture context:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
+
+**Active delivery tracker:** [#178 — Biological memory + Logseq DB Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/178)
+
+**Status:** planned for v2.1+ — schema-only tables exist in [`src/shadow/schema.py`](../../src/shadow/schema.py); decay algorithms are scaffolded in [`src/memory/decay.py`](../../src/memory/decay.py), but no memory read/write path is shipped
+
 **Preparation index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) · OpenSpec: [`biological-memory.md`](../openspec/biological-memory.md)  
 **Prerequisite:** [`ROADMAP_V2_SHADOW_DB.md`](ROADMAP_V2_SHADOW_DB.md) ([#24](https://github.com/MarcoPorcellato/matryca-plumber/issues/24), [#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17))  
 **Inspiration:** [Nacre](https://github.com/marcusschimizzi/nacre) by Marcus Sullivan (Apache-2.0) — native Python port, not a Node sidecar  
@@ -94,7 +98,8 @@ DDL in [`src/shadow/schema.py`](../../src/shadow/schema.py). Package [`src/memor
 - **Co-occurrence:** within the same block subtree (outliner-aware)
 - **Custom:** entity-map YAML in `.matryca/`
 
-Environment variable: `MATRYCA_MEMORY_GRAPH_ENABLED=false` (opt-in alpha).
+Future feature gate: `MATRYCA_MEMORY_GRAPH_ENABLED`. Its public default and
+rollout policy remain design decisions for a separately qualified v2.1+ slice.
 
 ### Phase B — Hybrid recall
 
@@ -160,14 +165,14 @@ Detailed checklist: “Apache-2.0 compliance” section in the original plan (ma
 | `maintenance_daemon.py` ~3,200 lines | Move Phase 3 into a dedicated module ([#57](https://github.com/MarcoPorcellato/matryca-plumber/issues/57)) |
 | Nacre parser ≠ Logseq | Use only `logseq-matryca-parser` |
 | Embedding dimension mismatch | Store metadata in `shadow_meta`; apply the same fix documented in the Nacre roadmap |
-| Scope creep | Keep the flag opt-in; ship decay + recall before visualization/hive |
+| Scope creep | Keep the feature gated pending v2.1+ design and qualification; ship decay + recall before visualization/hive |
 
 ---
 
 ## Next steps
 
 1. ~~Save the roadmap in the repository~~ (this file)
-2. Link the **Biological Memory Layer** issue to #20/#24.
+2. Keep delivery issue #178 linked to historical context #20 and Shadow DB prerequisite #24.
 3. Use RFC Discussion #19 to map block UUIDs to memory nodes.
 4. Implement `src/memory/decay.py` + Nacre parity tests.
 5. Prototype consolidation on 100 pages with `MATRYCA_MEMORY_GRAPH_ENABLED=true`.

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -34,7 +34,7 @@ Canonical DDL: [`src/shadow/schema.py`](../../src/shadow/schema.py)
 |-------|--------|---------|
 | **Meta** | `shadow_meta` | Schema version, last full sync, embedding provider metadata |
 | **Read cache** | `pages`, `blocks`, `block_refs`, `blocks_fts` | Logseq OG mirror for FTS5 + recursive CTE subtree reads |
-| **Memory graph** | `memory_nodes`, `memory_edges`, `memory_pending_edges`, `memory_episodes`, `memory_episode_entities`, `memory_procedures`, `memory_snapshots` | Nacre-inspired biological memory — see [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](ROADMAP_V2_BIOLOGICAL_MEMORY.md) |
+| **Memory graph** | `memory_nodes`, `memory_edges`, `memory_pending_edges`, `memory_episodes`, `memory_episode_entities`, `memory_procedures`, `memory_snapshots` | Schema only — planned Phase 4; no memory read/write path is shipped. See [`ROADMAP_V2_BIOLOGICAL_MEMORY.md`](ROADMAP_V2_BIOLOGICAL_MEMORY.md) |
 
 Historical published beta path: `<LOGSEQ_GRAPH_PATH>/.matryca_semantic_cache/shadow.sqlite`
 (`shadow_db_path` / `open_shadow_db`). Current RC storage, invalidation, health, and


### PR DESCRIPTION
## Summary

- align biological-memory OpenSpec and roadmap material on v2.1+ delivery
- make issue #178 the active delivery tracker while retaining issue #20 as historical architecture context
- mark memory tables as schema-only and remove obsolete alpha-era default and version promises
- keep v2.0 stable scoped to the qualified Shadow DB read path

## Verification

- `make agents-check`
- `make docs-check`
- `make ci` — 1,658 passed, 5 skipped, 83.47% coverage
- `git diff --check`
- focused stale-language and public-attribution scans

## Stack

- base: `docs/v2-distribution-status-authority-396`
- this is EX-16-06 in the repository-excellence programme
- merge after the preceding documentation-authority slices

## Boundaries

- documentation only; no runtime, configuration, prompt, MCP, or environment contract changes
- no Gate B evidence, release state, tag, publication, or GitHub issue mutation

Closes #396
