### PR TITLE
feat(benchmark): add deterministic retrieval scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - **Evidence-first agentic-memory programme** — sequence v2.1+ delivery through governed evidence, deterministic canonical recall, reproducible benchmarks, human-governed curation, and derived-only Shadow state before typed decay, procedural memory, or opt-in proactivity.
+- **BM25 scorecard benchmark schema** — add manifest-driven synthetic Italian hard-negative scorecard mode (`--manifest-path`) with deterministic Recall@K, MRR, nDCG, stale/contradiction, abstention, and manifest digest/environment signatures for reproducible ranking evidence without runtime behavior changes.
 
 ### Fixed
 

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -75,3 +75,31 @@ The 16,384-entry candidate adds no hit-rate benefit for the representative hot o
 ## Evidence boundary
 
 These are deterministic synthetic results, not live-vault qualification. RSS and process peak are measured in one sequential benchmark process, so allocator reuse and cumulative peak state make per-capacity memory deltas directional rather than isolated. The run covers one arm64 macOS machine and one fixed seed. A future capacity increase requires representative sanitized live-corpus traces, isolated-process memory measurements, and cross-platform confirmation without material p99 or correctness regression.
+
+## Scorecard baseline (manifest-driven hard-negative benchmark)
+
+The same benchmark harness now supports an additional scorecard profile for deterministic retrieval quality baselines.
+
+Run with:
+
+```bash
+uv run python scripts/bench_bm25_query_cache.py \
+  --manifest-path tests/fixtures/bm25_hard_negative_manifest_v1.json \
+  --top-k 8 \
+  --output benchmarks/results/bm25_query_cache_scorecard_macos_arm64_2026-08-10.json
+```
+
+Scorecard output includes:
+
+- `benchmark_schema_version: 2`
+- `manifest` identity and SHA-256 digest
+- retrieval-only Recall@K, MRR, nDCG, stale, contradiction, and abstention metrics
+- deterministic 95% percentile-bootstrap confidence intervals for mean ranking metrics
+- the `no_retrieval` signal ablation, which makes the lexical BM25 contribution explicit
+- latency micro-profile and RSS/payload-context measurements, including a transparent
+  byte-derived context-token estimate and zero external-model cost
+
+The profile is synthetic and deterministic: no external data or network runtime dependency is required.
+It intentionally does not report end-to-end answer quality: that belongs to the
+separate adapter layer, where answer model, judge, prompt, token budget, and
+failure policy can be pinned rather than conflated with retrieval quality.

--- a/scripts/bench_bm25_query_cache.py
+++ b/scripts/bench_bm25_query_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import json
 import math
@@ -20,7 +21,13 @@ from statistics import median
 from typing import Any, NamedTuple
 
 import src.graph.generational_cache as generational_cache
-from src.graph.generational_cache import Bm25Corpus, bm25_query_cache_stats, score_bm25_query
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from src.graph.generational_cache import (
+    Bm25Corpus,
+    bm25_diagnostics_snapshot,
+    bm25_query_cache_stats,
+    score_bm25_query,
+)
 
 resource_module: Any
 try:
@@ -38,6 +45,39 @@ _SEED = 20260802
 _CAPACITIES = (512, 2_048, 8_192, 16_384)
 _DEFAULT_CAPACITY = 8_192
 _RESULT_LIMITS = (1, 8, 32, 100)
+_MANIFEST_SCHEMA_VERSION = 1
+_SCORECARD_SCHEMA_VERSION = 2
+_DEFAULT_TOP_K = 8
+
+
+class ManifestDocument(BaseModel):
+    id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    content: str = Field(min_length=1)
+    stale: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ManifestCase(BaseModel):
+    seed: int
+    query: str = Field(min_length=1)
+    relevant: list[str]
+    hard_negatives: list[str] = Field(default_factory=list)
+    abstain_when_no_candidates: bool = False
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ManifestPayload(BaseModel):
+    schema_version: int
+    dataset_id: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    documents: list[ManifestDocument]
+    cases: list[ManifestCase]
+    top_k: int = Field(default=_DEFAULT_TOP_K, ge=1, le=100)
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class Request(NamedTuple):
@@ -54,6 +94,348 @@ class BenchmarkConfig:
     seed: int
     capacities: tuple[int, ...]
     multi_corpora: int
+
+
+def _read_manifest(path: Path) -> tuple[ManifestPayload, str]:
+    raw = path.read_text(encoding="utf-8")
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    try:
+        data: Any = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"Invalid manifest JSON in {path}: {error}") from error
+
+    try:
+        manifest = ManifestPayload.model_validate(data)
+    except ValidationError as error:
+        raise ValueError(f"Invalid manifest schema in {path}: {error}") from error
+
+    if manifest.schema_version != _MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported manifest schema_version {manifest.schema_version}; "
+            f"expected {_MANIFEST_SCHEMA_VERSION}"
+        )
+    if len(manifest.cases) < 20:
+        raise ValueError(
+            f"Manifest {manifest.dataset_id} must include at least 20 "
+            f"cases; got {len(manifest.cases)}"
+        )
+
+    document_ids = {document.id for document in manifest.documents}
+    if len(document_ids) != len(manifest.documents):
+        raise ValueError(f"Manifest {manifest.dataset_id} has duplicated document ids")
+
+    seen_seeds: set[int] = set()
+    for case in manifest.cases:
+        if case.seed in seen_seeds:
+            raise ValueError(
+                f"Manifest {manifest.dataset_id} contains duplicate case seed {case.seed}"
+            )
+        seen_seeds.add(case.seed)
+        missing_relevant = set(case.relevant) - document_ids
+        missing_hard_negatives = set(case.hard_negatives) - document_ids
+        if missing_relevant:
+            raise ValueError(
+                f"Case seed {case.seed} references missing relevant ids {sorted(missing_relevant)}"
+            )
+        if missing_hard_negatives:
+            raise ValueError(
+                f"Case seed {case.seed} references missing "
+                f"hard-negative ids {sorted(missing_hard_negatives)}"
+            )
+        if not set(case.relevant).isdisjoint(case.hard_negatives):
+            raise ValueError(
+                f"Case seed {case.seed} must not overlap relevant and hard-negative labels"
+            )
+        if case.abstain_when_no_candidates:
+            if case.relevant:
+                raise ValueError(
+                    f"Case seed {case.seed} abstention mode must not define relevant labels"
+                )
+            if len(case.hard_negatives) < 2:
+                raise ValueError(
+                    f"Case seed {case.seed} abstention mode must define at least two hard-negatives"
+                )
+        elif not case.relevant:
+            raise ValueError(f"Case seed {case.seed} must define at least one relevant label")
+        elif len(case.hard_negatives) < 2:
+            raise ValueError(f"Case seed {case.seed} must define at least two hard-negative labels")
+
+    return manifest, digest
+
+
+def _to_relation(document_id: str) -> str:
+    return f"pages/{document_id}.md"
+
+
+def _corpus_from_manifest(
+    manifest: ManifestPayload,
+) -> tuple[Bm25Corpus, set[str]]:
+    from src.rag.local_query import tokenize
+
+    rels: list[str] = []
+    doc_term_freqs: list[dict[str, int]] = []
+    doc_lens: list[int] = []
+    df: dict[str, int] = {}
+    stale_rels: set[str] = set()
+
+    for document in manifest.documents:
+        rel = _to_relation(document.id)
+        rels.append(rel)
+        tokens = [token for token in tokenize(document.content) if token]
+        term_freqs = {token: tokens.count(token) for token in tokens}
+        if not term_freqs:
+            raise ValueError(f"Manifest document {document.id} contains no indexable content")
+        doc_term_freqs.append(term_freqs)
+        doc_lens.append(len(tokens))
+        for token in term_freqs:
+            df[token] = df.get(token, 0) + 1
+        if document.stale:
+            stale_rels.add(rel)
+
+    document_count = len(doc_term_freqs)
+    if document_count == 0:
+        raise ValueError(f"Manifest {manifest.dataset_id} has no documents")
+
+    return (
+        Bm25Corpus(
+            rels=rels,
+            doc_term_freqs=doc_term_freqs,
+            doc_lens=doc_lens,
+            df=df,
+            n_docs=document_count,
+            avgdl=sum(doc_lens) / document_count,
+        ),
+        stale_rels,
+    )
+
+
+def _dcg(gains: Sequence[float]) -> float:
+    return sum(gain / math.log2(index + 2.0) for index, gain in enumerate(gains))
+
+
+def _rank_metrics(
+    retrieved_rels: list[str],
+    relevant_rels: set[str],
+    hard_negative_rels: set[str],
+    stale_rels: set[str],
+    top_k: int,
+    *,
+    has_reference: bool,
+) -> dict[str, float | int | bool]:
+    top = retrieved_rels[:top_k]
+    relevance = [1 if rel in relevant_rels else 0 for rel in top]
+    stale_hits = sum(1 for rel in top if rel in stale_rels)
+    contradiction_hits = sum(1 for rel in top if rel in hard_negative_rels)
+    recall = (
+        sum(1 for rel in relevant_rels if rel in top) / len(relevant_rels) if relevant_rels else 0.0
+    )
+    mrr = 0.0
+    if has_reference:
+        for position, rel in enumerate(top, start=1):
+            if rel in relevant_rels:
+                mrr = 1.0 / position
+                break
+    ideal = _dcg([1] * len(relevant_rels))
+    ndcg = _dcg(relevance) / ideal if ideal else 0.0
+    return {
+        "recall_at_k": round(recall, 4),
+        "mrr": round(mrr, 4),
+        "ndcg": round(ndcg, 4),
+        "stale_hits": stale_hits,
+        "contradiction_hits": contradiction_hits,
+        "abstained": has_reference is False and len(top) == 0,
+    }
+
+
+def _confidence_interval(
+    values: Sequence[float], *, seed: int, samples: int = 1_000
+) -> dict[str, Any]:
+    """Return a deterministic percentile-bootstrap interval for a mean metric."""
+    if not values:
+        return {"confidence_level": 0.95, "high": 0.0, "low": 0.0, "samples": 0}
+
+    rng = random.Random(seed)
+    count = len(values)
+    bootstrap_means = sorted(
+        sum(rng.choice(values) for _ in range(count)) / count for _ in range(samples)
+    )
+    return {
+        "confidence_level": 0.95,
+        "low": round(_percentile(bootstrap_means, 0.025), 4),
+        "high": round(_percentile(bootstrap_means, 0.975), 4),
+        "samples": samples,
+    }
+
+
+def _aggregate_rank_metrics(
+    case_metrics: Sequence[dict[str, float | int | bool]],
+    *,
+    top_k: int,
+    bootstrap_seed: int,
+    abstention_expected: int,
+    abstention_passed: int,
+) -> dict[str, Any]:
+    query_count = max(1, len(case_metrics))
+    recalls = [float(metrics["recall_at_k"]) for metrics in case_metrics]
+    mrrs = [float(metrics["mrr"]) for metrics in case_metrics]
+    ndcgs = [float(metrics["ndcg"]) for metrics in case_metrics]
+    stale_hits = sum(int(metrics["stale_hits"]) for metrics in case_metrics)
+    contradiction_hits = sum(int(metrics["contradiction_hits"]) for metrics in case_metrics)
+    stale_queries = sum(1 for metrics in case_metrics if metrics["stale_hits"])
+    contradiction_queries = sum(1 for metrics in case_metrics if metrics["contradiction_hits"])
+    return {
+        "recall_at_k": round(sum(recalls) / query_count, 4),
+        "mrr": round(sum(mrrs) / query_count, 4),
+        "ndcg": round(sum(ndcgs) / query_count, 4),
+        "confidence_intervals": {
+            "mrr": _confidence_interval(mrrs, seed=bootstrap_seed + 1),
+            "ndcg": _confidence_interval(ndcgs, seed=bootstrap_seed + 2),
+            "recall_at_k": _confidence_interval(recalls, seed=bootstrap_seed),
+        },
+        "stale": {
+            "hits": stale_hits,
+            "query_rate": round(stale_queries / query_count, 6),
+            "rate_per_query_position": round(stale_hits / (query_count * top_k), 6),
+        },
+        "contradiction": {
+            "hits": contradiction_hits,
+            "query_rate": round(contradiction_queries / query_count, 6),
+            "rate_per_query_position": round(contradiction_hits / (query_count * top_k), 6),
+        },
+        "abstention": {
+            "enabled_cases": abstention_expected,
+            "passed_cases": abstention_passed,
+            "rate": round(abstention_passed / abstention_expected, 6)
+            if abstention_expected
+            else 0.0,
+        },
+    }
+
+
+def _run_scorecard_benchmark(manifest: ManifestPayload, *, top_k: int) -> dict[str, Any]:
+    corpus, stale_rels = _corpus_from_manifest(manifest)
+    latencies_ns: list[int] = []
+    case_results: list[dict[str, Any]] = []
+    abstention_ok = 0
+    abstention_total = 0
+    ranked_case_metrics: list[dict[str, float | int | bool]] = []
+
+    for case in manifest.cases:
+        relevant_rels = {_to_relation(doc_id) for doc_id in case.relevant}
+        hard_negative_rels = {_to_relation(doc_id) for doc_id in case.hard_negatives}
+        started = time.perf_counter_ns()
+        results = score_bm25_query(
+            corpus,
+            case.query,
+            limit=max(top_k, max(1, len(case.relevant) or 1)),
+        )
+        latencies_ns.append(time.perf_counter_ns() - started)
+        retrieved = [rel for rel, _score in results]
+        metrics = _rank_metrics(
+            retrieved,
+            relevant_rels=relevant_rels,
+            hard_negative_rels=hard_negative_rels,
+            stale_rels=stale_rels,
+            top_k=top_k,
+            has_reference=bool(relevant_rels),
+        )
+        if not relevant_rels and case.abstain_when_no_candidates:
+            abstention_total += 1
+            if metrics["abstained"]:
+                abstention_ok += 1
+        ranked_case_metrics.append(metrics)
+        case_results.append(
+            {
+                "seed": case.seed,
+                "query": case.query,
+                "retrieved_relations": retrieved[:top_k],
+                "metrics": metrics,
+            }
+        )
+
+    bootstrap_seed = sum(case.seed for case in manifest.cases)
+    metrics_summary = _aggregate_rank_metrics(
+        ranked_case_metrics,
+        top_k=top_k,
+        bootstrap_seed=bootstrap_seed,
+        abstention_expected=abstention_total,
+        abstention_passed=abstention_ok,
+    )
+    no_retrieval_metrics = _aggregate_rank_metrics(
+        [
+            _rank_metrics(
+                [],
+                relevant_rels={_to_relation(doc_id) for doc_id in case.relevant},
+                hard_negative_rels={_to_relation(doc_id) for doc_id in case.hard_negatives},
+                stale_rels=stale_rels,
+                top_k=top_k,
+                has_reference=bool(case.relevant),
+            )
+            for case in manifest.cases
+        ],
+        top_k=top_k,
+        bootstrap_seed=bootstrap_seed + 100,
+        abstention_expected=abstention_total,
+        abstention_passed=abstention_total,
+    )
+    cache_stats = bm25_query_cache_stats(corpus)
+    diagnostics = bm25_diagnostics_snapshot(corpus).to_dict()
+    sorted_latencies = sorted(latencies_ns)
+    payload_estimate_bytes = diagnostics["estimated_payload_bytes"]
+    scorecard_fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "case_count": len(manifest.cases),
+                "case_results": case_results,
+                "manifest_dataset_id": manifest.dataset_id,
+                "manifest_schema_version": manifest.schema_version,
+                "metrics": metrics_summary,
+                "signal_ablations": {"no_retrieval": no_retrieval_metrics},
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    return {
+        "manifest_schema_version": manifest.schema_version,
+        "case_count": len(manifest.cases),
+        "manifest_dataset_id": manifest.dataset_id,
+        "scorecard_fingerprint": scorecard_fingerprint,
+        "case_results": case_results,
+        "evaluation_scope": {
+            "end_to_end_answer_evaluated": False,
+            "retrieval_only": True,
+        },
+        "metrics": metrics_summary,
+        "signal_ablations": {"no_retrieval": no_retrieval_metrics},
+        "measurements": {
+            "cache": cache_stats,
+            "cache_hit_ratio": round(
+                cache_stats["hits"] / (cache_stats["hits"] + cache_stats["misses"]),
+                6,
+            )
+            if cache_stats["hits"] + cache_stats["misses"] > 0
+            else 0.0,
+            "latency_us": {
+                "median": round(median(sorted_latencies) / 1_000, 3),
+                "p50": round(_percentile(sorted_latencies, 0.50) / 1_000, 3),
+                "p95": round(_percentile(sorted_latencies, 0.95) / 1_000, 3),
+                "p99": round(_percentile(sorted_latencies, 0.99) / 1_000, 3),
+            },
+            "peak_rss_bytes": _peak_rss_bytes(),
+            "payload_estimate_bytes": payload_estimate_bytes,
+            "context_estimate_tokens": math.ceil(payload_estimate_bytes / 4),
+            "context_token_estimator": "ceil(payload_estimate_bytes / 4)",
+            "external_model_calls": 0,
+            "estimated_model_cost_usd": 0.0,
+            "model_cost_applicability": "not_applicable",
+            "rss_end_bytes": _current_rss_bytes(),
+            "requests": len(manifest.cases),
+            "top_k": top_k,
+            "query_cache_row_budget": cache_stats["result_row_capacity"],
+        },
+    }
 
 
 def _corpus(document_count: int, *, namespace: str = "") -> Bm25Corpus:
@@ -131,7 +513,7 @@ def _workloads(config: BenchmarkConfig) -> dict[str, list[Request]]:
     }
 
 
-def _percentile(sorted_values: Sequence[int], percentile: float) -> float:
+def _percentile(sorted_values: Sequence[int | float], percentile: float) -> float:
     if not sorted_values:
         return 0.0
     position = (len(sorted_values) - 1) * percentile
@@ -334,9 +716,36 @@ def _source_commit() -> str:
     return completed.stdout.strip()
 
 
-def run_benchmark(config: BenchmarkConfig) -> dict[str, Any]:
+def run_benchmark(
+    config: BenchmarkConfig,
+    *,
+    manifest_path: Path | None = None,
+    top_k: int | None = None,
+) -> dict[str, Any]:
     original_capacity = generational_cache._DEFAULT_BM25_QUERY_CACHE_MAX_ENTRIES
     try:
+        if manifest_path is not None:
+            manifest, manifest_digest = _read_manifest(manifest_path)
+            effective_top_k = manifest.top_k if top_k is None else top_k
+            payload = _run_scorecard_benchmark(manifest, top_k=effective_top_k)
+            return {
+                "benchmark_schema_version": _SCORECARD_SCHEMA_VERSION,
+                **payload,
+                "manifest": {
+                    "digest": manifest_digest,
+                    "path": str(manifest_path),
+                    "schema_version": manifest.schema_version,
+                },
+                "config": asdict(config),
+                "environment": {
+                    "corpus_digest": manifest_digest,
+                    "machine": platform.machine(),
+                    "manifest_schema_version": manifest.schema_version,
+                    "os": platform.platform(),
+                    "python": platform.python_version(),
+                    "source_commit": _source_commit(),
+                },
+            }
         build_started = time.perf_counter_ns()
         _corpus(config.documents)
         build_seconds = (time.perf_counter_ns() - build_started) / 1_000_000_000
@@ -381,6 +790,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=_SEED)
     parser.add_argument("--capacities", default="512,2048,8192,16384")
     parser.add_argument("--multi-corpora", type=int, default=4)
+    parser.add_argument("--manifest-path", type=Path)
+    parser.add_argument("--top-k", type=int)
     parser.add_argument("--output", type=Path)
     return parser
 
@@ -388,7 +799,9 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     capacities = tuple(int(value) for value in args.capacities.split(","))
-    if (
+    if args.top_k is not None and args.top_k < 1:
+        raise SystemExit("--top-k must be positive")
+    if args.manifest_path is None and (
         args.documents < 1
         or args.requests < 1
         or args.repetitions < 1
@@ -398,6 +811,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         or any(capacity < 1 for capacity in capacities)
     ):
         raise SystemExit("benchmark dimensions and capacities must be positive")
+
     config = BenchmarkConfig(
         documents=args.documents,
         requests=args.requests,
@@ -407,7 +821,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         capacities=capacities,
         multi_corpora=args.multi_corpora,
     )
-    rendered = json.dumps(run_benchmark(config), indent=2, sort_keys=True) + "\n"
+    rendered = json.dumps(
+        run_benchmark(
+            config,
+            manifest_path=args.manifest_path,
+            top_k=args.top_k,
+        ),
+        indent=2,
+        sort_keys=True,
+    )
     if args.output is None:
         print(rendered, end="")
     else:

--- a/tests/fixtures/bm25_hard_negative_manifest_v1.json
+++ b/tests/fixtures/bm25_hard_negative_manifest_v1.json
@@ -1,0 +1,302 @@
+{
+  "schema_version": 1,
+  "dataset_id": "matryca-bm25-hard-negative-it-v1",
+  "description": "Deterministic Italian hard-negative retrieval cases for BM25 scorecard benchmarking.",
+  "top_k": 8,
+  "documents": [
+    {
+      "id": "progetto_alfa",
+      "title": "Progetto Alfa",
+      "content": "Il progetto Alfa introduce un sistema di cache distribuita con invalidazione deterministica e osservabilità locale.",
+      "stale": false
+    },
+    {
+      "id": "banca_dati_grafi",
+      "title": "Banca dati grafi",
+      "content": "La banca dati grafi registra relazioni, pagine, link e proprietà per supportare ricerche deterministiche in tempo limitato.",
+      "stale": false
+    },
+    {
+      "id": "pipeline_riassunto",
+      "title": "Pipeline riassunto",
+      "content": "La pipeline di riassunto estrae entit\u00e0 da titoli e sommari per costruire strutture di ricordo deterministiche.",
+      "stale": false
+    },
+    {
+      "id": "onboarding_team",
+      "title": "Onboarding Team",
+      "content": "L\u2019onboarding del team usa checklist ripetibili, check-in settimanali e revisioni condivise con propriet\u00e0 esplicite.",
+      "stale": false
+    },
+    {
+      "id": "backup_locale",
+      "title": "Backup locale",
+      "content": "Il backup locale conserva snapshot giornalieri e supporta ripristini rapidi senza dipendere da servizi esterni.",
+      "stale": false
+    },
+    {
+      "id": "sicurezza_oauth",
+      "title": "Sicurezza OAuth",
+      "content": "La sicurezza OAuth applica token a tempo limitato, ruoli, privilegi minimi e verifica della catena di autorizzazione.",
+      "stale": false
+    },
+    {
+      "id": "api_rest",
+      "title": "API REST",
+      "content": "Le API REST devono restituire payload stabili e codici di errore prevedibili durante i carichi elevati.",
+      "stale": false
+    },
+    {
+      "id": "cache_bm25",
+      "title": "Cache BM25",
+      "content": "La cache BM25 mantiene documenti tokenizzati, limite di righe, eviction policy e calcolo del ranking riusabile.",
+      "stale": false
+    },
+    {
+      "id": "indice_semantico",
+      "title": "Indice semantico",
+      "content": "L\u2019indice semantico usa vettori, tag strutturati e segnature di pagina per raggruppare contenuti simili.",
+      "stale": false
+    },
+    {
+      "id": "query_plausibile",
+      "title": "Query plausibile",
+      "content": "Una query plausibile evita assunzioni aggressive e misura precisione, recall e copertura con metriche trasparenti.",
+      "stale": true
+    },
+    {
+      "id": "contratti_energia",
+      "title": "Contratti energia",
+      "content": "I contratti energia gestiscono piani tariffari, monitoraggio consumo e rinnovi regolati da policy interne.",
+      "stale": false
+    },
+    {
+      "id": "diario_lavoro",
+      "title": "Diario di lavoro",
+      "content": "Il diario di lavoro registra stato giornaliero delle attività ma non deve essere usato come indice principale delle ricerche.",
+      "stale": false
+    },
+    {
+      "id": "agenda_sprint",
+      "title": "Agenda sprint",
+      "content": "L\u2019agenda sprint pianifica obiettivi, revisioni rapide e criteri di accettazione per ogni iterazione.",
+      "stale": false
+    },
+    {
+      "id": "metrica_precisione",
+      "title": "Metrica precisione",
+      "content": "La metrica precisione bilancia risultati top-k con qualità percettiva e controlli quantitativi.",
+      "stale": true
+    },
+    {
+      "id": "metriche_mrc",
+      "title": "Metriche MRC",
+      "content": "Le metriche MRC valutano recall, MRR e nDCG con ranking ordinato e riproducibilit\u00e0 completa.",
+      "stale": false
+    },
+    {
+      "id": "cronologia_patch",
+      "title": "Cronologia patch",
+      "content": "La cronologia patch mostra aggiornamenti recenti, hash, firme di esecuzione e segnature di controllo.",
+      "stale": true
+    },
+    {
+      "id": "utente_privilegiato",
+      "title": "Utente privilegiato",
+      "content": "L\u2019utente privilegiato richiede verifica multi-fattore, logging e ruoli espliciti con revoca rapida.",
+      "stale": false
+    },
+    {
+      "id": "orchestrazione_k8s",
+      "title": "Orchestrazione k8s",
+      "content": "L\u2019orchestrazione k8s scala workload, alloca risorse e conserva limiti di contesto per il runtime locale.",
+      "stale": false
+    },
+    {
+      "id": "modello_llm",
+      "title": "Modello LLM",
+      "content": "Il modello LLM genera testi, propone sintesi e richiede controlli prima dell\u2019aggiornamento delle proposte.",
+      "stale": false
+    },
+    {
+      "id": "backup_offline",
+      "title": "Backup offline",
+      "content": "Il backup offline protegge contenuti critici, verifica checksum e non invia dati a servizi di rete esterni.",
+      "stale": false
+    },
+    {
+      "id": "ricerca_vocale",
+      "title": "Ricerca vocale",
+      "content": "La ricerca vocale trascrive comandi in linguaggio naturale e normalizza termini in modo consistente tra sessioni.",
+      "stale": true
+    },
+    {
+      "id": "monitoraggio_risorse",
+      "title": "Monitoraggio risorse",
+      "content": "Il monitoraggio risorse controlla memoria, RSS, latenze e costo contesto per ogni fase di benchmark.",
+      "stale": false
+    },
+    {
+      "id": "vecchio_manifesto",
+      "title": "Vecchio manifesto",
+      "content": "Questo documento contiene regole superate e riferimenti obsoleti alla vecchia architettura di caching.",
+      "stale": true
+    },
+    {
+      "id": "documento_riconosciuto",
+      "title": "Documento riconosciuto",
+      "content": "Questo documento aggiornato contiene regole operative e firme di revisione per i test deterministici.",
+      "stale": false
+    }
+  ],
+  "cases": [
+    {
+      "seed": 20260802,
+      "query": "cache bm25 invalidazione limit row",
+      "relevant": ["cache_bm25"],
+      "hard_negatives": ["indice_semantico", "vecchio_manifesto"]
+    },
+    {
+      "seed": 20260803,
+      "query": "banca dati grafi relazioni pagine",
+      "relevant": ["banca_dati_grafi"],
+      "hard_negatives": ["diario_lavoro", "agenda_sprint"]
+    },
+    {
+      "seed": 20260804,
+      "query": "pipeline riassunto entit\u00e0 titolo sommario",
+      "relevant": ["pipeline_riassunto"],
+      "hard_negatives": ["indice_semantico", "api_rest"]
+    },
+    {
+      "seed": 20260805,
+      "query": "onboarding team checklist",
+      "relevant": ["onboarding_team"],
+      "hard_negatives": ["agenda_sprint", "modello_llm"]
+    },
+    {
+      "seed": 20260806,
+      "query": "backup locale snapshot ripristino",
+      "relevant": ["backup_locale", "backup_offline"],
+      "hard_negatives": ["query_plausibile", "metrica_precisione"]
+    },
+    {
+      "seed": 20260807,
+      "query": "sicurezza oauth token privilegio autorizzazione",
+      "relevant": ["sicurezza_oauth"],
+      "hard_negatives": ["utente_privilegiato", "modello_llm"]
+    },
+    {
+      "seed": 20260808,
+      "query": "api rest payload codice errore",
+      "relevant": ["api_rest"],
+      "hard_negatives": ["cache_bm25", "monitoraggio_risorse"]
+    },
+    {
+      "seed": 20260809,
+      "query": "indice semantico vettori tag struttura",
+      "relevant": ["indice_semantico"],
+      "hard_negatives": ["pipeline_riassunto", "progetto_alfa"]
+    },
+    {
+      "seed": 20260810,
+      "query": "query plausibile precisione recall",
+      "relevant": ["metriche_mrc", "metrica_precisione"],
+      "hard_negatives": ["query_plausibile", "vecchio_manifesto"]
+    },
+    {
+      "seed": 20260811,
+      "query": "contratti energia tariffa",
+      "relevant": ["contratti_energia"],
+      "hard_negatives": ["backup_locale", "progetto_alfa"]
+    },
+    {
+      "seed": 20260812,
+      "query": "agenda sprint revisione criteri",
+      "relevant": ["agenda_sprint"],
+      "hard_negatives": ["onboarding_team", "cronologia_patch"]
+    },
+    {
+      "seed": 20260813,
+      "query": "metrica mrr ndcg top-k",
+      "relevant": ["metriche_mrc"],
+      "hard_negatives": ["metrica_precisione", "cache_bm25"]
+    },
+    {
+      "seed": 20260814,
+      "query": "cronologia patch hash firma",
+      "relevant": ["cronologia_patch"],
+      "hard_negatives": ["backup_offline", "monitoraggio_risorse"]
+    },
+    {
+      "seed": 20260815,
+      "query": "utente privilegiato verifica multifattore",
+      "relevant": ["utente_privilegiato"],
+      "hard_negatives": ["sicurezza_oauth", "modello_llm"]
+    },
+    {
+      "seed": 20260816,
+      "query": "orchestrazione k8s risorse workload",
+      "relevant": ["orchestrazione_k8s"],
+      "hard_negatives": ["backup_offline", "monitoraggio_risorse"]
+    },
+    {
+      "seed": 20260817,
+      "query": "modello llm sintesi controllo",
+      "relevant": ["modello_llm"],
+      "hard_negatives": ["progetto_alfa", "indice_semantico"]
+    },
+    {
+      "seed": 20260818,
+      "query": "backup offline checksum rete",
+      "relevant": ["backup_offline"],
+      "hard_negatives": ["backup_locale", "cronologia_patch"]
+    },
+    {
+      "seed": 20260819,
+      "query": "monitoraggio risorse memoria rss latenza",
+      "relevant": ["monitoraggio_risorse"],
+      "hard_negatives": ["progetto_alfa", "cache_bm25"]
+    },
+    {
+      "seed": 20260820,
+      "query": "vecchio manifesto regole obsolete",
+      "relevant": ["vecchio_manifesto"],
+      "hard_negatives": ["documento_riconosciuto", "progetto_alfa"]
+    },
+    {
+      "seed": 20260821,
+      "query": "documento riconosciuto regole operative",
+      "relevant": ["documento_riconosciuto"],
+      "hard_negatives": ["vecchio_manifesto", "cronologia_patch"]
+    },
+    {
+      "seed": 20260822,
+      "query": "ricerca vocale trascrive comandi",
+      "relevant": [],
+      "hard_negatives": ["ricerca_vocale", "api_rest"],
+      "abstain_when_no_candidates": true
+    },
+    {
+      "seed": 20260823,
+      "query": "diario lavori personali",
+      "relevant": [],
+      "hard_negatives": ["diario_lavoro", "agenda_sprint"],
+      "abstain_when_no_candidates": true
+    },
+    {
+      "seed": 20260824,
+      "query": "query senza riferimenti validi",
+      "relevant": [],
+      "hard_negatives": ["progetto_alfa", "cache_bm25"],
+      "abstain_when_no_candidates": true
+    },
+    {
+      "seed": 20260825,
+      "query": "espressione sconosciuta assolutamente",
+      "relevant": [],
+      "hard_negatives": ["query_plausibile", "metrica_precisione"],
+      "abstain_when_no_candidates": true
+    }
+  ]
+}

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -119,3 +119,300 @@ def test_main_writes_machine_readable_result(
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["benchmark_schema_version"] == 1
     assert payload["environment"]["source_commit"] == "a" * 40
+
+
+def test_scorecard_manifest_validates_and_is_deterministic() -> None:
+    manifest_path = Path("tests/fixtures/bm25_hard_negative_manifest_v1.json")
+    first, first_digest = benchmark._read_manifest(manifest_path)
+    second, second_digest = benchmark._read_manifest(manifest_path)
+
+    assert first.schema_version == 1
+    assert first.dataset_id == "matryca-bm25-hard-negative-it-v1"
+    assert len(first.cases) >= 20
+    assert first_digest == second_digest
+
+    first_payload = benchmark._run_scorecard_benchmark(first, top_k=8)
+    second_payload = benchmark._run_scorecard_benchmark(first, top_k=8)
+    assert first_payload["manifest_schema_version"] == 1
+    assert first_payload["manifest_dataset_id"] == "matryca-bm25-hard-negative-it-v1"
+    assert first_payload["scorecard_fingerprint"] == second_payload["scorecard_fingerprint"]
+    assert first_payload["metrics"]["recall_at_k"] >= 0.0
+    assert first_payload["metrics"]["recall_at_k"] <= 1.0
+    assert first_payload["metrics"]["mrr"] >= 0.0
+    assert first_payload["metrics"]["mrr"] <= 1.0
+    assert first_payload["metrics"]["ndcg"] >= 0.0
+    assert first_payload["metrics"]["ndcg"] <= 1.0
+    assert first_payload["metrics"]["confidence_intervals"]["recall_at_k"]["samples"] == 1_000
+    assert (
+        first_payload["metrics"]["confidence_intervals"]["recall_at_k"]["low"]
+        <= (first_payload["metrics"]["recall_at_k"])
+        <= first_payload["metrics"]["confidence_intervals"]["recall_at_k"]["high"]
+    )
+    assert first_payload["signal_ablations"]["no_retrieval"]["recall_at_k"] == 0.0
+    assert first_payload["metrics"]["recall_at_k"] == 0.8333
+    assert first_payload["metrics"]["mrr"] == 0.7708
+    assert first_payload["metrics"]["ndcg"] == 0.7898
+    assert first_payload["metrics"]["stale"] == {
+        "hits": 10,
+        "query_rate": 0.333333,
+        "rate_per_query_position": 0.052083,
+    }
+    assert first_payload["metrics"]["contradiction"] == {
+        "hits": 9,
+        "query_rate": 0.375,
+        "rate_per_query_position": 0.046875,
+    }
+    assert first_payload["metrics"]["abstention"] == {
+        "enabled_cases": 4,
+        "passed_cases": 1,
+        "rate": 0.25,
+    }
+    assert first_payload["case_count"] == second_payload["case_count"] == 24
+    assert first_payload["case_results"] == second_payload["case_results"]
+    assert set(first_payload["measurements"]).issuperset(
+        {
+            "cache",
+            "cache_hit_ratio",
+            "latency_us",
+            "peak_rss_bytes",
+            "payload_estimate_bytes",
+            "rss_end_bytes",
+            "requests",
+            "top_k",
+            "query_cache_row_budget",
+        }
+    )
+    assert first_payload["measurements"]["cache_hit_ratio"] >= 0.0
+    assert first_payload["measurements"]["latency_us"]["median"] >= 0.0
+    assert first_payload["measurements"]["latency_us"]["p99"] >= 0.0
+    assert first_payload["measurements"]["peak_rss_bytes"] >= 0
+    assert first_payload["measurements"]["payload_estimate_bytes"] >= 0
+    assert first_payload["measurements"]["context_estimate_tokens"] >= 0
+    assert first_payload["measurements"]["estimated_model_cost_usd"] == 0.0
+    assert first_payload["measurements"]["model_cost_applicability"] == "not_applicable"
+    assert first_payload["measurements"]["rss_end_bytes"] >= 0
+    assert first_payload["measurements"]["requests"] == len(first.cases)
+    assert first_payload["measurements"]["top_k"] == 8
+    assert first_payload["measurements"]["query_cache_row_budget"] > 0
+    assert first_digest == second_digest
+
+
+def test_scorecard_main_writes_schema_and_environment_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = Path("tests/fixtures/bm25_hard_negative_manifest_v1.json")
+    output = tmp_path / "scorecard.json"
+    import hashlib
+
+    expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    monkeypatch.setattr(benchmark, "_source_commit", lambda: "b" * 40)
+
+    assert (
+        benchmark.main(
+            [
+                "--manifest-path",
+                str(manifest_path),
+                "--top-k",
+                "6",
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["benchmark_schema_version"] == 2
+    assert payload["manifest"]["digest"] == expected_digest
+    assert payload["manifest"]["schema_version"] == 1
+    assert payload["environment"]["manifest_schema_version"] == 1
+    assert payload["environment"]["source_commit"] == "b" * 40
+    assert payload["metrics"]["abstention"]["enabled_cases"] == 4
+    assert payload["metrics"]["abstention"]["rate"] >= 0.0
+    assert payload["metrics"]["abstention"]["rate"] <= 1.0
+    assert payload["evaluation_scope"] == {
+        "end_to_end_answer_evaluated": False,
+        "retrieval_only": True,
+    }
+    assert payload["measurements"]["top_k"] == 6
+    assert (
+        payload["measurements"]["cache"]["entries"] <= payload["measurements"]["cache"]["capacity"]
+    )
+
+
+def test_scorecard_uses_manifest_top_k_unless_cli_overrides_it() -> None:
+    config = benchmark.BenchmarkConfig(
+        documents=4,
+        requests=1,
+        repetitions=1,
+        warmup=1,
+        seed=1,
+        capacities=(4,),
+        multi_corpora=1,
+    )
+    manifest_path = Path("tests/fixtures/bm25_hard_negative_manifest_v1.json")
+
+    default_payload = benchmark.run_benchmark(config, manifest_path=manifest_path)
+    overridden_payload = benchmark.run_benchmark(config, manifest_path=manifest_path, top_k=3)
+
+    assert default_payload["measurements"]["top_k"] == 8
+    assert overridden_payload["measurements"]["top_k"] == 3
+
+
+def test_scorecard_metrics_detect_known_relevant_and_hard_negative_hits() -> None:
+    manifest = benchmark.ManifestPayload(
+        schema_version=1,
+        dataset_id="matryca-scorecard-unit-hits-v1",
+        description="Synthetic ranking sanity check for known hits",
+        top_k=2,
+        documents=[
+            benchmark.ManifestDocument(
+                id="doc_relevant",
+                title="Rilevante",
+                content="alpha beta gamma",
+                stale=False,
+            ),
+            benchmark.ManifestDocument(
+                id="doc_neg",
+                title="Negativo",
+                content="alpha beta delta",
+                stale=False,
+            ),
+            benchmark.ManifestDocument(
+                id="doc_other",
+                title="Nessun segnale",
+                content="zeta eta theta",
+                stale=False,
+            ),
+        ],
+        cases=[
+            benchmark.ManifestCase(
+                seed=777,
+                query="alpha",
+                relevant=["doc_relevant"],
+                hard_negatives=["doc_neg"],
+            )
+        ],
+    )
+    payload = benchmark._run_scorecard_benchmark(manifest, top_k=2)
+    first_case = payload["case_results"][0]
+    assert first_case["seed"] == 777
+    assert first_case["metrics"]["recall_at_k"] == 1.0
+    assert first_case["metrics"]["contradiction_hits"] >= 1
+    assert first_case["metrics"]["stale_hits"] == 0
+
+
+def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
+    shared_payload = {
+        "schema_version": 1,
+        "dataset_id": "matryca-scorecard-invariants-v1",
+        "description": "Invariant validation fixture",
+        "top_k": 8,
+        "documents": [
+            {"id": "doc_a", "title": "Doc A", "content": "alpha", "stale": False},
+            {"id": "doc_b", "title": "Doc B", "content": "beta", "stale": False},
+            {"id": "doc_c", "title": "Doc C", "content": "gamma", "stale": False},
+        ],
+    }
+    base_cases = [
+        {
+            "seed": 1000 + index,
+            "query": f"alpha {index}",
+            "relevant": ["doc_a"],
+            "hard_negatives": ["doc_b", "doc_c"],
+        }
+        for index in range(20)
+    ]
+
+    duplicate_seed_cases = base_cases.copy()
+    duplicate_seed_cases[1] = {
+        "seed": base_cases[0]["seed"],
+        "query": "alpha duplicate",
+        "relevant": ["doc_b"],
+        "hard_negatives": ["doc_b", "doc_c"],
+    }
+    duplicate_seed_payload = {**shared_payload, "cases": duplicate_seed_cases}
+
+    abstain_with_relevant_cases = base_cases.copy()
+    abstain_with_relevant_cases[0] = {
+        **base_cases[0],
+        "abstain_when_no_candidates": True,
+        "relevant": ["doc_a"],
+    }
+    abstain_with_relevant_payload = {**shared_payload, "cases": abstain_with_relevant_cases}
+
+    overlapping_cases = base_cases.copy()
+    overlapping_cases[0] = {**base_cases[0], "hard_negatives": ["doc_a", "doc_b"]}
+    overlapping_payload = {**shared_payload, "cases": overlapping_cases}
+
+    too_few_negatives_cases = base_cases.copy()
+    too_few_negatives_cases[0] = {**base_cases[0], "hard_negatives": ["doc_b"]}
+    too_few_negatives_payload = {**shared_payload, "cases": too_few_negatives_cases}
+
+    unknown_nested_field_cases = base_cases.copy()
+    unknown_nested_field_cases[0] = {**base_cases[0], "untracked": True}
+    unknown_nested_field_payload = {**shared_payload, "cases": unknown_nested_field_cases}
+
+    abstain_min_cases = base_cases.copy()
+    abstain_min_cases[0] = {
+        **base_cases[0],
+        "query": "alpha abstain",
+        "relevant": [],
+        "hard_negatives": ["doc_b"],
+        "abstain_when_no_candidates": True,
+    }
+    abstain_min_payload = {**shared_payload, "cases": abstain_min_cases}
+
+    duplicate_seed_path = tmp_path / "duplicate.json"
+    abstain_with_relevant_path = tmp_path / "abstain_with_relevant.json"
+    overlapping_path = tmp_path / "overlap.json"
+    too_few_negatives_path = tmp_path / "few_negatives.json"
+    unknown_nested_field_path = tmp_path / "unknown_nested_field.json"
+    abstain_min_path = tmp_path / "abstain_min.json"
+
+    duplicate_seed_path.write_text(json.dumps(duplicate_seed_payload), encoding="utf-8")
+    abstain_with_relevant_path.write_text(
+        json.dumps(abstain_with_relevant_payload), encoding="utf-8"
+    )
+    overlapping_path.write_text(json.dumps(overlapping_payload), encoding="utf-8")
+    too_few_negatives_path.write_text(json.dumps(too_few_negatives_payload), encoding="utf-8")
+    unknown_nested_field_path.write_text(json.dumps(unknown_nested_field_payload), encoding="utf-8")
+    abstain_min_path.write_text(json.dumps(abstain_min_payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate case seed"):
+        benchmark._read_manifest(duplicate_seed_path)
+    with pytest.raises(ValueError, match="abstention mode"):
+        benchmark._read_manifest(abstain_with_relevant_path)
+    with pytest.raises(ValueError, match="must not overlap"):
+        benchmark._read_manifest(overlapping_path)
+    with pytest.raises(ValueError, match="must define at least two hard-negative labels"):
+        benchmark._read_manifest(too_few_negatives_path)
+    with pytest.raises(ValueError, match="must define at least two hard-negatives"):
+        benchmark._read_manifest(abstain_min_path)
+    with pytest.raises(ValueError, match="untracked"):
+        benchmark._read_manifest(unknown_nested_field_path)
+
+
+def test_manifest_mode_does_not_touch_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import socket
+
+    config = benchmark.BenchmarkConfig(
+        documents=4,
+        requests=1,
+        repetitions=1,
+        warmup=1,
+        seed=1,
+        capacities=(4,),
+        multi_corpora=1,
+    )
+    manifest_path = Path("tests/fixtures/bm25_hard_negative_manifest_v1.json")
+
+    def reject_network(*_args: object, **_kwargs: object) -> list[object]:
+        raise AssertionError("Unexpected network call in scorecard benchmark")
+
+    monkeypatch.setattr(socket, "gethostbyname", reject_network)
+    monkeypatch.setattr(socket, "create_connection", reject_network)
+
+    benchmark.run_benchmark(config, manifest_path=manifest_path, top_k=8)


### PR DESCRIPTION
## Summary
- Add a versioned synthetic Italian hard-negative retrieval scorecard with deterministic ranking evidence.
- Report retrieval-only metrics, bootstrap confidence intervals, an explicit no-retrieval ablation, and reproducible artifact metadata.
- Preserve clear boundaries for later public-suite adapters and end-to-end answer evaluation.

## Validation
- Focused scorecard tests (10 passed)
- Ruff
- Documentation knowledge check

Refs #448