### PR TITLE
refactor(graph): simplify bootstrap harvest (#230)

### DIFF
--- a/src/graph/bootstrap_harvest.py
+++ b/src/graph/bootstrap_harvest.py
@@ -184,6 +184,24 @@ def _catalog_entry_from_harvest(
     )
 
 
+def _read_catalog_source(graph_root: Path, page_path: Path) -> tuple[str, CatalogEntry | None]:
+    from .markdown_io import graph_read_mmap_enabled
+
+    if graph_read_mmap_enabled():
+        with mmap_graph_page(page_path, graph_root) as view:
+            extracted = extract_catalog_fields_from_mmap(view)
+            content = view.decode_utf8(errors="replace")
+    else:
+        content = read_graph_page_text(page_path, graph_root, errors="replace")
+        extracted = extract_catalog_fields_from_content(content)
+    return content, extracted
+
+
+def _raise_if_harvest_stopped(stop_event: threading.Event | None) -> None:
+    if stop_event is not None and stop_event.is_set():
+        raise BootstrapHarvestStopped
+
+
 def harvest_page_into_catalog(
     graph_root: Path,
     catalog: MasterCatalog,
@@ -210,26 +228,15 @@ def harvest_page_into_catalog(
 
     incoming = incoming_counts or {}
     orphan = incoming.get(title, 0) == 0
-    extracted: CatalogEntry | None = None
-    content = ""
     try:
-        from .markdown_io import graph_read_mmap_enabled
-
-        if graph_read_mmap_enabled():
-            with mmap_graph_page(page_path, graph_root) as view:
-                extracted = extract_catalog_fields_from_mmap(view)
-                content = view.decode_utf8(errors="replace")
-        else:
-            content = read_graph_page_text(page_path, graph_root, errors="replace")
-            extracted = extract_catalog_fields_from_content(content)
+        content, extracted = _read_catalog_source(graph_root, page_path)
     except OSError as exc:
         return f"error:{exc}", False, False
 
     if not content.strip():
         return "skipped_empty", False, False
 
-    if extracted is None:
-        extracted = extract_catalog_fields_from_content(content)
+    extracted = extracted if extracted is not None else extract_catalog_fields_from_content(content)
     if extracted is not None:
         extracted.last_mtime = mtime
         extracted.orphan = orphan
@@ -239,8 +246,7 @@ def harvest_page_into_catalog(
     if llm is None:
         return "pending_llm", False, False
 
-    if stop_event is not None and stop_event.is_set():
-        raise BootstrapHarvestStopped
+    _raise_if_harvest_stopped(stop_event)
 
     lint_config = config or load_harvest_runtime_config()
     domain = _infer_domain_from_content(title, content)

--- a/tests/test_bootstrap_yield.py
+++ b/tests/test_bootstrap_yield.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ import pytest
 from src.agent.plumber_llm import BootstrapSummaryResult
 from src.graph.alias_index import page_title_from_path
 from src.graph.bootstrap_harvest import harvest_page_into_catalog, run_bootstrap_harvest
+from src.graph.bootstrap_stop import BootstrapHarvestStopped
 from src.graph.master_catalog import (
     SEMANTIC_INDEX_HEADER,
     clear_master_catalog_cache,
@@ -109,6 +111,30 @@ def test_harvest_upserts_catalog_when_semantic_index_append_succeeds(graph_root:
     assert llm_called is True
 
 
+def test_harvest_stops_before_llm_and_catalog_mutation(graph_root: Path) -> None:
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Needs Index.md"
+    original = "- type:: risorsa\n- Body content\n"
+    page.write_text(original, encoding="utf-8")
+    title = page_title_from_path(graph_root, page)
+    catalog = load_master_catalog(graph_root)
+    stop_event = threading.Event()
+    stop_event.set()
+
+    with pytest.raises(BootstrapHarvestStopped):
+        harvest_page_into_catalog(
+            graph_root,
+            catalog,
+            page,
+            llm=StubHarvestLLM(),
+            stop_event=stop_event,
+        )
+
+    assert page.read_text(encoding="utf-8") == original
+    assert catalog.get(title) is None
+
+
 def test_harvest_regex_path_stores_nanosecond_mtime(graph_root: Path) -> None:
     pages = graph_root / "pages"
     pages.mkdir(parents=True)
@@ -133,3 +159,69 @@ def test_harvest_regex_path_stores_nanosecond_mtime(graph_root: Path) -> None:
     assert status == "regex"
     assert changed is True
     assert llm_called is False
+
+
+@pytest.mark.parametrize("use_mmap", [False, True])
+def test_harvest_regex_read_paths_match(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    use_mmap: bool,
+) -> None:
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Indexed.md"
+    page.write_text(
+        f"- type:: risorsa\n{SEMANTIC_INDEX_HEADER}\n- summary:: Indexed summary\n",
+        encoding="utf-8",
+    )
+    title = page_title_from_path(graph_root, page)
+    catalog = load_master_catalog(graph_root)
+    monkeypatch.setattr(
+        "src.graph.markdown_io.graph_read_mmap_enabled",
+        lambda: use_mmap,
+    )
+
+    result = harvest_page_into_catalog(
+        graph_root,
+        catalog,
+        page,
+        llm=None,
+        incoming_counts={title: 1},
+    )
+
+    entry = catalog.get(title)
+    assert entry is not None
+    assert entry.last_mtime == page.stat().st_mtime_ns
+    assert entry.orphan is False
+    assert result == ("regex", True, False)
+
+
+@pytest.mark.parametrize("use_mmap", [False, True])
+def test_harvest_read_error_preserves_status_without_catalog_mutation(
+    graph_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    use_mmap: bool,
+) -> None:
+    pages = graph_root / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Unreadable.md"
+    page.write_text("- Body\n", encoding="utf-8")
+    title = page_title_from_path(graph_root, page)
+    catalog = load_master_catalog(graph_root)
+    monkeypatch.setattr(
+        "src.graph.markdown_io.graph_read_mmap_enabled",
+        lambda: use_mmap,
+    )
+
+    def raise_read_error(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read failed")
+
+    target = "mmap_graph_page" if use_mmap else "read_graph_page_text"
+    monkeypatch.setattr(f"src.graph.bootstrap_harvest.{target}", raise_read_error)
+
+    result = harvest_page_into_catalog(graph_root, catalog, page, llm=None)
+
+    assert result == ("error:read failed", False, False)
+    assert catalog.get(title) is None


### PR DESCRIPTION
## Summary

- extract graph-page read selection and cooperative-stop enforcement from `harvest_page_into_catalog`;
- preserve mmap extraction order, replacement decoding, OSError status translation, catalog mutation, and the existing LLM/OCC sequence;
- add focused parity coverage for mmap/direct reads, read failures, and stopping before LLM or catalog mutation.

## Test plan

- [x] `uv run pytest tests/test_bootstrap_yield.py --no-cov -q` — 9 passed
- [x] `uv run pytest tests/test_master_catalog.py tests/test_hierarchical_summarization.py --no-cov -q` — 38 passed
- [x] target-specific `C901`, `PLR0912`, and `PLR0915` gate — `harvest_page_into_catalog` is clean; the command still reports pre-existing findings in the out-of-scope `run_bootstrap_harvest`
- [x] changed-file Ruff lint and format checks
- [x] `make ci` — 1,695 passed, 5 skipped, 83.49% coverage
- [x] staged graph-based scope audit — low risk, two intended files, no affected indexed execution flow
- [x] independent behavior-parity review — GO

## Scope

Two Python files only. No public API, dependency, configuration, documentation,
runtime-write policy, Gate B evidence, release artifact, or publication change.

Fixes #230
