### PR TITLE
refactor(graph): simplify property list parsing (#235)

### DIFF
--- a/src/graph/mldoc_properties.py
+++ b/src/graph/mldoc_properties.py
@@ -84,6 +84,22 @@ def is_logseq_block_property_line(stripped_line: str) -> bool:
     return parse_logseq_property_line(stripped_line) is not None
 
 
+def _append_property_list_piece(values: list[str], current: list[str]) -> None:
+    piece = "".join(current).strip()
+    if piece:
+        values.append(piece)
+    current.clear()
+
+
+def _consume_quoted_property_char(value: str, index: int, current: list[str]) -> tuple[int, bool]:
+    ch = value[index]
+    if ch == "\\" and index + 1 < len(value):
+        current.extend((ch, value[index + 1]))
+        return index + 2, True
+    current.append(ch)
+    return index + 1, ch != '"'
+
+
 def split_logseq_property_list_values(raw_value: str) -> list[str]:
     """Split comma-separated property values without breaking quotes or ``[[...]]``.
 
@@ -101,15 +117,7 @@ def split_logseq_property_list_values(raw_value: str) -> list[str]:
     while i < len(v):
         ch = v[i]
         if in_dq:
-            if ch == "\\" and i + 1 < len(v):
-                cur.append(ch)
-                cur.append(v[i + 1])
-                i += 2
-                continue
-            if ch == '"':
-                in_dq = False
-            cur.append(ch)
-            i += 1
+            i, in_dq = _consume_quoted_property_char(v, i, cur)
             continue
         if ch == '"':
             in_dq = True
@@ -127,17 +135,12 @@ def split_logseq_property_list_values(raw_value: str) -> list[str]:
             i += 2
             continue
         if ch == "," and link_depth == 0:
-            piece = "".join(cur).strip()
-            if piece:
-                out.append(piece)
-            cur = []
+            _append_property_list_piece(out, cur)
             i += 1
             continue
         cur.append(ch)
         i += 1
-    tail = "".join(cur).strip()
-    if tail:
-        out.append(tail)
+    _append_property_list_piece(out, cur)
     return out
 
 

--- a/tests/test_mldoc_phase7.py
+++ b/tests/test_mldoc_phase7.py
@@ -29,6 +29,35 @@ def test_parse_property_quoted_commas() -> None:
     assert split_logseq_property_list_values(p.value_raw) == ['"Foo, Inc"', "[[Bar]]"]
 
 
+def test_parse_property_nested_wikilinks() -> None:
+    p = parse_logseq_property_line('alias:: [[Outer, [[Inner, A]], B]], "flat"')
+    assert p is not None
+    assert split_logseq_property_list_values(p.value_raw) == [
+        "[[Outer, [[Inner, A]], B]]",
+        '"flat"',
+    ]
+
+
+def test_parse_property_escaped_commas_and_quotes() -> None:
+    p = parse_logseq_property_line('alias:: "a\\,b", "c\\"d"')
+    assert p is not None
+    assert split_logseq_property_list_values(p.value_raw) == ['"a\\,b"', '"c\\"d"']
+
+
+def test_parse_property_unterminated_quote_is_preserved() -> None:
+    raw = '"unterminated, A, B'
+    assert split_logseq_property_list_values(raw) == [raw]
+
+
+def test_parse_property_trailing_backslash_in_quote_is_preserved() -> None:
+    raw = '"A' + "\\"
+    assert split_logseq_property_list_values(raw) == [raw]
+
+
+def test_parse_property_empty_segments_are_omitted() -> None:
+    assert split_logseq_property_list_values('a,, , "b",[[c]],,') == ["a", '"b"', "[[c]]"]
+
+
 def test_bullet_with_double_colon_is_not_property() -> None:
     assert is_logseq_block_property_line("  - Question here :: Answer") is False
 


### PR DESCRIPTION
## Summary

- extract quoted-character consumption and piece finalization from the Logseq property-list parser;
- preserve the public signature and existing quote, escape, nested-wikilink, trimming, and empty-segment semantics;
- add focused parity coverage for malformed and nested inputs.

## Test plan

- [x] `uv run pytest tests/test_mldoc_phase7.py --no-cov -q` — 15 passed
- [x] `uv run pytest tests/test_alias_index.py tests/test_page_properties.py tests/test_property_line_edit.py --no-cov -q` — 34 passed
- [x] `uv run ruff check --select C901,PLR0912,PLR0915 src/graph/mldoc_properties.py`
- [x] changed-file Ruff lint and format checks
- [x] differential parity against the previous implementation — 119,608 deterministic inputs
- [x] `make ci`
- [x] staged change-scope audit — expected medium parser impact; one affected execution flow

## Scope

Two Python files only. No public API, dependency, configuration, documentation,
runtime-write policy, Gate B evidence, release artifact, or publication change.

Fixes #235
