### PR TITLE
ci: add Python 3.13 observation evidence (#401)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,31 @@ jobs:
       - name: Run CI gate (format check, Ruff, Mypy, Pytest)
         run: make ci
 
+  python-313-evidence:
+    name: Python 3.13 evidence (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv and Python 3.13
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          python-version: "3.13"
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Sync locked Python dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Run full Python 3.13 test evidence
+        run: uv run pytest -n auto -q -o addopts=
+
   shadow-cross-platform:
     name: Shadow contract (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ uv run pytest tests/test_ui_server.py tests/test_maintenance_daemon.py tests/tes
 
 ### Frontend (Sovereign UI)
 
-Same build as in **Daemon-first dev loop**; CI runs `npm ci` + `npm run build` before `make check`.
+Same build as in **Daemon-first dev loop**; CI runs `npm ci`, lint, tests, and the production build before `make ci`.
 
 ```bash
 cd frontend
@@ -254,9 +254,9 @@ That means, in order:
 1. **Ruff** — lint clean (`make ci` also runs `format-check` without mutating the tree)
 2. **Mypy** — strict type-check on `src/` and `tests/` (**zero `# type: ignore` in `src/`** — see [Strict typing](#strict-typing-zero-mypy-suppressions-in-src))
 3. **Sandbox read gate** — `make sandbox-read-check` (no new `Path.read_text()` bypasses in graph/agent/rag; daemon pid/lock reads need `# sandbox-read-ok`)
-4. **Pytest** — full suite via `make test-full` / `make test` (**720+** targets on `main`; slow tests excluded unless you run `make perf`). Use **`make test-fast`** during iteration (`NUM_WORKERS` default `4`, no coverage).
+4. **Pytest** — full suite via `make test-full` / `make test`; opt-in slow probes remain under `make perf`. Use **`make test-fast`** during iteration (`NUM_WORKERS` default `4`, no coverage).
 
-GitHub Actions on pushes and pull requests to **`main`** runs **`make ci`** (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)): `uv sync`, frontend `npm ci` + `npm run build`, then `make ci`. **Any failing test blocks merge.**
+GitHub Actions on pushes and pull requests to **`main`** runs the blocking Python 3.12 **`make ci`** gate (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)), including frontend lint, tests, and build. A separate non-blocking Python 3.13 job runs the full Python test suite without duplicating coverage or static-analysis work. It remains observational until its compatibility findings are fixed and the documented duration and flake promotion budget is satisfied. **Any failing blocking check prevents merge.**
 
 Never commit secrets (no `.env`, tokens, or private graph paths in git).
 

--- a/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+++ b/docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
@@ -1577,15 +1577,79 @@ evidence, release state, tags, publication, and GitHub issue state were not touc
 
 #### EX-18 — Expand CI where it buys independent evidence
 
+Current baseline: frontend lint, tests, and production build already block the Linux
+Python 3.12 gate and release verification. Focused macOS and Windows Shadow contracts
+already run on every pull request. The remaining work must add independent evidence,
+not duplicate those completed checks.
+
 Recommended order:
 
-1. run frontend tests in CI, not only build/lint;
-2. add Python 3.13 alongside 3.12 for the declared support contract;
-3. keep focused macOS/Windows Shadow contract lanes on every PR;
+1. observe the full Python suite under 3.13 without duplicating static, coverage, or frontend work;
+2. remediate compatibility findings through separately qualified runtime slices;
+3. promote the 3.13 lane only after a measured duration and flake budget;
 4. run fuller cross-platform suites on a scheduled cadence before making all OSes mandatory for every PR;
 5. add scheduled performance and mutation/property-test jobs for bounded allowlisted modules.
 
 This is more cost-effective than immediately tripling every PR's full CI workload.
+
+##### EX-18A — Add bounded Python 3.13 observation evidence
+
+```yaml
+tranche_id: EX-18A
+issue: 401
+objective: Observe the complete Python 3.13 test contract without weakening or duplicating the blocking Python 3.12 gate.
+base: ci/docs-machine-report-402
+allowed_files:
+  - .github/workflows/ci.yml
+  - tests/test_ci_workflow_contract.py
+  - CONTRIBUTING.md
+  - docs/quality/REPOSITORY_EXCELLENCE_STUDY_2026-08-06.md
+non_goals:
+  - no runtime, dependency, lockfile, Makefile, frontend, or release-workflow change
+  - no Gate B evidence, package, tag, publication, artifact, or branch-protection change
+  - no action-reference hardening; immutable action pinning requires a separate security review
+acceptance:
+  - locked dependencies install under Python 3.13 without changing uv.lock
+  - the complete Python suite runs without duplicate coverage, static analysis, docs, or frontend work
+  - the observation job cannot block the established Python 3.12 release gate
+  - the job has a 15-minute hard timeout and uploads no repository artifact
+  - promotion requires ten consecutive green runs, zero test or infrastructure flakes, and observed p95 duration no greater than four minutes
+rollback: revert the four-file CI-evidence commit
+documentation_impact: update
+release_qualification_impact: none
+residual_risks:
+  - Python 3.13 changes non-strict pathlib symlink-loop behavior and currently exposes one fail-closed policy incompatibility
+  - observational success is not release qualification and cannot replace Gate B evidence
+```
+
+Local preflight on CPython 3.13.2 installed the locked dependency graph and ran the
+complete suite without coverage in 101.38 seconds: 1,681 tests passed, 5 skipped, and
+`test_runtime_write_policy_fails_closed_on_unresolvable_cache_path` failed. Python 3.13
+changed `Path.resolve(strict=False)` so a symlink loop no longer raises; the current
+policy therefore does not detect that adversarial path through its legacy exception
+branch. This is a real supported-version safety finding, not a reason to hide the test
+behind a passing selector allowlist.
+
+The workflow lane is intentionally non-blocking until the runtime defect is fixed in a
+separate safety slice and its read-only qualification impact is explicitly decided.
+Changing `RuntimeWritePolicy` here would alter a high-fan-out Gate B surface. Workflow
+logs remain available subject to the repository's platform retention policy, but the
+lane uploads no artifacts. After remediation, ten
+consecutive green observations with no test or infrastructure flakes and p95 duration
+at or below four minutes are required before a separately reviewed branch-protection
+change may make it mandatory. The changelog gate selects **no entry** because this slice
+changes repository CI evidence only, not the distributed package or operator behavior.
+
+Implementation receipt (2026-08-08): focused workflow-contract tests passed on Python
+3.12 and 3.13 (2 each), with Ruff formatting and lint, Mypy, the documentation knowledge
+gate, and whitespace validation all clean. The unchanged blocking Python 3.12 `make ci`
+gate passed with 1,684 tests, 5 skips, and 83.47% coverage. The complete Python 3.13
+observation finished in 108.12 seconds with 1,683 passes, 5 skips, and exactly the one
+known `RuntimeWritePolicy` symlink-loop failure documented above. An independent
+challenger review found no blocking issue after the contract test was strengthened to
+protect the mandatory 3.12 gate and prevent duplicated frontend, documentation, or
+static-analysis work in the 3.13 lane. No runtime source, dependency lock, release
+workflow, Gate B evidence, package artifact, tag, publication, or changelog entry changed.
 
 #### EX-19 — Reconcile the issue and milestone control plane
 

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -1,0 +1,64 @@
+"""Regression tests for the staged GitHub Actions evidence contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_ci_workflow() -> dict[str, Any]:
+    loaded = yaml.load(CI_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(loaded, dict)
+    return cast(dict[str, Any], loaded)
+
+
+def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    step = next(item for item in steps if isinstance(item, dict) and item.get("name") == name)
+    return cast(dict[str, Any], step)
+
+
+def test_frontend_tests_remain_in_the_blocking_gate() -> None:
+    workflow = _load_ci_workflow()
+    gate = workflow["jobs"]["ironclad-gatekeeper"]
+    assert "continue-on-error" not in gate
+
+    frontend = _step_by_name(gate, "Build React cockpit")
+
+    assert frontend["working-directory"] == "frontend"
+    commands = str(frontend["run"]).splitlines()
+    assert commands == ["npm ci", "npm run lint", "npm run test", "npm run build"]
+
+    ci_gate = _step_by_name(gate, "Run CI gate (format check, Ruff, Mypy, Pytest)")
+    assert ci_gate["run"] == "make ci"
+
+
+def test_python_313_evidence_lane_is_bounded_and_non_blocking() -> None:
+    workflow = _load_ci_workflow()
+    job = workflow["jobs"]["python-313-evidence"]
+
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["continue-on-error"] == "true"
+    assert job["timeout-minutes"] == "15"
+
+    setup = _step_by_name(job, "Install uv and Python 3.13")
+    assert setup["with"]["python-version"] == "3.13"
+
+    sync = _step_by_name(job, "Sync locked Python dependencies")
+    assert sync["run"] == "uv sync --locked --extra dev"
+
+    test = _step_by_name(job, "Run full Python 3.13 test evidence")
+    assert test["run"] == "uv run pytest -n auto -q -o addopts="
+    assert all("upload-artifact" not in str(step.get("uses", "")) for step in job["steps"])
+
+    rendered_steps = "\n".join(
+        f"{step.get('name', '')}\n{step.get('run', '')}" for step in job["steps"]
+    ).lower()
+    for duplicated_work in ("node", "npm", "frontend", "docs", "ruff", "mypy", "make ci"):
+        assert duplicated_work not in rendered_steps


### PR DESCRIPTION
## Summary

- add a bounded, non-blocking Python 3.13 evidence job using the locked dependency graph
- run the complete Python suite without duplicating coverage, static analysis, documentation checks, or frontend work
- preserve the mandatory Python 3.12 `make ci` gate with workflow-contract regression tests
- document the observation and promotion budget under repository-excellence issue #401

## Stack

- base: `ci/docs-machine-report-402`
- head: `ci/python313-evidence-401`
- this pull request should be retargeted to `main` after its base branch merges

## Known Python 3.13 finding

The observational suite exposes one supported-version compatibility defect:
`test_runtime_write_policy_fails_closed_on_unresolvable_cache_path` does not raise on
Python 3.13 because non-strict `Path.resolve()` no longer raises for symlink loops.

The job is deliberately non-blocking while that safety-sensitive, high-fan-out runtime
change is handled and qualified separately. This slice does not weaken the blocking
Python 3.12 gate or modify `RuntimeWritePolicy`.

## Verification

- Python 3.12 full `make ci`: 1,684 passed, 5 skipped, 83.47% coverage
- Python 3.13 full observation: 1,683 passed, 5 skipped, exactly the known failure above
- Python 3.12 workflow-contract tests: 2 passed
- Python 3.13 workflow-contract tests: 2 passed
- Ruff format and lint: passed
- Mypy: passed
- documentation knowledge check: passed
- staged code-audit scope: low risk, four files, no affected runtime process
- independent challenger review: no blocking findings

## Release boundary

- no runtime source, dependency lock, frontend, Makefile, or release-workflow change
- no Gate B evidence, package artifact, tag, publication, or branch-protection change
- no changelog entry: this is CI evidence only and does not change distributed or operator behavior

Refs #401
