### PR TITLE
fix(quality): bind Gate B runner to RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Gate B RC2 artifact binding** — bind fresh dual-profile qualification to the exact installed `2.0.0rc2` public wheel instead of rejecting it through the historical RC1 package identity.
+
 ## [2.0.0-rc.2] - 2026-08-09
 
 ### Added

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -6,7 +6,9 @@ public candidate wheel, never a source checkout.
 
 ## Post-RC read-path requalification boundary
 
-The public-RC soak records evidence only for the exact `2.0.0rc1` wheel. Issue
+Each public-RC campaign records evidence only for its exact installed wheel. The
+historical rc.1 results below apply only to `2.0.0rc1`; the current campaign must
+start from zero and bind both profiles to the exact public `2.0.0rc2` wheel. Issue
 [#389](https://github.com/MarcoPorcellato/matryca-plumber/issues/389) changes the FTS
 and subtree paths exercised by both profiles by adding requested-row freshness checks
 and explicit Markdown/BM25 fallback reasons. Do not rewrite or transfer the RC result

--- a/scripts/qualify_gate_b_soak.py
+++ b/scripts/qualify_gate_b_soak.py
@@ -33,7 +33,7 @@ Profile = Literal["default-on", "read-only-external"]
 _PROFILE_FILE = "gate-b-profile.json"
 _PROFILE_SCHEMA_VERSION = 1
 _PROFILES: tuple[Profile, ...] = ("default-on", "read-only-external")
-_RC_PACKAGE = "2.0.0rc1"
+_RC_PACKAGE = "2.0.0rc2"
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 
 _DEFAULT_ON_PROBE = r"""

--- a/tests/test_gate_b_soak.py
+++ b/tests/test_gate_b_soak.py
@@ -243,7 +243,7 @@ def test_public_rc_wheel_binding_records_exact_installed_identity(
 ) -> None:
     module = _module()
     output = tmp_path / "evidence"
-    wheel = tmp_path / "matryca_plumber-2.0.0rc1-py3-none-any.whl"
+    wheel = tmp_path / "matryca_plumber-2.0.0rc2-py3-none-any.whl"
     wheel.write_bytes(b"public rc wheel")
     expected_sha256 = module._sha256(wheel.read_bytes())
     provenance = "b" * 64
@@ -263,7 +263,7 @@ def test_public_rc_wheel_binding_records_exact_installed_identity(
         )
         == provenance
     )
-    assert observed == [(Path(sys.executable).absolute(), "2.0.0rc1")]
+    assert observed == [(Path(sys.executable).absolute(), "2.0.0rc2")]
     checkpoint = json.loads((output / "checkpoint.json").read_text(encoding="utf-8"))
     details = checkpoint["gates"]["wheel"]["details"]
     assert details["wheel_sha256"] == expected_sha256


### PR DESCRIPTION
## Summary

- bind the public-RC Gate B qualifier to the exact installed `2.0.0rc2` wheel
- update focused artifact-identity assertions
- clarify that RC1 evidence remains historical and RC2 starts from zero
- record the runner correction under `Unreleased`

## Verification

- `16 passed` in the focused Gate B qualifier/supervisor suite
- Ruff and format checks pass
- documentation governance passes
- full CI: 1,709 passed, 5 skipped; the sole sandbox-blocked `ps` test passes with normal process-inspection access
- code-audit impact: LOW, no affected production process

The released `2.0.0rc2` wheel remains unchanged at `main@c4cb76dd`; this PR corrects only the external qualification runner used to bind fresh Gate B evidence.