### PR TITLE
refactor(tana): simplify journal date pattern parsing (#223)

### DIFF
--- a/src/agent/importers/tana/journal.py
+++ b/src/agent/importers/tana/journal.py
@@ -55,6 +55,25 @@ def _format_python_strftime(pattern: str, day: date) -> str:
         return day.strftime(patched)
 
 
+def _consume_quoted_literal(pattern: str, start: int) -> tuple[str, int]:
+    length = len(pattern)
+    if start + 1 < length and pattern[start + 1] == "'":
+        return "'", start + 2
+
+    literal: list[str] = []
+    i = start + 1
+    while i < length:
+        if pattern[i] == "'":
+            if i + 1 < length and pattern[i + 1] == "'":
+                literal.append("'")
+                i += 2
+                continue
+            return "".join(literal), i + 1
+        literal.append(pattern[i])
+        i += 1
+    return "".join(literal), i
+
+
 def format_edn_date_pattern(pattern: str, day: date) -> str:
     """Translate a Logseq/Java ``journal/page-title-format`` pattern for ``day``.
 
@@ -69,23 +88,8 @@ def format_edn_date_pattern(pattern: str, day: date) -> str:
     while i < length:
         ch = pattern[i]
         if ch == "'":
-            if i + 1 < length and pattern[i + 1] == "'":
-                out.append("'")
-                i += 2
-                continue
-            i += 1
-            literal: list[str] = []
-            while i < length:
-                if pattern[i] == "'":
-                    if i + 1 < length and pattern[i + 1] == "'":
-                        literal.append("'")
-                        i += 2
-                        continue
-                    i += 1
-                    break
-                literal.append(pattern[i])
-                i += 1
-            out.append("".join(literal))
+            literal, i = _consume_quoted_literal(pattern, i)
+            out.append(literal)
             continue
 
         matched = False

--- a/tests/test_tana_journal.py
+++ b/tests/test_tana_journal.py
@@ -70,6 +70,30 @@ def test_escaped_quote_literal() -> None:
     assert format_edn_date_pattern("yyyy''MMdd", _SAMPLE_DAY) == "2026'0622"
 
 
+def test_doubled_quote_inside_literal() -> None:
+    assert format_edn_date_pattern("'o''clock' yyyy", _SAMPLE_DAY) == "o'clock 2026"
+
+
+def test_unmatched_quote_consumes_remaining_literal() -> None:
+    assert format_edn_date_pattern("yyyy 'journal MM", _SAMPLE_DAY) == "2026 journal MM"
+
+
+def test_whitespace_pattern_uses_default_format() -> None:
+    assert format_edn_date_pattern("   ", _SAMPLE_DAY) == "2026-06-22"
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("MMMMM", "June6"),
+        ("EEEEE", "MondayE"),
+        ("'Q' q yyyy", "Q q 2026"),
+    ],
+)
+def test_token_longest_prefix_boundaries(pattern: str, expected: str) -> None:
+    assert format_edn_date_pattern(pattern, _SAMPLE_DAY) == expected
+
+
 def test_format_journal_page_title_alias() -> None:
     assert format_journal_page_title(_SAMPLE_DAY, "yyyy-MM-dd") == "2026-06-22"
 


### PR DESCRIPTION
## Summary

- extract quoted-literal consumption from the Logseq/Tana journal date-pattern formatter;
- preserve default fallback, Java-token ordering, doubled/unmatched quote handling, ordinal rendering, and platform `strftime` behavior;
- add characterization coverage for quote and token-boundary semantics.

## Test plan

- [x] `uv run pytest tests/test_tana_journal.py --no-cov -q` — 59 passed
- [x] `uv run pytest tests/test_tana_tags.py tests/test_tana_convert.py --no-cov -q` — 15 passed
- [x] `uv run ruff check --select C901,PLR0912,PLR0915 src/agent/importers/tana/journal.py`
- [x] changed-file Ruff lint and format checks
- [x] differential parity — 137,257 exhaustive patterns and 20,000 seeded random dates
- [x] serial full suite — 1,707 passed, 5 skipped, 83.66% coverage
- [x] parallel full suite — 1,707 passed, 5 skipped, 83.67% coverage
- [x] canonical static, type, documentation, and generated-prompt gates
- [x] isolated rerun of the single sustained-load MCP handshake timeout — passed in 2.76s
- [x] staged graph-based scope audit — two intended files; pre-change high fan-out retained and validated with transitive tests
- [x] independent formatter-parity review — GO

## Scope

One Python source file and one focused test file. No public API, dependency,
configuration, documentation, runtime-write policy, Gate B evidence, release
artifact, or publication change.

Fixes #223
