### PR TITLE
refactor(graph): simplify page property injection (#236)

### DIFF
--- a/src/graph/page_properties.py
+++ b/src/graph/page_properties.py
@@ -125,6 +125,28 @@ def _content_start(stripped: list[str], fm_end: int) -> int:
     return idx
 
 
+def _merge_existing_frontmatter_property(
+    lines: list[str],
+    stripped: list[str],
+    norm_key: str,
+    existing_value: str,
+    value: str,
+) -> str | None:
+    fm_start, fm_end = _frontmatter_span(stripped)
+    line_idx = _find_frontmatter_key_line(stripped, fm_start, fm_end, norm_key)
+    if line_idx is None:
+        return None
+    merged = _merge_list_property_value(existing_value, value)
+    if merged is None:
+        return None
+    parsed = parse_logseq_property_line(stripped[line_idx])
+    if parsed is None:
+        return None
+    newline = "\n" if lines[line_idx].endswith(("\n", "\r\n", "\r")) else ""
+    lines[line_idx] = f"{parsed.key_raw}::{parsed.sep_after_colons}{merged}{newline}"
+    return "".join(lines)
+
+
 def inject_page_property(markdown_text: str, key: str, value: str) -> str:
     """Insert or merge ``key:: value`` as page-level frontmatter at the top of the file."""
     norm_key = normalize_logseq_property_key(key)
@@ -143,19 +165,16 @@ def inject_page_property(markdown_text: str, key: str, value: str) -> str:
     if norm_key in existing:
         if norm_key not in _MERGE_LIST_KEYS:
             return markdown_text
-        fm_start, fm_end = _frontmatter_span(stripped)
-        line_idx = _find_frontmatter_key_line(stripped, fm_start, fm_end, norm_key)
-        if line_idx is None:
+        merged_frontmatter = _merge_existing_frontmatter_property(
+            lines,
+            stripped,
+            norm_key,
+            existing[norm_key],
+            value,
+        )
+        if merged_frontmatter is None:
             return markdown_text
-        merged = _merge_list_property_value(existing[norm_key], value)
-        if merged is None:
-            return markdown_text
-        parsed = parse_logseq_property_line(stripped[line_idx])
-        if parsed is None:
-            return markdown_text
-        newline = "\n" if lines[line_idx].endswith(("\n", "\r\n", "\r")) else ""
-        lines[line_idx] = f"{parsed.key_raw}::{parsed.sep_after_colons}{merged}{newline}"
-        return "".join(lines)
+        return merged_frontmatter
 
     fm_start, fm_end = _frontmatter_span(stripped)
     prop_line = f"{key}:: {value}\n"


### PR DESCRIPTION
## Summary

- extract the existing mergeable frontmatter-property path into one private helper;
- preserve the public signature and every existing normalization, deduplication, ordering, newline, and fallback behavior;
- keep the pure string-transform boundary and all write-policy/OCC responsibilities unchanged.

## Test plan

- [x] `uv run pytest tests/test_page_properties.py --no-cov -q` — 16 passed
- [x] `uv run pytest tests/test_property_line_edit.py --no-cov -q` — 10 passed
- [x] `uv run pytest tests/test_plumber_cognitive_modules.py -k property --no-cov -q` — 2 passed, 16 deselected
- [x] `uv run ruff check --select C901,PLR0912,PLR0915 src/graph/page_properties.py`
- [x] changed-file Ruff lint and format checks
- [x] deterministic differential parity against the previous implementation — 100,000 inputs
- [x] `make ci` — 1,695 passed, 5 skipped, 83.49% coverage
- [x] staged graph-based scope audit — low risk, one intended file, no affected indexed execution flow
- [x] independent behavior-parity review — GO

## Scope

One Python source file only. No public API, dependency, configuration,
documentation, runtime-write policy, Gate B evidence, release artifact, or
publication change.

Fixes #236
