### PR TITLE
refactor(graph): simplify advanced query brackets (#229)

### DIFF
--- a/src/graph/advanced_query_block.py
+++ b/src/graph/advanced_query_block.py
@@ -11,6 +11,11 @@ from typing import Final
 
 _BEGIN: Final = "#+BEGIN_QUERY"
 _END: Final = "#+END_QUERY"
+_BRACKET_PAIRS: Final = {"(": ")", "[": "]", "{": "}"}
+
+
+def _closing_bracket_matches(stack: list[str], closing: str) -> bool:
+    return bool(stack) and _BRACKET_PAIRS[stack.pop()] == closing
 
 
 def _balanced_brackets(inner: str) -> bool:
@@ -32,13 +37,8 @@ def _balanced_brackets(inner: str) -> bool:
             continue
         if ch in "([{":
             stack.append(ch)
-        elif ch in ")]}":
-            if not stack:
-                return False
-            open_ch = stack.pop()
-            pairs = {"(": ")", "[": "]", "{": "}"}
-            if pairs.get(open_ch) != ch:
-                return False
+        elif ch in ")]}" and not _closing_bracket_matches(stack, ch):
+            return False
     return not stack and not in_string
 
 

--- a/tests/test_advanced_query_block.py
+++ b/tests/test_advanced_query_block.py
@@ -23,6 +23,30 @@ def test_validate_rejects_unbalanced() -> None:
         validate_advanced_query_edn(inner)
 
 
+@pytest.mark.parametrize(
+    "inner",
+    [
+        "){:query []}",
+        "{:query [(]}",
+        '{:query ["unterminated]}',
+    ],
+)
+def test_validate_rejects_bracket_state_edge_cases(inner: str) -> None:
+    with pytest.raises(ValueError, match="bracket|unterminated"):
+        validate_advanced_query_edn(inner)
+
+
+@pytest.mark.parametrize(
+    "inner",
+    [
+        '{:query [:find ?a :where [?a :block/content "(]"]]}',
+        '{:query [:find ?a :where [?a :block/content "quote: \\"(]" ]]}',
+    ],
+)
+def test_validate_ignores_brackets_inside_strings(inner: str) -> None:
+    assert validate_advanced_query_edn(inner) == inner
+
+
 def test_validate_requires_query_key() -> None:
     with pytest.raises(ValueError, match=":query"):
         validate_advanced_query_edn('{:title "only"}')

--- a/tests/test_graph_dispatch_mutate.py
+++ b/tests/test_graph_dispatch_mutate.py
@@ -8,6 +8,7 @@ import pytest
 from src.agent.dispatch_mutate_handlers import (
     handle_mutate_append_journal,
     handle_mutate_generate_moc,
+    handle_mutate_inject_query,
     mutate_error,
 )
 from src.agent.graph_dispatch import dispatch_mutate
@@ -62,3 +63,30 @@ async def test_dispatch_mutate_generate_moc_dry_run(tmp_path: object) -> None:
     assert out.get("ok") is True
     assert out.get("dry_run") is True
     assert "markdown_preview" in out
+
+
+@pytest.mark.asyncio
+async def test_handle_mutate_inject_query_dry_run_preserves_validation_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.agent.graph_dispatch._resolve_write_parent_target",
+        lambda _graph_path, _target: (object(), None, []),
+    )
+
+    valid = await handle_mutate_inject_query(
+        "/tmp/graph",
+        "parent-uuid",
+        '{"query_edn":"{:query [:find ?a]}","dry_run":true}',
+    )
+    invalid = await handle_mutate_inject_query(
+        "/tmp/graph",
+        "parent-uuid",
+        '{"query_edn":"{:query [(]}","dry_run":true}',
+    )
+
+    assert valid["ok"] is True
+    assert valid["dry_run"] is True
+    assert valid["markdown"] == "#+BEGIN_QUERY\n{:query [:find ?a]}\n#+END_QUERY"
+    assert invalid["ok"] is False
+    assert "unbalanced brackets" in invalid["error"]


### PR DESCRIPTION
## Summary

- extract closing-bracket stack matching from the advanced-query scanner;
- preserve quote, escape, nesting, mismatch, early-failure, and terminal-state behavior;
- add focused parser edge coverage and dry-run mutation-handler contract coverage.

## Test plan

- [x] `uv run pytest tests/test_advanced_query_block.py tests/test_graph_dispatch_mutate.py --no-cov -q` — 16 passed
- [x] `uv run ruff check --select C901,PLR0912,PLR0915 src/graph/advanced_query_block.py`
- [x] changed-file Ruff lint and format checks
- [x] differential parity against the previous implementation — 597,871 exhaustive inputs and 20,000 seeded random inputs
- [x] `make ci` — 1,701 passed, 5 skipped, 83.65% coverage
- [x] staged graph-based scope audit — three intended files; pre-change impact retained as high and validated with caller-level tests
- [x] independent state-machine and caller-contract review — GO

## Scope

One Python source file and two focused test files. No public API, dependency,
configuration, documentation, runtime-write policy, Gate B evidence, release
artifact, or publication change.

Fixes #229
