### PR TITLE
ci(docs): separate OKF and Matryca reporting (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Dual-layer documentation validation (#402)** — report deterministic OKF v0.2 format compatibility separately from the stricter Matryca quality profile, preserve unknown concept types and extension fields, and keep both layers blocking under independently versioned specification, profile, validator, and finding-schema contracts.
 - **Typed Shadow operational snapshot (#391)** — expose content-free generation, validated last-incremental-sync time, quarantine retry/reason pressure, maximum attempts, and oldest age from an existing SQLite connection without changing schema, synchronization, locks, routing, or fallback.
 - **Typed watcher operational snapshot (#391)** — expose path-free pending depth, coalescing, dispatch/failure counters, oldest-event age, and last/maximum convergence latency under the existing debounce lock without changing scheduling, callback routing, or backlog policy.
 - **Checkpoint recovery diagnostics (#391)** — expose a bounded recovery-source vocabulary and explicit reset event in the bootstrap status projection, distinguishing missing, primary, backup, and unreadable checkpoint states without changing recovery, Soft Gate, or read-only behavior.

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-07
 
+- **Dual-layer validation:** Separated OKF v0.2 format compatibility from Matryca quality reporting while retaining one deterministic blocking documentation gate.
 - **Biological-memory scope authority:** Aligned OpenSpec, roadmaps, and issue templates on v2.1+ delivery while preserving v2.0 as the Shadow DB read-path release.
 - **Distribution authority:** Preserved the versioned RC agent contract while routing mutable qualification and stable-promotion status to the readiness record.
 - **OpenSpec authority:** Retired the pre-ship Shadow migration trigger, corrected generated-prompt ownership, and routed current operator behavior to its canonical contract.

--- a/docs/knowledge/profile.md
+++ b/docs/knowledge/profile.md
@@ -72,6 +72,21 @@ Maintained concepts require:
 | `audience` | Any of `maintainer`, `contributor`, `operator`, or `agent` when present |
 | `owner` | Maintainer area responsible for the concept |
 
+## Validator reporting contract
+
+`make docs-check` reports two independent top-level results: **OKF v0.2 format
+compatibility** and **Matryca quality profile v1.0**. Passing the format gate is
+not an official certification and does not imply that the stricter repository
+profile passes. Unknown concept types and extension fields remain consumable;
+the Matryca layer owns repository-specific links, anchors, freshness, canonical
+roles, safe local paths, inventory drift, and generated-view integrity.
+
+The specification, profile, validator, and finding-schema versions advance
+independently. Text findings are sorted before emission so identical source bytes
+and policy versions produce stable output. Machine-readable findings and
+changed-policy invalidation remain separately reviewable follow-up work under
+[#402](https://github.com/MarcoPorcellato/matryca-plumber/issues/402).
+
 `last_verified` is intentionally dual-written during the transition to native OKF v0.2 trust parsing in Matryca Knowledge. It may be removed only after the registry validates `verified[].at` directly for freshness.
 
 ## Classification and lifecycle are different

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -96,11 +96,12 @@ The accepted model contains two independent result streams:
    classification, link, anchor, provenance, privacy, and canonical-role rules.
 
 This document does **not** claim official OKF v0.2 conformance. The current
-Matryca validator implements a transitional OKF-inspired flat-frontmatter
-profile; the planned nested v0.2 parser and dual-layer conformance reporter are
-not treated as shipped. `status` therefore uses the official lifecycle
-vocabulary (`draft`, `stable`, `deprecated`), while plan acceptance and Matryca
-classification remain separate extension fields.
+Matryca validator reports deterministic OKF v0.2 format compatibility separately
+from Matryca quality, while official certification, machine-readable findings,
+changed-policy invalidation, and any future nested parser remain unshipped.
+`status` therefore uses the official lifecycle vocabulary (`draft`, `stable`,
+`deprecated`), while plan acceptance and Matryca classification remain separate
+extension fields.
 
 Adoption rules for this programme:
 
@@ -1434,10 +1435,17 @@ state were not touched.
 
 #### EX-17 — Make dual-layer documentation checks mandatory
 
-`docs-check` currently passes but is not part of `make ci`. Add it to the
-mandatory gate. Add a repository-aware internal-link checker that understands
-relative paths, directory indexes, anchors, generated files, and an explicit
-external-link policy.
+The deterministic baseline is complete under closed issue
+[#400](https://github.com/MarcoPorcellato/matryca-plumber/issues/400): `docs-check`
+is mandatory in both `make check` and `make ci`, GitHub Actions exposes an early
+labelled documentation step, and regression coverage prevents accidental removal.
+The checker already validates maintained local links, anchors, lifecycle metadata,
+reserved files, safe legacy paths, inventory drift, and generated-view parity.
+
+The remaining architecture is tracked by
+[#402](https://github.com/MarcoPorcellato/matryca-plumber/issues/402): report the
+portable OKF v0.2 format contract independently from the stricter Matryca quality
+profile without weakening the single blocking gate.
 
 Evolve validation in separately reviewable slices:
 
@@ -1455,6 +1463,52 @@ path/anchor and lifecycle fixtures fail the Matryca quality layer; official
 format fixtures fail only the official layer; generated inventory drift fails
 CI; identical source bytes and policy versions produce byte-identical results;
 no LLM output participates in acceptance.
+
+##### EX-17A — Separate deterministic validation layers
+
+```yaml
+tranche_id: EX-17A
+issue: 402
+objective: Separate OKF format compatibility from Matryca quality findings without weakening blocking documentation checks.
+allowed_files:
+  - scripts/docs_knowledge_check.py
+  - tests/test_docs_knowledge_check.py
+  - docs/knowledge/profile.md
+  - docs/knowledge/log.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+  - CHANGELOG.md
+documentation_impact: update
+official_okf_conformance_impact: compatibility-reporting-only
+matryca_quality_impact: validation | provenance
+residual_risks:
+  - PASS means deterministic format compatibility, not official certification
+  - machine-readable findings and invalidation remain follow-up slices under issue 402
+```
+
+This slice preserves the existing `validate_concept_frontmatter` entry point as a
+combined compatibility facade, keeps both layers blocking, sorts findings before
+emission, tolerates unknown non-empty concept types and extension fields, and versions
+the specification, profile, validator, and finding schema independently. It does not
+change the Makefile, workflow topology, repository metadata, runtime, Gate B, or release
+state.
+
+**EX-17A implementation receipt (2026-08-08):** the six-file allowlist above is the
+complete diff. The mandatory gate now emits separate OKF format-compatibility and
+Matryca-quality results while retaining one final blocking exit. Unknown non-empty
+types and extension fields remain consumable; inventory and generated-view drift are
+reported as Matryca findings instead of bypassing the layer summary. A challenger
+review initially rejected the slice because of one stale planning claim, early
+inventory exits, and missing negative fixtures; all findings were corrected, and the
+second review returned **GO**.
+
+Thirty-five focused documentation-validator tests passed, including official-only,
+Matryca-only, simultaneous-layer, deterministic-order, inventory-drift, and compatibility-
+facade cases. Full exact-worktree `make ci` passed formatting, Ruff, strict mypy over
+379 source files, safety/version/public-metrics checks, documentation and generated-
+prompt verification, and 1,666 tests with 5 skipped at 83.48% coverage. The changelog
+records the developer-facing validation contract. Runtime, Makefile/workflow topology,
+Gate B evidence, release state, tags, publication, and GitHub issue state were not
+touched.
 
 #### EX-18 — Expand CI where it buys independent evidence
 
@@ -1580,8 +1634,8 @@ Low runtime risk, no release-line disturbance:
 
 1. Keep monitoring Gate B without crediting downtime.
 2. Reconcile documentation lifecycle language and establish the EX-16 authority matrix.
-3. Execute EX-17 incrementally: first add the existing `docs-check` to CI,
-   then introduce separately reported official OKF v0.2 and Matryca quality
+3. Continue EX-17 incrementally: retain the completed mandatory `docs-check`
+   baseline, then finish separately reported OKF v0.2 and Matryca quality
    gates without a mass migration.
 4. Triage milestones and map existing issues to this dossier.
 5. Establish benchmark result schemas and capture a baseline without changing implementation.

--- a/scripts/docs_knowledge_check.py
+++ b/scripts/docs_knowledge_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""OKF-inspired knowledge bundle checks, inventory sync, and legacy audit."""
+"""Dual-layer knowledge checks, inventory sync, and legacy audit."""
 
 from __future__ import annotations
 
@@ -8,8 +8,10 @@ import json
 import re
 import sys
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import redirect_stderr
 from dataclasses import dataclass
 from datetime import date, datetime
+from io import StringIO
 from pathlib import Path
 from typing import Any, NoReturn, cast
 from urllib.parse import unquote, urlsplit
@@ -41,7 +43,11 @@ DOC_TYPES: frozenset[str] = frozenset(
 )
 
 INVENTORY_SCHEMA_VERSION = 2
-OKF_VERSION = "0.2"
+OKF_SPEC_VERSION = "0.2"
+MATRYCA_PROFILE_VERSION = "1.0"
+DOCS_VALIDATOR_VERSION = "1"
+FINDING_SCHEMA_VERSION = "1"
+OKF_VERSION = OKF_SPEC_VERSION
 OKF_STATUSES: frozenset[str] = frozenset({"draft", "stable", "deprecated"})
 CLASSIFICATIONS: frozenset[str] = frozenset({"canonical", "active", "historical", "generated"})
 
@@ -103,6 +109,16 @@ class HeuristicDefaults:
     action: str
     surface_class: str
     destination: str | None = None
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    official_okf: tuple[str, ...]
+    matryca_quality: tuple[str, ...]
+
+    @property
+    def has_findings(self) -> bool:
+        return bool(self.official_okf or self.matryca_quality)
 
 
 def _fail(message: str) -> NoReturn:
@@ -763,14 +779,35 @@ def validate_legacy_sources(
     return errors
 
 
-def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[str]:
+def validate_official_okf_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[str]:
     errors: list[str] = []
     rel = path.relative_to(KNOWLEDGE_DIR).as_posix()
-    label = f"{rel}"
+    label = rel
 
     doc_type = meta.get("type")
-    if not isinstance(doc_type, str) or doc_type not in DOC_TYPES:
-        errors.append(f"{label}: type must be one of profile types")
+    if not isinstance(doc_type, str) or not doc_type.strip():
+        errors.append(f"{label}: type must be a non-empty string")
+
+    status = meta.get("status")
+    if status is not None and (not isinstance(status, str) or status not in OKF_STATUSES):
+        errors.append(f"{label}: invalid OKF status")
+
+    if "generated" in meta:
+        errors.extend(
+            _validate_actor_event(meta.get("generated"), f"{label}.generated", allow_many=False)
+        )
+    if "verified" in meta:
+        errors.extend(
+            _validate_actor_event(meta.get("verified"), f"{label}.verified", allow_many=True)
+        )
+    if "stale_after" in meta:
+        errors.extend(_validate_iso_date(meta.get("stale_after"), f"{label}.stale_after"))
+    return errors
+
+
+def validate_matryca_quality_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    label = path.relative_to(KNOWLEDGE_DIR).as_posix()
 
     for field in (
         "title",
@@ -783,10 +820,6 @@ def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[st
     ):
         if field not in meta:
             errors.append(f"{label}: missing required field {field}")
-
-    status = meta.get("status")
-    if status is not None and (not isinstance(status, str) or status not in OKF_STATUSES):
-        errors.append(f"{label}: invalid OKF status")
 
     classification = meta.get("classification")
     if classification is not None and (
@@ -806,16 +839,7 @@ def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[st
     ):
         errors.append(f"{label}: invalid audience")
 
-    if "generated" in meta:
-        errors.extend(
-            _validate_actor_event(meta.get("generated"), f"{label}.generated", allow_many=False)
-        )
-    if "verified" in meta:
-        errors.extend(
-            _validate_actor_event(meta.get("verified"), f"{label}.verified", allow_many=True)
-        )
     errors.extend(_validate_iso_date(meta.get("last_verified"), f"{label}.last_verified"))
-    errors.extend(_validate_iso_date(meta.get("stale_after"), f"{label}.stale_after"))
     last_verified = meta.get("last_verified")
     stale_after = meta.get("stale_after")
     last_verified_date = _parse_iso_date(last_verified)
@@ -842,6 +866,13 @@ def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[st
     return errors
 
 
+def validate_concept_frontmatter(path: Path, meta: Mapping[str, Any]) -> list[str]:
+    """Return the combined findings for compatibility with existing callers."""
+    return validate_official_okf_frontmatter(path, meta) + validate_matryca_quality_frontmatter(
+        path, meta
+    )
+
+
 def collect_knowledge_concepts() -> list[Path]:
     concepts: list[Path] = []
     for path in sorted(KNOWLEDGE_DIR.rglob("*.md")):
@@ -851,14 +882,50 @@ def collect_knowledge_concepts() -> list[Path]:
     return concepts
 
 
+def _validation_report(
+    official_okf: list[str],
+    matryca_quality: list[str],
+) -> ValidationReport:
+    return ValidationReport(
+        official_okf=tuple(sorted(official_okf)),
+        matryca_quality=tuple(sorted(matryca_quality)),
+    )
+
+
+def _print_validation_report(report: ValidationReport) -> None:
+    print(
+        f"OKF v{OKF_SPEC_VERSION} format compatibility: "
+        f"{'FAIL' if report.official_okf else 'PASS'} "
+        f"({len(report.official_okf)} findings)"
+    )
+    print(
+        f"Matryca quality profile v{MATRYCA_PROFILE_VERSION}: "
+        f"{'FAIL' if report.matryca_quality else 'PASS'} "
+        f"({len(report.matryca_quality)} findings)"
+    )
+    print(f"Validator v{DOCS_VALIDATOR_VERSION}; finding schema v{FINDING_SCHEMA_VERSION}")
+
+
+def _collect_check_failures(check: Callable[[], None]) -> list[str]:
+    stderr = StringIO()
+    try:
+        with redirect_stderr(stderr):
+            check()
+    except SystemExit:
+        findings = [line for line in stderr.getvalue().splitlines() if line]
+        return findings or ["validation command failed without a diagnostic"]
+    return []
+
+
 def check_bundle() -> None:
-    errors: list[str] = []
+    official_okf: list[str] = []
+    matryca_quality: list[str] = []
 
     if not PROFILE_MD.is_file():
-        errors.append("missing docs/knowledge/profile.md")
+        matryca_quality.append("missing docs/knowledge/profile.md")
 
     data = load_inventory()
-    errors.extend(validate_inventory_schema(data))
+    matryca_quality.extend(validate_inventory_schema(data))
 
     entries = data.get("entries", [])
     canonical_for_values = {
@@ -873,58 +940,64 @@ def check_bundle() -> None:
         rel = concept_path.relative_to(KNOWLEDGE_DIR).as_posix()
         meta, body = split_frontmatter(concept_path)
         if meta is None:
-            errors.append(f"{rel}: concept documents require YAML frontmatter")
+            official_okf.append(f"{rel}: concept documents require YAML frontmatter")
             continue
-        errors.extend(validate_concept_frontmatter(concept_path, meta))
-        errors.extend(validate_legacy_sources(meta, concept_path, rel))
+        official_okf.extend(validate_official_okf_frontmatter(concept_path, meta))
+        matryca_quality.extend(validate_matryca_quality_frontmatter(concept_path, meta))
+        matryca_quality.extend(validate_legacy_sources(meta, concept_path, rel))
 
         canonical_for = meta.get("canonical_for")
         if canonical_for is not None:
             if not isinstance(canonical_for, str):
-                errors.append(f"{rel}: canonical_for must be a string")
+                matryca_quality.append(f"{rel}: canonical_for must be a string")
             elif canonical_for in canonical_for_values:
-                errors.append(
+                matryca_quality.append(
                     f"duplicate canonical_for {canonical_for!r} in "
                     f"{canonical_for_values[canonical_for]} and {rel}"
                 )
             else:
                 canonical_for_values[canonical_for] = rel
 
-        errors.extend(validate_document_links(concept_path, body, rel))
+        matryca_quality.extend(validate_document_links(concept_path, body, rel))
 
     for index_path in sorted(KNOWLEDGE_DIR.rglob("index.md")):
         rel = index_path.relative_to(KNOWLEDGE_DIR).as_posix()
         meta, body = split_frontmatter(index_path)
         if index_path == KNOWLEDGE_DIR / "index.md":
             if meta != {"okf_version": OKF_VERSION}:
-                errors.append(
+                official_okf.append(
                     f"{rel}: root index frontmatter must contain only okf_version: {OKF_VERSION!r}"
                 )
         elif meta is not None:
-            errors.append(f"{rel}: nested OKF indexes must not have frontmatter")
-        errors.extend(validate_document_links(index_path, body, rel))
+            official_okf.append(f"{rel}: nested OKF indexes must not have frontmatter")
+        matryca_quality.extend(validate_document_links(index_path, body, rel))
 
     log_path = KNOWLEDGE_DIR / "log.md"
     if not log_path.is_file():
-        errors.append("missing docs/knowledge/log.md")
+        official_okf.append("missing docs/knowledge/log.md")
     else:
         meta, body = split_frontmatter(log_path)
         if meta is not None:
-            errors.append("log.md: OKF log files must not have frontmatter")
+            official_okf.append("log.md: OKF log files must not have frontmatter")
         date_headings = re.findall(r"^## (\d{4}-\d{2}-\d{2})$", body, re.MULTILINE)
         if not date_headings:
-            errors.append("log.md: expected at least one ISO date heading")
+            matryca_quality.append("log.md: expected at least one ISO date heading")
         elif date_headings != sorted(date_headings, reverse=True):
-            errors.append("log.md: date headings must be newest first")
-        errors.extend(validate_document_links(log_path, body, "log.md"))
+            matryca_quality.append("log.md: date headings must be newest first")
+        matryca_quality.extend(validate_document_links(log_path, body, "log.md"))
 
-    inventory_sync(check=True)
-    inventory_md(check=True)
+    matryca_quality.extend(_collect_check_failures(lambda: inventory_sync(check=True)))
+    matryca_quality.extend(_collect_check_failures(lambda: inventory_md(check=True)))
 
-    if errors:
-        for error in errors:
-            print(error, file=sys.stderr)
-        _fail(f"docs knowledge check failed ({len(errors)} issue(s))")
+    report = _validation_report(official_okf, matryca_quality)
+    _print_validation_report(report)
+    if report.has_findings:
+        for error in report.official_okf:
+            print(f"[official-okf] {error}", file=sys.stderr)
+        for error in report.matryca_quality:
+            print(f"[matryca-quality] {error}", file=sys.stderr)
+        total = len(report.official_okf) + len(report.matryca_quality)
+        _fail(f"docs knowledge check failed ({total} issue(s))")
     print("docs knowledge check OK")
 
 

--- a/tests/test_docs_knowledge_check.py
+++ b/tests/test_docs_knowledge_check.py
@@ -11,7 +11,11 @@ from typing import Any
 
 import pytest
 from scripts.docs_knowledge_check import (
+    DOCS_VALIDATOR_VERSION,
+    FINDING_SCHEMA_VERSION,
     KNOWLEDGE_DIR,
+    MATRYCA_PROFILE_VERSION,
+    OKF_SPEC_VERSION,
     build_default_entry,
     discover_inventory_paths,
     inventory_sync,
@@ -24,6 +28,8 @@ from scripts.docs_knowledge_check import (
     validate_document_links,
     validate_inventory_schema,
     validate_legacy_sources,
+    validate_matryca_quality_frontmatter,
+    validate_official_okf_frontmatter,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -381,6 +387,136 @@ def test_validate_concept_frontmatter_rejects_legacy_status() -> None:
     errors = validate_concept_frontmatter(path, changed)
 
     assert any("invalid OKF status" in error for error in errors)
+
+
+def test_official_okf_accepts_unknown_types_and_extensions() -> None:
+    path = KNOWLEDGE_DIR / "architecture" / "system-overview.md"
+    meta, _ = split_frontmatter(path)
+    assert meta is not None
+    changed = dict(meta)
+    changed["type"] = "Domain-Specific Future Type"
+    changed["future_extension"] = {"preserved": True}
+    snapshot = dict(changed)
+
+    assert validate_official_okf_frontmatter(path, changed) == []
+    assert validate_matryca_quality_frontmatter(path, changed) == []
+    assert changed == snapshot
+
+
+def test_official_okf_default_status_is_separate_from_matryca_profile() -> None:
+    path = KNOWLEDGE_DIR / "architecture" / "system-overview.md"
+    meta, _ = split_frontmatter(path)
+    assert meta is not None
+    changed = dict(meta)
+    changed.pop("status")
+
+    assert validate_official_okf_frontmatter(path, changed) == []
+    assert any(
+        "missing required field status" in error
+        for error in validate_matryca_quality_frontmatter(path, changed)
+    )
+
+
+def test_profile_and_validator_versions_are_independent() -> None:
+    meta, _ = split_frontmatter(KNOWLEDGE_DIR / "profile.md")
+    assert meta is not None
+    assert meta["okf_spec_version"] == OKF_SPEC_VERSION
+    assert meta["profile_version"] == MATRYCA_PROFILE_VERSION
+    assert DOCS_VALIDATOR_VERSION == "1"
+    assert FINDING_SCHEMA_VERSION == "1"
+
+
+def test_check_bundle_reports_separate_top_level_results(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import scripts.docs_knowledge_check as module
+
+    module.check_bundle()
+    output = capsys.readouterr().out
+
+    assert "OKF v0.2 format compatibility: PASS (0 findings)" in output
+    assert "Matryca quality profile v1.0: PASS (0 findings)" in output
+    assert "Validator v1; finding schema v1" in output
+
+
+def test_combined_frontmatter_validator_preserves_layer_order() -> None:
+    path = KNOWLEDGE_DIR / "architecture" / "system-overview.md"
+    meta, _ = split_frontmatter(path)
+    assert meta is not None
+    changed = dict(meta)
+    changed["type"] = ""
+    changed.pop("title")
+
+    assert validate_concept_frontmatter(path, changed) == (
+        validate_official_okf_frontmatter(path, changed)
+        + validate_matryca_quality_frontmatter(path, changed)
+    )
+
+
+def test_validation_report_sorts_findings_within_each_layer() -> None:
+    import scripts.docs_knowledge_check as module
+
+    report = module._validation_report(["z", "a"], ["y", "b"])
+
+    assert report.official_okf == ("a", "z")
+    assert report.matryca_quality == ("b", "y")
+
+
+def test_inventory_drift_is_reported_as_matryca_quality_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import scripts.docs_knowledge_check as module
+
+    def fail_inventory_sync(*, check: bool = False) -> None:
+        assert check is True
+        module._fail("inventory drift fixture")
+
+    monkeypatch.setattr(module, "inventory_sync", fail_inventory_sync)
+
+    with pytest.raises(SystemExit):
+        module.check_bundle()
+
+    captured = capsys.readouterr()
+    assert "OKF v0.2 format compatibility: PASS (0 findings)" in captured.out
+    assert "Matryca quality profile v1.0: FAIL (1 findings)" in captured.out
+    assert "[matryca-quality] inventory drift fixture" in captured.err
+
+
+def test_both_layers_report_before_check_bundle_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import scripts.docs_knowledge_check as module
+
+    concept = KNOWLEDGE_DIR / "architecture" / "system-overview.md"
+    original_split = module.split_frontmatter
+
+    def one_concept() -> list[Path]:
+        return [concept]
+
+    def split_with_layer_failures(path: Path) -> tuple[dict[str, Any] | None, str]:
+        meta, body = original_split(path)
+        if path != concept or meta is None:
+            return meta, body
+        changed = dict(meta)
+        changed["type"] = ""
+        changed.pop("title")
+        return changed, body
+
+    monkeypatch.setattr(module, "collect_knowledge_concepts", one_concept)
+    monkeypatch.setattr(module, "split_frontmatter", split_with_layer_failures)
+
+    with pytest.raises(SystemExit):
+        module.check_bundle()
+
+    captured = capsys.readouterr()
+    assert "OKF v0.2 format compatibility: FAIL (1 findings)" in captured.out
+    assert "Matryca quality profile v1.0: FAIL (1 findings)" in captured.out
+    assert "[official-okf] architecture/system-overview.md: type" in captured.err
+    assert "[matryca-quality] architecture/system-overview.md: missing required field title" in (
+        captured.err
+    )
 
 
 def test_validate_concept_frontmatter_rejects_empty_verification() -> None:


### PR DESCRIPTION
## Summary

- report OKF v0.2 format compatibility separately from Matryca quality
- preserve unknown non-empty concept types and extension fields
- keep the existing combined validator entry point and one blocking CI outcome
- capture inventory and generated-view drift as Matryca findings before the final exit
- version the specification, profile, validator, and text finding schema independently

## Verification

- 35 focused documentation-validator tests
- challenger review: GO after all initial findings were corrected
- `make agents-check`
- `make docs-check`
- `make ci` — 1,666 passed, 5 skipped, 83.48% coverage
- `git diff --check`

## Stack

- base: `docs/v2-biological-scope-authority-396`
- follows EX-16-06 in the repository-excellence programme

## Boundaries

- no official OKF certification claim
- no Makefile or GitHub Actions topology change
- no runtime, Gate B, release, tag, publication, or GitHub issue mutation
- machine-readable findings, fingerprints, and changed-policy invalidation remain follow-up work under #402

Refs #402
