### PR TITLE
refactor(marpa): simplify SSoT block collection (#227)

### DIFF
--- a/src/agent/plumber_modules/marpa_framework.py
+++ b/src/agent/plumber_modules/marpa_framework.py
@@ -71,14 +71,20 @@ def _has_top_level_type(content: str) -> bool:
     return "type" in page_property_keys(content)
 
 
-def _scan_ssot_duplication(graph_root: Path, page_path: Path, content: str) -> list[str]:
-    """Flag large verbatim blocks that appear to duplicate another page (SSoT guard)."""
-    flags: list[str] = []
+def _large_bullet_blocks(content: str) -> list[str]:
+    """Return normalized bullet bodies large enough for SSoT comparison."""
     blocks: list[str] = []
     for line in content.splitlines():
         match = _BULLET.match(line.rstrip("\n"))
         if match and len(match.group(2)) >= _MIN_DUP_CHARS:
             blocks.append(match.group(2).strip())
+    return blocks
+
+
+def _scan_ssot_duplication(graph_root: Path, page_path: Path, content: str) -> list[str]:
+    """Flag large verbatim blocks that appear to duplicate another page (SSoT guard)."""
+    flags: list[str] = []
+    blocks = _large_bullet_blocks(content)
     if not blocks:
         return flags
 

--- a/tests/test_plumber_cognitive_modules.py
+++ b/tests/test_plumber_cognitive_modules.py
@@ -25,7 +25,7 @@ from src.agent.plumber_modules import run_cognitive_lint_pipeline
 from src.agent.plumber_modules.auto_split import run_auto_split
 from src.agent.plumber_modules.dangling_healer import run_dangling_healer
 from src.agent.plumber_modules.entity_consolidation import run_entity_consolidation
-from src.agent.plumber_modules.marpa_framework import run_marpa_framework
+from src.agent.plumber_modules.marpa_framework import _scan_ssot_duplication, run_marpa_framework
 from src.agent.plumber_modules.property_hygiene import run_property_hygiene
 from src.agent.semantic_lint_prompts import build_semantic_lint_system_prompt
 from src.graph.master_catalog import load_master_catalog
@@ -427,6 +427,29 @@ def test_marpa_framework_classifies_project_with_deadline(graph_root: Path) -> N
     assert outcome.pages_modified == [page_title]
     type_line_idx = next(i for i, line in enumerate(text.splitlines()) if "type:: progetto" in line)
     assert not text.splitlines()[type_line_idx].lstrip().startswith("- ")
+
+
+def test_scan_ssot_duplication_flags_only_large_bullet_blocks(graph_root: Path) -> None:
+    short_block = "s" * 79
+    large_block = "l" * 80
+    body = f"- {short_block}\n- {large_block}\n"
+    page_path = _write_page(graph_root, "Source", body)
+    _write_page(graph_root, "Duplicate", body)
+
+    assert _scan_ssot_duplication(graph_root, page_path, body) == [
+        "ssot_duplicate:pages/Duplicate.md",
+    ]
+
+
+def test_scan_ssot_duplication_ignores_hidden_pages(graph_root: Path) -> None:
+    large_block = "l" * 80
+    body = f"- {large_block}\n"
+    page_path = _write_page(graph_root, "Source", body)
+    hidden_dir = graph_root / "pages" / ".hidden"
+    hidden_dir.mkdir()
+    (hidden_dir / "Duplicate.md").write_text(body, encoding="utf-8")
+
+    assert _scan_ssot_duplication(graph_root, page_path, body) == []
 
 
 def test_marpa_disabled_by_default_leaves_file_untouched(graph_root: Path) -> None:


### PR DESCRIPTION
## Summary

- extract large bullet-block collection from the MARPA SSoT duplication scanner;
- preserve the existing scan scope, traversal order, sandbox filtering, fallback, and error-handling behavior;
- add direct characterization coverage for the 80-character boundary and hidden-page exclusion.

## Test plan

- [x] `uv run pytest tests/test_plumber_cognitive_modules.py -q --no-cov` — 20 passed
- [x] transitive maintenance tests — 93 passed
- [x] changed-file Ruff lint and format checks
- [x] target complexity check — `_scan_ssot_duplication` no longer violates C901
- [x] differential parity — 500 seeded randomized graph cases
- [x] serial full suite — 1,709 passed, 5 skipped, 83.77% coverage
- [x] canonical static, type, sandbox, version, documentation, and generated-prompt gates
- [x] staged graph-based scope audit — two intended files and one affected MARPA execution flow
- [x] independent filesystem-safety and parity review — GO

## Scope

One private Python helper and two focused tests. No public API, dependency,
configuration, documentation, runtime-write policy, Gate B evidence, release
artifact, or publication change.

Fixes #227
