### PR TITLE
feat(memory): add gated canonical recall (#186)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -496,10 +496,12 @@ MATRYCA_EMBEDDING_MODEL=text-embedding-3-small
 # -----------------------------------------------------------------------------
 # v2.0 Shadow DB — biological memory graph (Epic #99, shadow feature)
 # -----------------------------------------------------------------------------
-# Nacre-inspired decay/reinforcement layer in shadow.sqlite. src/memory/config.py
+# Enables the P0 provider-free canonical recall envelope. src/memory/config.py
 # Default (code): false
 # Template: false
-# Range / notes: opt-in alpha; no runtime effect until Phase A consolidation ships
+# Range / notes: opt-in. `search_graph(recall)` remains graph-immutable and uses only a READY,
+# query-only Shadow FTS cache. Disabled, stale, empty-unproven, or unsupported-filter requests
+# return an explicit structured state; they never fall back to another retrieval method.
 MATRYCA_MEMORY_GRAPH_ENABLED=false
 
 # Park over-budget pages instead of failing the whole rebuild. src/shadow/config.py

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -228,6 +228,7 @@ Shadow DB is a **derived read cache outside `LOGSEQ_GRAPH_PATH`**. It does **not
 |---------|---------|-------------|
 | `MATRYCA_READ_ONLY` | `false` | Blocks every Matryca write, lock, temp file, or support artifact inside the Logseq graph; reads remain available |
 | `MATRYCA_SHADOW_DB_ENABLED` | `true` | Maintains the external cache; `search_graph(bm25)` prefers FTS5 and `read_graph_data(subtree)` prefers recursive CTE only while `READY`; **always falls back** to generational BM25 / parser+AST when disabled or non-ready |
+| `MATRYCA_MEMORY_GRAPH_ENABLED` | `false` | Enables the P0 `search_graph(recall)` envelope only. It is provider-free and graph-immutable: disabled, stale, empty-unproven, unavailable, or unsupported-filter requests return an explicit structured state and never fall back, rebuild, write, or call a model. |
 | `MATRYCA_SHADOW_QUARANTINE_ENABLED` | `true` | Park over-budget pages instead of failing the whole rebuild (beta.1); `false` restores strict mode |
 | `MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` | `10` | Cross-process advisory flock wait for incremental sync/delete (alpha.1) |
 | `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` | `120` | Cross-process advisory flock wait for full rebuild (alpha.1) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - **Evidence-first agentic-memory programme** — sequence v2.1+ delivery through governed evidence, deterministic canonical recall, reproducible benchmarks, human-governed curation, and derived-only Shadow state before typed decay, procedural memory, or opt-in proactivity.
 - **BM25 scorecard benchmark schema** — add manifest-driven synthetic Italian hard-negative scorecard mode (`--manifest-path`) with deterministic Recall@K, MRR, nDCG, stale/contradiction, abstention, and manifest digest/environment signatures for reproducible ranking evidence without runtime behavior changes.
 
+### Added
+
+- **Gated canonical recall (#186)** — add the provider-free, graph-immutable `search_graph(method="recall")` P0 envelope with generation-bound UUID/hash references, deterministic reusable fingerprints, bounded per-turn retrieval, and explicit disabled/unavailable states; it uses only a fresh query-only Shadow FTS cache and never falls back, rebuilds, writes, or calls a model.
+
 ### Fixed
 
 - **Gate B RC2 artifact binding** — bind fresh dual-profile qualification to the exact installed `2.0.0rc2` public wheel instead of rejecting it through the historical RC1 package identity.

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 <!-- GENERATED — do not edit -->
 
-<!-- build-hash: 8aba43147560d95c7cbb6c856f75e4fe9beec99215dbc8435cbd5acfb43a86b9 -->
+<!-- build-hash: c5d8b1c3c0a303c28684aab0a26df84e49f75699b96f25fd5ca863a3cdd8cf6c -->
 
 <!-- package-version: v2.0.0rc2 -->
 
@@ -149,7 +149,7 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 | Tool | Discriminator | Purpose |
 |------|---------------|---------|
 | `read_graph_data` | `target_type` | Read pages, L1 memory, **bootstrap_status**, block excerpts, **subtree** (heading-filtered), structural hops, dashboard, X-Ray aliases |
-| `search_graph` | `method` | BM25, regex, unlinked mentions, journal tasks, entity resolution (`resolve_entity`) |
+| `search_graph` | `method` | BM25, regex, unlinked mentions, journal tasks, entity resolution, gated canonical recall (`recall`) |
 | `mutate_graph` | `action` | Write outlines, edit properties, append journal, inject queries |
 | `refactor_blocks` | `action` | Split wall bullets, reparent siblings, generate flashcards |
 | `run_linter` | `linter_name` | Tag unification preview, block-ref integrity, wiki schema scan |
@@ -157,7 +157,9 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 | `ingest_document` | _(none — `source_name`, `raw_text`)_ | Atomic external markdown ingestion → ingest page + `LOG` + `GLOSSARY` |
 | `import_tana` | _(none — `export_path`, `dry_run`)_ | Tana workspace JSON export → `Tana/` pages + journals; **dry-run default** |
 
-**Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with `target_type="memory"`.
+**Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with
+`target_type="memory"` and disabled `search_graph(method="recall")`, which returns its
+explicit feature-gate state before graph setup.
 
 `read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.
 
@@ -168,6 +170,15 @@ Markdown/generational BM25 fallback and appends one content-free `Shadow fallbac
 code: `page_untracked`, `source_missing`, `source_changed`, or
 `empty_result_unproven`. Treat the fallback output as authoritative; do not retry the
 cache path.
+
+`search_graph(method="recall")` is an opt-in P0 canonical envelope, not a BM25 alias.
+Set `MATRYCA_MEMORY_GRAPH_ENABLED=true`, then pass text or
+`{"query":"...", "limit":15, "filters":{}}`. It returns a provider-free,
+content-free `RecallBundle` with ordered block UUID/hash references, a generation-bound
+fingerprint, and a no-progress signature. It uses only a READY query-only Shadow FTS cache.
+When disabled, unavailable, stale, empty-unproven, or given unsupported filters, it returns
+an explicit structured state and never falls back, rebuilds Shadow, reads via a model, or
+writes the graph.
 
 ## Project context
 
@@ -386,6 +397,18 @@ rows, and empty cached results whose freshness cannot be proved, route to
 generational BM25 and append a content-free `Shadow fallback` code. The closed codes
 are `page_untracked`, `source_missing`, `source_changed`, and
 `empty_result_unproven`.
+
+```json
+{ "method": "recall", "query": "redis cache invalidation" }
+```
+
+P0 canonical recall is disabled by default. Set `MATRYCA_MEMORY_GRAPH_ENABLED=true` to
+receive a structured, provider-free envelope with ordered block UUID/content-hash references,
+the Shadow generation, a deterministic fingerprint, and a no-progress signature. It accepts
+`{"query":"...", "limit":15, "filters":{}}`; the limit is bounded to 50 per call.
+It uses a READY query-only Shadow FTS cache and validates every returned source page. It never
+falls back to BM25/semantic, rebuilds Shadow, calls a model, or writes the graph: disabled,
+unavailable, stale, empty-unproven, and unsupported-filter cases are explicit states.
 
 ```json
 { "method": "regex", "query": "TODO|LATER" }

--- a/docs/openspec/README.md
+++ b/docs/openspec/README.md
@@ -31,7 +31,7 @@ Trimmed behavioral specs aligned with [MehmetGoekce/llm-wiki](https://github.com
 | [`../roadmaps/ROADMAP_V2_PREPARATION.md`](../roadmaps/ROADMAP_V2_PREPARATION.md) | v2 sequencing, contribution guidance, and milestone history. |
 | [`../roadmaps/ROADMAP_V2_SHADOW_DB.md`](../roadmaps/ROADMAP_V2_SHADOW_DB.md) | Shadow read-path sequencing and completed implementation history. |
 | [`../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md`](../roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md) | Nacre-inspired decay/recall/procedure memory |
-| [`biological-memory.md`](biological-memory.md) | Planned env vars, `search_graph(method=recall)`, Safe-Sync contract |
+| [`biological-memory.md`](biological-memory.md) | P0 gated canonical recall, later memory phases, and Safe-Sync contract |
 | [`evidence-archive.md`](evidence-archive.md) | P0 external append-only provenance archive and privacy/durability contract |
 | [`../v1.8-SOFTWARE-EDGE-PLAN.md`](../v1.8-SOFTWARE-EDGE-PLAN.md) | CPU sandbox, frozen KV prefix, adaptive LLM, mmap reads. |
 | [`../v1.8-OPTIMIZATION-PLAN.md`](../v1.8-OPTIMIZATION-PLAN.md) | v1.8 operator env vars, verification matrix, load testing. |

--- a/docs/openspec/agent/mcp-tools.md
+++ b/docs/openspec/agent/mcp-tools.md
@@ -5,7 +5,7 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 | Tool | Discriminator | Purpose |
 |------|---------------|---------|
 | `read_graph_data` | `target_type` | Read pages, L1 memory, **bootstrap_status**, block excerpts, **subtree** (heading-filtered), structural hops, dashboard, X-Ray aliases |
-| `search_graph` | `method` | BM25, regex, unlinked mentions, journal tasks, entity resolution (`resolve_entity`) |
+| `search_graph` | `method` | BM25, regex, unlinked mentions, journal tasks, entity resolution, gated canonical recall (`recall`) |
 | `mutate_graph` | `action` | Write outlines, edit properties, append journal, inject queries |
 | `refactor_blocks` | `action` | Split wall bullets, reparent siblings, generate flashcards |
 | `run_linter` | `linter_name` | Tag unification preview, block-ref integrity, wiki schema scan |
@@ -13,7 +13,9 @@ Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, an
 | `ingest_document` | _(none — `source_name`, `raw_text`)_ | Atomic external markdown ingestion → ingest page + `LOG` + `GLOSSARY` |
 | `import_tana` | _(none — `export_path`, `dry_run`)_ | Tana workspace JSON export → `Tana/` pages + journals; **dry-run default** |
 
-**Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with `target_type="memory"`.
+**Requires:** `LOGSEQ_GRAPH_PATH` for every operation except `read_graph_data` with
+`target_type="memory"` and disabled `search_graph(method="recall")`, which returns its
+explicit feature-gate state before graph setup.
 
 `read_graph_data(target_type="xray_page")` persists its alias map at graph root in normal mode. Under Strict Read Only, it uses the private per-graph external runtime cache so the read remains graph-immutable while aliases stay available to later operations.
 
@@ -24,3 +26,12 @@ Markdown/generational BM25 fallback and appends one content-free `Shadow fallbac
 code: `page_untracked`, `source_missing`, `source_changed`, or
 `empty_result_unproven`. Treat the fallback output as authoritative; do not retry the
 cache path.
+
+`search_graph(method="recall")` is an opt-in P0 canonical envelope, not a BM25 alias.
+Set `MATRYCA_MEMORY_GRAPH_ENABLED=true`, then pass text or
+`{"query":"...", "limit":15, "filters":{}}`. It returns a provider-free,
+content-free `RecallBundle` with ordered block UUID/hash references, a generation-bound
+fingerprint, and a no-progress signature. It uses only a READY query-only Shadow FTS cache.
+When disabled, unavailable, stale, empty-unproven, or given unsupported filters, it returns
+an explicit structured state and never falls back, rebuilds Shadow, reads via a model, or
+writes the graph.

--- a/docs/openspec/agent/tool-reference.md
+++ b/docs/openspec/agent/tool-reference.md
@@ -94,6 +94,18 @@ are `page_untracked`, `source_missing`, `source_changed`, and
 `empty_result_unproven`.
 
 ```json
+{ "method": "recall", "query": "redis cache invalidation" }
+```
+
+P0 canonical recall is disabled by default. Set `MATRYCA_MEMORY_GRAPH_ENABLED=true` to
+receive a structured, provider-free envelope with ordered block UUID/content-hash references,
+the Shadow generation, a deterministic fingerprint, and a no-progress signature. It accepts
+`{"query":"...", "limit":15, "filters":{}}`; the limit is bounded to 50 per call.
+It uses a READY query-only Shadow FTS cache and validates every returned source page. It never
+falls back to BM25/semantic, rebuilds Shadow, calls a model, or writes the graph: disabled,
+unavailable, stale, empty-unproven, and unsupported-filter cases are explicit states.
+
+```json
 { "method": "regex", "query": "TODO|LATER" }
 ```
 

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -1,6 +1,8 @@
-# Biological memory layer — OpenSpec (projection contract, planned v2.1+)
+# Biological memory layer — OpenSpec (projection contract, v2.1+)
 
-**Status:** planned for v2.1+ — no memory read/write path is shipped in `main`; schema and scaffolds remain proposal-stage
+**Status:** P0 canonical recall is shipped behind a disabled-by-default feature gate. It is a
+read-only, provider-free projection over the existing Shadow FTS cache; no memory write,
+decay, consolidation, provider call, or autonomous behavior is shipped in this surface.
 
 **Historical architecture context:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
 
@@ -52,7 +54,7 @@ This OpenSpec is a projection contract that keeps external expectations aligned 
 
 | Variable | Contract status | Role |
 | --- | --- | --- |
-| `MATRYCA_MEMORY_GRAPH_ENABLED` | Not yet public contract | Future gate for derived projection operations only; it never authorizes canonical writes |
+| `MATRYCA_MEMORY_GRAPH_ENABLED` | P0 public gate, default `false` | Enables `search_graph(method="recall")` only; it never authorizes canonical writes |
 
 When publicly exposed, document in `.env.example` under **Advanced / high impact** with rollout and fallback policy.
 
@@ -67,7 +69,7 @@ When publicly exposed, document in `.env.example` under **Advanced / high impact
 
 | Existing surface | Planned extension |
 | --- | --- |
-| `search_graph(...)` | Add recall-focused method and scoring envelope after P0 acceptance |
+| `search_graph(method="recall")` | Canonical `RecallBundle`: deterministic block UUID/hash refs, generation-bound fingerprint, volatile telemetry outside the reusable prefix, and explicit unavailable states |
 | `store_fact` | Extend to support proposal and procedural pathways after P2/P3 acceptance |
 
 ## Evidence and benchmark policy
@@ -77,6 +79,26 @@ When publicly exposed, document in `.env.example` under **Advanced / high impact
 - Letta Evals, Mem0 memory-benchmarks, and Graphiti are treated as design/reference harness material.
 - No best/SOTA/world-leading claim is made before reproducible evidence with provenance.
 - Every claim must include task set, corpus/version, seed/config, and decision label.
+
+## P0 canonical recall
+
+`search_graph(method="recall")` accepts plain text or JSON
+`{"query":"...", "limit":15, "filters":{}}`. It is disabled unless
+`MATRYCA_MEMORY_GRAPH_ENABLED=true`. The result is a structured `RecallBundle` that binds
+the schema, Shadow generation, conservatively normalized query, method, filters, bounded
+per-turn limit, FTS index version, retrieval-instruction version, and ordered
+`(block_uuid, content_hash)` references. Scores and latency are telemetry only and never
+affect the reusable fingerprint.
+
+The P0 retrieval path is deliberately narrow: it reads a `READY` Shadow DB through
+`mode=ro` / `PRAGMA query_only`, validates every returned source page against canonical
+Markdown, and never initializes, rebuilds, writes, calls a model, or falls back to
+page-level BM25. Disabled, missing graph, invalid request, unsupported filter, unavailable
+Shadow cache, stale source, and unproven empty results all return explicit content-free
+states. Consumers compare `no_progress_signature` before retrying the same expansion.
+
+P0 is not hybrid retrieval: semantic, entity, and graph-signal composition belong to P1
+after the governed #447 evidence contracts and #448 scorecard baseline are accepted.
 
 ## Safe-Sync and mutation constraints
 

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -3,7 +3,9 @@
 **Historical architecture context:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)
 
 **Active delivery tracker:** [#178 — Coordinate v2.1 memory, Safe-Sync, and import programme](https://github.com/MarcoPorcellato/matryca-plumber/issues/178)
-**Status:** planned for v2.1+, scaffolded components exist in [`src/shadow/schema.py`](../../src/shadow/schema.py) and [`src/memory/decay.py`](../../src/memory/decay.py); no memory read/write path is shipped.
+**Status:** P0 ships only a disabled-by-default, provider-free canonical recall envelope over a
+fresh query-only Shadow FTS cache. No memory write, decay, consolidation, remote provider, or
+autonomous behavior is shipped; scaffolded later-phase components remain roadmap-only.
 
 **Canonical surface:** this roadmap in `docs/roadmaps`
 

--- a/llms.txt
+++ b/llms.txt
@@ -228,6 +228,7 @@ Shadow DB is a **derived read cache outside `LOGSEQ_GRAPH_PATH`**. It does **not
 |---------|---------|-------------|
 | `MATRYCA_READ_ONLY` | `false` | Blocks every Matryca write, lock, temp file, or support artifact inside the Logseq graph; reads remain available |
 | `MATRYCA_SHADOW_DB_ENABLED` | `true` | Maintains the external cache; `search_graph(bm25)` prefers FTS5 and `read_graph_data(subtree)` prefers recursive CTE only while `READY`; **always falls back** to generational BM25 / parser+AST when disabled or non-ready |
+| `MATRYCA_MEMORY_GRAPH_ENABLED` | `false` | Enables the P0 `search_graph(recall)` envelope only. It is provider-free and graph-immutable: disabled, stale, empty-unproven, unavailable, or unsupported-filter requests return an explicit structured state and never fall back, rebuild, write, or call a model. |
 | `MATRYCA_SHADOW_QUARANTINE_ENABLED` | `true` | Park over-budget pages instead of failing the whole rebuild (beta.1); `false` restores strict mode |
 | `MATRYCA_SHADOW_WRITER_LOCK_TIMEOUT_S` | `10` | Cross-process advisory flock wait for incremental sync/delete (alpha.1) |
 | `MATRYCA_SHADOW_REBUILD_LOCK_TIMEOUT_S` | `120` | Cross-process advisory flock wait for full rebuild (alpha.1) |

--- a/src/agent/dispatch_search_handlers.py
+++ b/src/agent/dispatch_search_handlers.py
@@ -52,6 +52,17 @@ async def handle_search_bm25(graph_path: str, query: str) -> str:
     return await asyncio.to_thread(_run)
 
 
+async def handle_search_recall(graph_path: str, query: str) -> dict[str, Any]:
+    """Return the gated, provider-free canonical recall envelope (#186)."""
+
+    def _run() -> dict[str, Any]:
+        from ..memory.recall import recall_from_existing_retrieval
+
+        return recall_from_existing_retrieval(graph_path, query).model_dump(mode="json")
+
+    return await asyncio.to_thread(_run)
+
+
 async def handle_search_semantic(graph_path: str, query: str) -> str:
     sem_opts = parse_optional_json_query(query)
     sem_query = str(sem_opts.get("query", sem_opts.get("keyword", query))).strip()
@@ -202,6 +213,7 @@ async def handle_search_journal_tasks(graph_path: str, query: str) -> str | dict
 
 _SEARCH_HANDLERS: dict[SearchGraphMethod, SearchHandler] = {
     "bm25": handle_search_bm25,
+    "recall": handle_search_recall,
     "semantic": handle_search_semantic,
     "regex": handle_search_regex,
     "unlinked_mentions": handle_search_unlinked_mentions,
@@ -216,6 +228,10 @@ async def dispatch_search_target(
 ) -> str | dict[str, Any]:
     """Route ``search_graph`` by ``method``."""
     graph_path = graph_path_from_env()
+    if method == "recall":
+        # The handler checks the gate before resolving or reading a graph. In
+        # disabled mode this is an explicit contract response, never BM25 fallback.
+        return await handle_search_recall(graph_path, query)
     if not graph_path:
         if method == "journal_tasks":
             return {
@@ -235,6 +251,7 @@ async def dispatch_search_target(
 __all__ = [
     "dispatch_search_target",
     "handle_search_bm25",
+    "handle_search_recall",
     "handle_search_journal_tasks",
     "handle_search_regex",
     "handle_search_resolve_entity",

--- a/src/agent/graph_tool_helpers.py
+++ b/src/agent/graph_tool_helpers.py
@@ -39,6 +39,7 @@ SearchGraphMethod = Literal[
     "unlinked_mentions",
     "journal_tasks",
     "resolve_entity",
+    "recall",
 ]
 MutateGraphAction = Literal[
     "write_outline", "edit_property", "append_journal", "inject_query", "generate_moc"

--- a/src/agent/mcp_server.py
+++ b/src/agent/mcp_server.py
@@ -193,10 +193,15 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         **``method=resolve_entity``** — ``query`` = page title or ``alias::`` name. Resolves
         collisions, lists existing aliases, and reports whether a new entity page is safe to create.
 
-        PREREQUISITE: Check ``bootstrap_status`` and scan ``[[Matryca Master Index]]`` via
-        ``read_graph_data(page)`` first. If index unavailable, pause and present fallback options
-        (Local Daemon, Blind Search, Cloud Indexing) to the operator for authorization before
-        blind ``bm25`` discovery.
+        **``method=recall``** — gated, provider-free canonical block-reference envelope. ``query``
+        is text or JSON ``{"query":"...", "limit":15, "filters":{}}``. Disabled by default;
+        it returns an explicit structured state and never falls back to another search method.
+
+        PREREQUISITE for graph-search methods other than ``recall``: Check ``bootstrap_status``
+        and scan ``[[Matryca Master Index]]`` via ``read_graph_data(page)`` first. If index is
+        unavailable, pause and present fallback options (Local Daemon, Blind Search, Cloud
+        Indexing) to the operator for authorization before blind ``bm25`` discovery. Disabled
+        ``recall`` returns its explicit feature-gate state before graph setup.
         """
         if method == "bm25":
             await mcp_tool_info(

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -44,6 +44,7 @@ from ..graph.safety.write_policy import (
     is_graph_read_only,
 )
 from ..graph.service_manager import manage_matryca_service
+from ..memory.config import memory_graph_enabled
 from ..utils.runtime_bootstrap import try_prepare_matryca_runtime_from_env
 from ..utils.secret_redaction import redact_secrets_in_text
 from .ui_server import run_ui_server
@@ -65,6 +66,7 @@ SEARCH_METHODS: tuple[SearchGraphMethod, ...] = (
     "unlinked_mentions",
     "journal_tasks",
     "resolve_entity",
+    "recall",
 )
 MUTATE_ACTIONS: tuple[MutateGraphAction, ...] = (
     "write_outline",
@@ -463,11 +465,12 @@ async def run_cli(args: argparse.Namespace) -> int:
 def _cli_eager_graph(args: argparse.Namespace) -> bool:
     """Return whether this CLI invocation should warm the in-memory AST index.
 
-    ``search bm25`` scores raw Markdown / Shadow FTS and must not pay for
-    ``GraphAstCache.bootstrap`` (A-CLI-01 / #297). Other graph commands keep
-    eager load so first-read latency stays predictable.
+    ``search bm25`` and gated ``search recall`` use read-only lexical Shadow
+    paths and must not pay for ``GraphAstCache.bootstrap`` (A-CLI-01 / #297).
+    Keeping recall lazy also lets its disabled gate respond before graph setup.
+    Other graph commands keep eager load so first-read latency stays predictable.
     """
-    return not (args.command == "search" and getattr(args, "method", None) == "bm25")
+    return not (args.command == "search" and getattr(args, "method", None) in {"bm25", "recall"})
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -476,12 +479,15 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     ui_only = args.command == "plumber" and args.plumber_action in {"status", "ui"}
     skip_eager_bootstrap = args.command == "plumber" and args.plumber_action == "start"
+    disabled_recall = (
+        args.command == "search" and args.method == "recall" and not memory_graph_enabled()
+    )
     try:
         _reject_read_only_cli_mutation(args)
     except GraphReadOnlyError as exc:
         _emit_error(f"{exc.code}: {exc}")
         raise SystemExit(1) from exc
-    if not ui_only and not skip_eager_bootstrap:
+    if not ui_only and not skip_eager_bootstrap and not disabled_recall:
         try_prepare_matryca_runtime_from_env(eager_graph=_cli_eager_graph(args))
     if ui_only:
         try:

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -11,6 +11,7 @@ from .decay import (
     days_between,
     half_life_days,
 )
+from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
     "DEFAULT_DECAY_RATE",
@@ -22,4 +23,6 @@ __all__ = [
     "days_between",
     "half_life_days",
     "memory_graph_enabled",
+    "RecallBundle",
+    "recall_from_existing_retrieval",
 ]

--- a/src/memory/recall.py
+++ b/src/memory/recall.py
@@ -1,0 +1,299 @@
+"""Deterministic, read-only canonical recall envelope for Memory P0 (#186)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..graph.path_sandbox import PathTraversalSecurityError, resolved_graph_root
+from ..shadow.connection import open_shadow_db_query_only
+from ..shadow.freshness import ShadowFreshnessError, ensure_shadow_page_fresh
+from ..shadow.fts_validation import (
+    MAX_FTS_MATCH_QUERY_CHARS,
+    FtsQueryValidationError,
+    validate_fts_match_query,
+)
+from ..shadow.health import ShadowHealthState, resolve_shadow_health
+from ..shadow.meta import META_GENERATION, get_meta
+from ..shadow.query import BlockHit, search_blocks_fts
+from ..shadow.schema import SHADOW_SCHEMA_VERSION
+from .config import memory_graph_enabled
+
+RECALL_SCHEMA_VERSION = "recall-bundle.v1"
+RECALL_INSTRUCTION_VERSION = "recall-v1"
+RECALL_INDEX_VERSION = f"shadow-fts5/schema-{SHADOW_SCHEMA_VERSION}"
+MAX_RECALL_RESULTS_PER_TURN = 50
+MAX_RECALL_REQUEST_CHARS = 4_096
+MAX_RECALL_FILTER_ENTRIES = 16
+MAX_RECALL_FILTER_KEY_CHARS = 128
+MAX_RECALL_FILTER_VALUE_CHARS = 256
+
+RecallState = Literal["completed", "disabled", "unavailable"]
+
+
+class RecallResultRef(BaseModel):
+    """Content-free identity of one recalled canonical block."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    block_uuid: str = Field(min_length=1)
+    content_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class RecallVolatileMetadata(BaseModel):
+    """Observability only; excluded from the reusable fingerprint prefix."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rank_scores: tuple[float, ...] = ()
+    elapsed_ms: float = Field(ge=0)
+
+
+class RecallBundle(BaseModel):
+    """Provider-neutral result envelope with a deterministic cache identity."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: str = RECALL_SCHEMA_VERSION
+    state: RecallState
+    code: str
+    graph_generation: int | None = Field(default=None, ge=0)
+    normalized_query: str
+    method: Literal["recall"] = "recall"
+    filters: dict[str, Any] = Field(default_factory=dict)
+    limit: int = Field(ge=1, le=MAX_RECALL_RESULTS_PER_TURN)
+    embedding_index_version: str = RECALL_INDEX_VERSION
+    retrieval_instruction_version: str = RECALL_INSTRUCTION_VERSION
+    results: tuple[RecallResultRef, ...] = ()
+    fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    no_progress_signature: str = Field(pattern=r"^[0-9a-f]{64}$")
+    per_turn_expansion_budget: int = Field(ge=1, le=MAX_RECALL_RESULTS_PER_TURN)
+    volatile: RecallVolatileMetadata | None = None
+
+    def cache_stable_prefix(self) -> dict[str, Any]:
+        """Return the exact content-addressed fields that define reusable recall."""
+        return {
+            "schema_version": self.schema_version,
+            "state": self.state,
+            "code": self.code,
+            "graph_generation": self.graph_generation,
+            "normalized_query": self.normalized_query,
+            "method": self.method,
+            "filters": self.filters,
+            "limit": self.limit,
+            "embedding_index_version": self.embedding_index_version,
+            "retrieval_instruction_version": self.retrieval_instruction_version,
+            "results": [item.model_dump(mode="json") for item in self.results],
+            "per_turn_expansion_budget": self.per_turn_expansion_budget,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RecallRequest:
+    """Validated request controls that must bind the recall fingerprint."""
+
+    normalized_query: str
+    filters: dict[str, Any]
+    limit: int
+
+
+def normalize_recall_query(query: str) -> str:
+    """Conservatively normalize only whitespace; FTS syntax and case are preserved."""
+    return " ".join(query.split())
+
+
+def _digest(value: object) -> str:
+    payload = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _bundle(
+    *,
+    state: RecallState,
+    code: str,
+    request: RecallRequest,
+    graph_generation: int | None = None,
+    results: tuple[RecallResultRef, ...] = (),
+    volatile: RecallVolatileMetadata | None = None,
+) -> RecallBundle:
+    stable = {
+        "schema_version": RECALL_SCHEMA_VERSION,
+        "state": state,
+        "code": code,
+        "graph_generation": graph_generation,
+        "normalized_query": request.normalized_query,
+        "method": "recall",
+        "filters": request.filters,
+        "limit": request.limit,
+        "embedding_index_version": RECALL_INDEX_VERSION,
+        "retrieval_instruction_version": RECALL_INSTRUCTION_VERSION,
+        "results": [item.model_dump(mode="json") for item in results],
+        "per_turn_expansion_budget": MAX_RECALL_RESULTS_PER_TURN,
+    }
+    fingerprint = _digest(stable)
+    return RecallBundle(
+        schema_version=RECALL_SCHEMA_VERSION,
+        state=state,
+        code=code,
+        graph_generation=graph_generation,
+        normalized_query=request.normalized_query,
+        filters=request.filters,
+        limit=request.limit,
+        embedding_index_version=RECALL_INDEX_VERSION,
+        retrieval_instruction_version=RECALL_INSTRUCTION_VERSION,
+        results=results,
+        fingerprint=fingerprint,
+        no_progress_signature=_digest(
+            {"protocol": "recall-no-progress.v1", "fingerprint": fingerprint}
+        ),
+        per_turn_expansion_budget=MAX_RECALL_RESULTS_PER_TURN,
+        volatile=volatile,
+    )
+
+
+def _request_from_query(query: str) -> RecallRequest:
+    raw = query.strip()
+    if len(raw) > MAX_RECALL_REQUEST_CHARS:
+        raise ValueError("recall request exceeds the bounded input size")
+    options: dict[str, Any] = {}
+    if raw.startswith("{"):
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise TypeError("recall query JSON must be an object")
+        options = parsed
+    text = str(options.get("query", options.get("keyword", raw))).strip()
+    filters = options.get("filters", {})
+    if not isinstance(filters, dict):
+        raise TypeError("recall filters must be an object")
+    if len(filters) > MAX_RECALL_FILTER_ENTRIES:
+        raise ValueError("recall filters exceed the bounded entry count")
+    for key, value in filters.items():
+        if not isinstance(key, str) or len(key) > MAX_RECALL_FILTER_KEY_CHARS:
+            raise TypeError("recall filter keys must be bounded strings")
+        if not isinstance(value, (str, int, bool)) and value is not None:
+            raise TypeError("recall filter values must be scalar")
+        if isinstance(value, str) and len(value) > MAX_RECALL_FILTER_VALUE_CHARS:
+            raise ValueError("recall filter values must be bounded strings")
+    raw_limit = options.get("limit", 15)
+    if type(raw_limit) is not int:
+        raise TypeError("recall limit must be an integer")
+    limit = raw_limit
+    if not 1 <= limit <= MAX_RECALL_RESULTS_PER_TURN:
+        raise ValueError(f"recall limit must be between 1 and {MAX_RECALL_RESULTS_PER_TURN}")
+    normalized_query = normalize_recall_query(text)
+    if len(normalized_query) > MAX_FTS_MATCH_QUERY_CHARS:
+        raise ValueError("recall query exceeds the FTS input limit")
+    return RecallRequest(normalized_query=normalized_query, filters=filters, limit=limit)
+
+
+def _safe_request(query: str) -> RecallRequest:
+    """Produce a bounded identity even when a disabled request is malformed."""
+    return RecallRequest(
+        normalized_query=normalize_recall_query(query[:MAX_RECALL_REQUEST_CHARS]),
+        filters={},
+        limit=15,
+    )
+
+
+def _require_generation(connection: sqlite3.Connection) -> int:
+    """Read a persisted generation without silently repairing malformed metadata."""
+    raw = get_meta(connection, META_GENERATION)
+    if raw is None or not raw.isdecimal():
+        raise ValueError("recall generation metadata is invalid")
+    return int(raw)
+
+
+def _unavailable(code: str, request: RecallRequest) -> RecallBundle:
+    return _bundle(state="unavailable", code=code, request=request)
+
+
+def _completed_bundle(
+    request: RecallRequest,
+    generation: int,
+    hits: list[BlockHit],
+    elapsed_ms: float,
+) -> RecallBundle:
+    ordered = sorted(hits, key=lambda hit: (hit.rank, hit.block_uuid))
+    refs = tuple(
+        RecallResultRef(
+            block_uuid=hit.block_uuid,
+            content_hash=hashlib.sha256(hit.content.encode("utf-8")).hexdigest(),
+        )
+        for hit in ordered
+    )
+    return _bundle(
+        state="completed",
+        code="recall_completed",
+        request=request,
+        graph_generation=generation,
+        results=refs,
+        volatile=RecallVolatileMetadata(
+            rank_scores=tuple(hit.rank for hit in ordered),
+            elapsed_ms=elapsed_ms,
+        ),
+    )
+
+
+def recall_from_existing_retrieval(graph_path: str, query: str = "") -> RecallBundle:
+    """Build a gated canonical envelope from the existing read-only Shadow FTS path.
+
+    P0 deliberately never changes retrieval method: an unavailable Shadow cache,
+    stale source row, empty result, or unsupported filter returns an explicit state
+    instead of falling back to page-level BM25 or a provider/model path.
+    """
+    if not memory_graph_enabled():
+        return _bundle(state="disabled", code="recall_disabled", request=_safe_request(query))
+    try:
+        request = _request_from_query(query)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return _unavailable("recall_invalid_request", _safe_request(query))
+    if not request.normalized_query:
+        return _unavailable("recall_query_required", request)
+    if request.filters:
+        return _unavailable("recall_filters_unsupported", request)
+    if not graph_path.strip():
+        return _unavailable("recall_graph_unavailable", request)
+    try:
+        root = resolved_graph_root(graph_path)
+        if resolve_shadow_health(root) is not ShadowHealthState.READY:
+            return _unavailable("recall_shadow_unavailable", request)
+        validate_fts_match_query(request.normalized_query)
+        started = time.perf_counter()
+        conn = open_shadow_db_query_only(root)
+        try:
+            generation = _require_generation(conn)
+            hits = search_blocks_fts(conn, request.normalized_query, limit=request.limit)
+            if not hits:
+                return _unavailable("recall_empty_result_unproven", request)
+            for page_id in sorted({hit.page_id for hit in hits}):
+                ensure_shadow_page_fresh(conn, root, page_id=page_id)
+        finally:
+            conn.close()
+    except FtsQueryValidationError:
+        return _unavailable("recall_query_invalid", request)
+    except (ShadowFreshnessError, ValueError):
+        return _unavailable("recall_freshness_unproven", request)
+    except (OSError, RuntimeError, sqlite3.Error, PathTraversalSecurityError):
+        return _unavailable("recall_shadow_unavailable", request)
+    return _completed_bundle(request, generation, hits, (time.perf_counter() - started) * 1_000)
+
+
+__all__ = [
+    "MAX_RECALL_RESULTS_PER_TURN",
+    "MAX_RECALL_REQUEST_CHARS",
+    "RECALL_INDEX_VERSION",
+    "RECALL_INSTRUCTION_VERSION",
+    "RECALL_SCHEMA_VERSION",
+    "RecallBundle",
+    "RecallRequest",
+    "RecallResultRef",
+    "RecallVolatileMetadata",
+    "normalize_recall_query",
+    "recall_from_existing_retrieval",
+]

--- a/tests/test_canonical_recall.py
+++ b/tests/test_canonical_recall.py
@@ -1,0 +1,202 @@
+"""Contract tests for the P0 canonical recall envelope (#186)."""
+
+from __future__ import annotations
+
+import random
+import sqlite3
+from pathlib import Path
+
+import pytest
+from src.agent.dispatch_search_handlers import dispatch_search_target
+from src.memory import recall
+from src.shadow.bootstrap import rebuild_shadow_from_graph
+from src.shadow.freshness import ShadowFreshnessError, ShadowFreshnessReason
+from src.shadow.health import ShadowHealthState
+from src.shadow.query import BlockHit
+
+
+def _request(**changes: object) -> recall.RecallRequest:
+    values: dict[str, object] = {"normalized_query": "alpha beta", "filters": {}, "limit": 3}
+    values.update(changes)
+    return recall.RecallRequest(**values)  # type: ignore[arg-type]
+
+
+def _hits(*, jitter: float = 0.0, content: str = "alpha") -> list[BlockHit]:
+    return [
+        BlockHit(block_uuid="b", content="bravo", page_id=1, rank=-2.0 + jitter),
+        BlockHit(block_uuid="a", content=content, page_id=1, rank=-2.0 + jitter),
+        BlockHit(block_uuid="c", content="charlie", page_id=2, rank=-1.0 + jitter),
+    ]
+
+
+def test_equivalent_permutations_are_byte_stable() -> None:
+    expected = recall._completed_bundle(_request(), 7, _hits(), 1.0)  # noqa: SLF001
+    for seed in range(1_000):
+        shuffled = _hits()
+        random.Random(seed).shuffle(shuffled)
+        actual = recall._completed_bundle(_request(), 7, shuffled, float(seed))  # noqa: SLF001
+        assert actual.fingerprint == expected.fingerprint
+        assert actual.model_dump_json(exclude={"volatile"}) == expected.model_dump_json(
+            exclude={"volatile"}
+        )
+
+
+def test_score_jitter_without_rank_change_preserves_prefix_and_fingerprint() -> None:
+    baseline = recall._completed_bundle(_request(), 7, _hits(), 1.0)  # noqa: SLF001
+    jittered = recall._completed_bundle(_request(), 7, _hits(jitter=0.1), 99.0)  # noqa: SLF001
+    assert jittered.cache_stable_prefix() == baseline.cache_stable_prefix()
+    assert jittered.fingerprint == baseline.fingerprint
+    assert jittered.volatile != baseline.volatile
+
+
+@pytest.mark.parametrize(
+    ("recall_request", "generation", "hits"),
+    [
+        (_request(normalized_query="alpha gamma"), 7, _hits()),
+        (_request(filters={"page": "alpha"}), 7, _hits()),
+        (_request(limit=2), 7, _hits()),
+        (_request(), 8, _hits()),
+        (_request(), 7, _hits(content="changed")),
+        (_request(), 7, [BlockHit("z", "alpha", 1, -2.0)]),
+    ],
+)
+def test_stable_contract_inputs_invalidate_fingerprint(
+    recall_request: recall.RecallRequest,
+    generation: int,
+    hits: list[BlockHit],
+) -> None:
+    baseline = recall._completed_bundle(_request(), 7, _hits(), 1.0)  # noqa: SLF001
+    changed = recall._completed_bundle(recall_request, generation, hits, 1.0)  # noqa: SLF001
+    assert changed.fingerprint != baseline.fingerprint
+
+
+def test_index_and_instruction_versions_invalidate_fingerprint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    baseline = recall._completed_bundle(_request(), 7, _hits(), 1.0)  # noqa: SLF001
+    monkeypatch.setattr(recall, "RECALL_INDEX_VERSION", "shadow-fts5/schema-next")
+    assert recall._completed_bundle(_request(), 7, _hits(), 1.0).fingerprint != baseline.fingerprint  # noqa: SLF001
+    monkeypatch.setattr(recall, "RECALL_INSTRUCTION_VERSION", "recall-next")
+    assert recall._completed_bundle(_request(), 7, _hits(), 1.0).fingerprint != baseline.fingerprint  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_disabled_recall_is_explicit_and_never_reads_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "false")
+    monkeypatch.delenv("LOGSEQ_GRAPH_PATH", raising=False)
+    monkeypatch.setattr(
+        recall, "resolve_shadow_health", lambda _root: pytest.fail("unexpected read")
+    )
+    result = await dispatch_search_target("recall", '{"query":"alpha"}')
+    assert isinstance(result, dict)
+    assert result["state"] == "disabled"
+    assert result["code"] == "recall_disabled"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        ShadowFreshnessReason.PAGE_UNTRACKED,
+        ShadowFreshnessReason.SOURCE_MISSING,
+        ShadowFreshnessReason.SOURCE_CHANGED,
+    ],
+)
+def test_unproven_freshness_cannot_return_stale_refs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, reason: ShadowFreshnessReason
+) -> None:
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "true")
+    monkeypatch.setattr(recall, "resolve_shadow_health", lambda _root: ShadowHealthState.READY)
+    monkeypatch.setattr(
+        recall, "open_shadow_db_query_only", lambda _root: sqlite3.connect(":memory:")
+    )
+    monkeypatch.setattr(recall, "get_meta", lambda _conn, _key: "7")
+    monkeypatch.setattr(recall, "search_blocks_fts", lambda *_args, **_kwargs: _hits())
+
+    def _stale(*_args: object, **_kwargs: object) -> None:
+        raise ShadowFreshnessError(reason)
+
+    monkeypatch.setattr(recall, "ensure_shadow_page_fresh", _stale)
+    result = recall.recall_from_existing_retrieval(str(tmp_path), "alpha")
+    assert result.state == "unavailable"
+    assert result.code == "recall_freshness_unproven"
+    assert result.results == ()
+
+
+def test_recall_is_bounded_and_does_not_call_a_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "true")
+    monkeypatch.setattr(recall, "resolve_shadow_health", lambda _root: ShadowHealthState.READY)
+    monkeypatch.setattr(
+        recall, "open_shadow_db_query_only", lambda _root: sqlite3.connect(":memory:")
+    )
+    monkeypatch.setattr(recall, "get_meta", lambda _conn, _key: "7")
+    monkeypatch.setattr(recall, "ensure_shadow_page_fresh", lambda *_args, **_kwargs: None)
+    seen: dict[str, object] = {}
+
+    def _hits_limited(_conn: object, _query: str, *, limit: int) -> list[BlockHit]:
+        seen["limit"] = limit
+        return _hits()[:limit]
+
+    monkeypatch.setattr(recall, "search_blocks_fts", _hits_limited)
+    result = recall.recall_from_existing_retrieval(str(tmp_path), '{"query":"alpha", "limit": 2}')
+    assert seen["limit"] == 2
+    assert len(result.results) == 2
+    assert result.per_turn_expansion_budget == recall.MAX_RECALL_RESULTS_PER_TURN
+    assert result.no_progress_signature
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "x" * (recall.MAX_RECALL_REQUEST_CHARS + 1),
+        '{"query":"alpha", "limit":1.9}',
+        '{"query":"alpha", "limit":null}',
+        '{"query":"alpha", "filters":{"nested":{"x":"y"}}}',
+        '{"query":"alpha", "filters":null}',
+    ],
+)
+def test_invalid_or_oversized_enabled_requests_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, query: str
+) -> None:
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "true")
+    result = recall.recall_from_existing_retrieval("/never-read", query)
+    assert result.state == "unavailable"
+    assert result.code == "recall_invalid_request"
+
+
+def test_invalid_generation_cannot_produce_completed_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "true")
+    monkeypatch.setattr(recall, "resolve_shadow_health", lambda _root: ShadowHealthState.READY)
+    monkeypatch.setattr(
+        recall, "open_shadow_db_query_only", lambda _root: sqlite3.connect(":memory:")
+    )
+    monkeypatch.setattr(recall, "get_meta", lambda _conn, _key: "not-a-generation")
+    result = recall.recall_from_existing_retrieval(str(tmp_path), "alpha")
+    assert result.state == "unavailable"
+    assert result.code == "recall_freshness_unproven"
+
+
+def test_real_query_only_recall_is_graph_immutable_under_strict_read_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    graph = tmp_path / "graph"
+    pages = graph / "pages"
+    pages.mkdir(parents=True)
+    page = pages / "Alpha.md"
+    page.write_text("- alpha cache\n  id:: alpha-block\n", encoding="utf-8")
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "true")
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "true")
+    rebuild_shadow_from_graph(graph)
+    before = page.read_bytes()
+    monkeypatch.setenv("MATRYCA_READ_ONLY", "true")
+
+    result = recall.recall_from_existing_retrieval(str(graph), "alpha")
+
+    assert result.state == "completed"
+    assert [item.block_uuid for item in result.results] == ["alpha-block"]
+    assert page.read_bytes() == before

--- a/tests/test_runtime_bootstrap_entrypoints.py
+++ b/tests/test_runtime_bootstrap_entrypoints.py
@@ -200,10 +200,30 @@ def test_cli_eager_graph_route_matrix() -> None:
     from src.cli import _cli_eager_graph
 
     assert _cli_eager_graph(Namespace(command="search", method="bm25")) is False
+    assert _cli_eager_graph(Namespace(command="search", method="recall")) is False
     assert _cli_eager_graph(Namespace(command="search", method="regex")) is True
     assert _cli_eager_graph(Namespace(command="search", method="semantic")) is True
     assert _cli_eager_graph(Namespace(command="read", method=None)) is True
     assert _cli_eager_graph(Namespace(command="lint", method=None)) is True
+
+
+def test_disabled_cli_recall_skips_runtime_prepare(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.cli import main as cli_main
+
+    monkeypatch.setenv("MATRYCA_MEMORY_GRAPH_ENABLED", "false")
+    monkeypatch.delenv("LOGSEQ_GRAPH_PATH", raising=False)
+    monkeypatch.setattr(
+        "src.cli.try_prepare_matryca_runtime_from_env",
+        lambda **_kwargs: pytest.fail("disabled recall must not prepare a graph runtime"),
+    )
+
+    async def _run_cli(_args: object) -> int:
+        return 0
+
+    monkeypatch.setattr("src.cli.run_cli", _run_cli)
+    with pytest.raises(SystemExit) as exc:
+        cli_main(["search", "recall", "alpha"])
+    assert exc.value.code == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a disabled-by-default, provider-free canonical `search_graph(method="recall")` envelope
- bind deterministic block UUID/hash references to Shadow generation, query, filters, limit, index, and instruction versions
- preserve strict read-only behavior with explicit unavailable states and no fallback, rebuild, write, or model call

## Test plan
- [x] focused recall, CLI, MCP, Shadow, security, and environment coverage (119 tests)
- [x] Ruff and MyPy for the changed surfaces
- [x] documentation, prompt, agent-coherence, and llms identity checks

Closes #186