### PR TITLE
feat(memory): add governed P0 evidence packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
+- **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 
 ### Changed
 

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -38,6 +38,25 @@ This OpenSpec is a projection contract that keeps external expectations aligned 
 #### P1: hybrid retrieval, cache, and clustering
 
 - Retrieval composition is activated only after P0 acceptance.
+
+#### P0: governed coordination packet
+
+`P0EvidencePacket` is the content-free joining contract for one **retrieval-only**
+claim. It binds an exact source commit plus opaque references to the #186 canonical
+recall envelope, the #448 reproducible scorecard, and the #449 append-only archive
+event. Its canonical JSON and packet ID are byte-stable.
+
+All P0 persisted contract loaders use closed schemas: unknown fields fail closed
+instead of being retained as ungoverned content. The #448 adapter accepts only a
+retrieval-only scorecard scope and its exact manifest schema/version, dataset ID,
+and scorecard fingerprint; a scorecard is benchmark evidence, never runtime recall
+provenance or proof of end-to-end agent quality.
+
+The packet is deliberately a `proposed` value only. It performs no archive I/O,
+Shadow query, model call, remote export, canonical write, approval, or state
+transition. Accepted or rejected curation requires a later human-governed,
+canonical-write-adjacent slice; an external runtime cannot manufacture authority by
+attaching a label to a P0 packet. See [the evidence archive contract](evidence-archive.md).
 - Cache/fallback rules are deterministic.
 
 #### P2: proposal queue and curation

--- a/docs/openspec/evidence-archive.md
+++ b/docs/openspec/evidence-archive.md
@@ -24,6 +24,11 @@ SHA-256 digests, UTC timestamps, and bounded classifications. Raw vault text,
 prompts, credentials, absolute paths, and reconstructed candidate prose are
 not accepted by this P0 contract.
 
+Its event identity may be referenced by the pure `P0EvidencePacket` coordination
+contract in [biological-memory.md](biological-memory.md). That reference never
+opens, replays, or writes this archive, and it does not turn a candidate into an
+accepted canonical memory.
+
 Events serialize as canonical JSON and derive an event ID from their canonical
 bytes. A replay of the same event is a no-op. A complete malformed record fails
 closed. A final unterminated JSON fragment is recoverable only when it has the

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -28,7 +28,15 @@ autonomous behavior is shipped; scaffolded later-phase components remain roadmap
 
 ### P0 — evidence controls, canonical recall/provenance/idempotence, and benchmark baseline
 
-1. Define governed evidence and provenance rules for recall envelope behavior.
+1. Define governed evidence and provenance rules for recall envelope behavior,
+   including a byte-stable `P0EvidencePacket` that joins recall, scorecard, and
+   append-only archive references without adding a write path.
+
+P0 is closed only when the four independently reviewable deliverables agree:
+the external append-only archive (#449), retrieval-only scorecard baseline (#448),
+gated canonical recall envelope (#186), and proposed-only governed packet (#447).
+Their completion is a prerequisite for P1; it is not a benchmark claim about
+end-to-end agent quality or authority to curate canonical memory.
 2. Define canonical recall fingerprints, invalidation behavior, and idempotent processing boundaries.
 3. Define benchmark baseline and acceptance policy.
 4. Define replay/rollback/freshness boundaries before any P1 rollout.

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -11,6 +11,7 @@ from .decay import (
     days_between,
     half_life_days,
 )
+from .evidence_coordination import P0EvidencePacket
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -24,5 +25,6 @@ __all__ = [
     "half_life_days",
     "memory_graph_enabled",
     "RecallBundle",
+    "P0EvidencePacket",
     "recall_from_existing_retrieval",
 ]

--- a/src/memory/evidence_coordination.py
+++ b/src/memory/evidence_coordination.py
@@ -1,0 +1,241 @@
+"""Pure, privacy-safe coordination contracts for the Memory P0 evidence gate.
+
+This module joins the independently owned P0 outputs without persisting,
+executing, accepting, or promoting anything.  Its values contain only opaque
+identifiers and bounded labels, so a packet cannot become a second semantic
+memory store or a canonical-write authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from .evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    canonical_event_bytes,
+)
+from .recall import RECALL_SCHEMA_VERSION, RecallBundle, stable_recall_fingerprint
+
+COORDINATION_SCHEMA_VERSION = "governed-evidence-packet.v1"
+_GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+P0ClaimLabel = Literal["retrieval_only"]
+P0MetricLayer = Literal["retrieval"]
+P0Decision = Literal["proposed"]
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _identifier(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _digest_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _schema_version(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise EvidenceContractError("invalid_scorecard_schema")
+    return value
+
+
+def _required_string(value: Mapping[str, Any], *, field: str) -> str:
+    raw = value.get(field)
+    if not isinstance(raw, str):
+        raise EvidenceContractError(f"invalid_{field}")
+    return raw
+
+
+@dataclass(frozen=True, slots=True)
+class P0EvidencePacket:
+    """A content-free, byte-stable reference bundle for one P0 retrieval claim.
+
+    ``decision`` is intentionally restricted to ``proposed``.  Human curation
+    and any accepted/rejected transition belong to later canonical-write work;
+    constructing this packet never grants that authority.
+    """
+
+    source_revision: str
+    recall_ref: EvidenceRef
+    scorecard_ref: EvidenceRef
+    archive_ref: EvidenceRef
+    claim_label: P0ClaimLabel = "retrieval_only"
+    metric_layers: tuple[P0MetricLayer, ...] = ("retrieval",)
+    decision: P0Decision = "proposed"
+    schema_version: str = COORDINATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_revision, str) or not _GIT_REVISION.fullmatch(
+            self.source_revision
+        ):
+            raise EvidenceContractError("invalid_source_revision")
+        for field, value in (
+            ("recall_ref", self.recall_ref),
+            ("scorecard_ref", self.scorecard_ref),
+            ("archive_ref", self.archive_ref),
+        ):
+            if not isinstance(value, EvidenceRef):
+                raise EvidenceContractError(f"invalid_{field}")
+        if self.claim_label != "retrieval_only":
+            raise EvidenceContractError("invalid_claim_label")
+        layers = tuple(self.metric_layers)
+        if layers != ("retrieval",):
+            raise EvidenceContractError("invalid_metric_layers")
+        object.__setattr__(self, "metric_layers", layers)
+        if self.decision != "proposed":
+            raise EvidenceContractError("invalid_decision")
+        if self.schema_version != COORDINATION_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_coordination_schema_version")
+
+    @property
+    def packet_id(self) -> str:
+        """Return the stable content address of this packet's governed claim."""
+        return hashlib.sha256(canonical_packet_bytes(self)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "archive_ref": self.archive_ref.to_dict(),
+            "claim_label": self.claim_label,
+            "decision": self.decision,
+            "metric_layers": list(self.metric_layers),
+            "recall_ref": self.recall_ref.to_dict(),
+            "schema_version": self.schema_version,
+            "scorecard_ref": self.scorecard_ref.to_dict(),
+            "source_revision": self.source_revision,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> P0EvidencePacket:
+        expected = {
+            "archive_ref",
+            "claim_label",
+            "decision",
+            "metric_layers",
+            "recall_ref",
+            "schema_version",
+            "scorecard_ref",
+            "source_revision",
+        }
+        if set(value) != expected:
+            raise EvidenceContractError("unexpected_packet_fields")
+        raw_layers = value.get("metric_layers")
+        if not isinstance(raw_layers, list) or any(
+            not isinstance(layer, str) for layer in raw_layers
+        ):
+            raise EvidenceContractError("invalid_metric_layers")
+        refs: dict[str, EvidenceRef] = {}
+        for field in ("recall_ref", "scorecard_ref", "archive_ref"):
+            raw_ref = value.get(field)
+            if not isinstance(raw_ref, Mapping):
+                raise EvidenceContractError(f"invalid_{field}")
+            refs[field] = EvidenceRef.from_dict(raw_ref)
+        source_revision = _required_string(value, field="source_revision")
+        claim_label = _required_string(value, field="claim_label")
+        decision = _required_string(value, field="decision")
+        schema_version = _required_string(value, field="schema_version")
+        return cls(
+            source_revision=source_revision,
+            recall_ref=refs["recall_ref"],
+            scorecard_ref=refs["scorecard_ref"],
+            archive_ref=refs["archive_ref"],
+            claim_label=cast(P0ClaimLabel, claim_label),
+            metric_layers=tuple(cast(P0MetricLayer, layer) for layer in raw_layers),
+            decision=cast(P0Decision, decision),
+            schema_version=schema_version,
+        )
+
+
+def canonical_packet_bytes(packet: P0EvidencePacket) -> bytes:
+    """Return canonical JSON without semantic content, paths, or volatile metrics."""
+    return json.dumps(
+        packet.to_dict(), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def recall_contract_ref(bundle: RecallBundle) -> EvidenceRef:
+    """Pin a #186 recall bundle through its stable, generation-bound fingerprint."""
+    if not isinstance(bundle, RecallBundle) or bundle.schema_version != RECALL_SCHEMA_VERSION:
+        raise EvidenceContractError("invalid_recall_bundle")
+    fingerprint = _digest_string(bundle.fingerprint, field="recall_fingerprint")
+    if fingerprint != stable_recall_fingerprint(bundle.cache_stable_prefix()):
+        raise EvidenceContractError("recall_fingerprint_unproven")
+    return EvidenceRef(
+        source_kind="canonical-recall",
+        source_id=_digest({"kind": "canonical-recall", "fingerprint": fingerprint}),
+        revision_digest=fingerprint,
+    )
+
+
+def scorecard_payload_ref(payload: Mapping[str, Any]) -> EvidenceRef:
+    """Pin a retrieval-only #448 scorecard without retaining its raw payload."""
+    if not isinstance(payload, Mapping):
+        raise EvidenceContractError("invalid_scorecard_payload")
+    schema_version = _schema_version(payload.get("manifest_schema_version"))
+    dataset_id = _identifier(payload.get("manifest_dataset_id"), field="scorecard_dataset")
+    fingerprint = _digest_string(
+        payload.get("scorecard_fingerprint"), field="scorecard_fingerprint"
+    )
+    scope = payload.get("evaluation_scope")
+    if (
+        not isinstance(scope, Mapping)
+        or set(scope) != {"retrieval_only", "end_to_end_answer_evaluated"}
+        or scope.get("retrieval_only") is not True
+        or scope.get("end_to_end_answer_evaluated") is not False
+    ):
+        raise EvidenceContractError("invalid_scorecard_scope")
+    return EvidenceRef(
+        source_kind="benchmark-scorecard",
+        source_id=_digest(
+            {
+                "dataset_id": dataset_id,
+                "kind": "benchmark-scorecard",
+                "schema_version": schema_version,
+            }
+        ),
+        revision_digest=fingerprint,
+    )
+
+
+def archive_event_ref(event: EvidenceEvent) -> EvidenceRef:
+    """Pin one append-only #449 event without opening or writing its archive."""
+    if not isinstance(event, EvidenceEvent):
+        raise EvidenceContractError("invalid_evidence_event")
+    event_id = _digest_string(event.event_id, field="event_id")
+    if hashlib.sha256(canonical_event_bytes(event)).hexdigest() != event_id:
+        raise EvidenceContractError("invalid_evidence_event")
+    return EvidenceRef(
+        source_kind="evidence-archive-event",
+        source_id=event.candidate.candidate_id,
+        revision_digest=event_id,
+    )
+
+
+__all__ = [
+    "COORDINATION_SCHEMA_VERSION",
+    "P0ClaimLabel",
+    "P0Decision",
+    "P0EvidencePacket",
+    "P0MetricLayer",
+    "archive_event_ref",
+    "canonical_packet_bytes",
+    "recall_contract_ref",
+    "scorecard_payload_ref",
+]

--- a/src/memory/evidence_models.py
+++ b/src/memory/evidence_models.py
@@ -78,6 +78,7 @@ class EvidenceRef:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceRef:
+        _require_exact_keys(value, {"source_kind", "source_id", "revision_digest"})
         return cls(
             source_kind=_required_string(value, "source_kind"),
             source_id=_required_string(value, "source_id"),
@@ -129,6 +130,10 @@ class MemoryCandidate:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> MemoryCandidate:
+        _require_exact_keys(
+            value,
+            {"candidate_id", "candidate_kind", "evidence_refs", "observed_at", "status"},
+        )
         raw_refs = value.get("evidence_refs")
         if not isinstance(raw_refs, list):
             raise EvidenceContractError("invalid_evidence_refs")
@@ -181,6 +186,7 @@ class EvidenceEvent:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceEvent:
+        _require_exact_keys(value, {"candidate", "event_type", "recorded_at", "schema_version"})
         raw_candidate = value.get("candidate")
         if not isinstance(raw_candidate, Mapping):
             raise EvidenceContractError("invalid_candidate")
@@ -217,6 +223,12 @@ def _required_int(value: Mapping[str, Any], key: str) -> int:
     if isinstance(raw, bool) or not isinstance(raw, int):
         raise EvidenceContractError(f"invalid_{key}")
     return raw
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str]) -> None:
+    """Reject unmodeled persisted fields before they can bypass privacy validation."""
+    if set(value) != expected:
+        raise EvidenceContractError("unexpected_fields")
 
 
 def _ref_sort_key(value: EvidenceRef) -> tuple[str, str, str]:

--- a/src/memory/recall.py
+++ b/src/memory/recall.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sqlite3
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -113,6 +114,11 @@ def _digest(value: object) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def stable_recall_fingerprint(prefix: Mapping[str, Any]) -> str:
+    """Hash the exact reusable recall prefix used by the canonical envelope."""
+    return _digest(prefix)
+
+
 def _bundle(
     *,
     state: RecallState,
@@ -136,7 +142,7 @@ def _bundle(
         "results": [item.model_dump(mode="json") for item in results],
         "per_turn_expansion_budget": MAX_RECALL_RESULTS_PER_TURN,
     }
-    fingerprint = _digest(stable)
+    fingerprint = stable_recall_fingerprint(stable)
     return RecallBundle(
         schema_version=RECALL_SCHEMA_VERSION,
         state=state,
@@ -296,4 +302,5 @@ __all__ = [
     "RecallVolatileMetadata",
     "normalize_recall_query",
     "recall_from_existing_retrieval",
+    "stable_recall_fingerprint",
 ]

--- a/tests/test_evidence_coordination.py
+++ b/tests/test_evidence_coordination.py
@@ -1,0 +1,210 @@
+"""Deterministic, side-effect-free contract tests for Memory P0 coordination (#447)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+from scripts import bench_bm25_query_cache as benchmark
+from src.memory.evidence_coordination import (
+    COORDINATION_SCHEMA_VERSION,
+    P0EvidencePacket,
+    archive_event_ref,
+    canonical_packet_bytes,
+    recall_contract_ref,
+    scorecard_payload_ref,
+)
+from src.memory.evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    MemoryCandidate,
+)
+from src.memory.recall import RecallBundle, stable_recall_fingerprint
+
+_A = "a" * 64
+_B = "b" * 64
+_C = "c" * 64
+_REVISION = "d" * 40
+
+
+def _event() -> EvidenceEvent:
+    return EvidenceEvent(
+        candidate=MemoryCandidate(
+            candidate_id=_A,
+            candidate_kind="semantic-claim",
+            observed_at="2026-08-10T12:00:00Z",
+            evidence_refs=(EvidenceRef("benchmark", _B, _C),),
+        ),
+        recorded_at="2026-08-10T12:01:00Z",
+    )
+
+
+def _bundle() -> RecallBundle:
+    bundle = RecallBundle(
+        state="completed",
+        code="recall_completed",
+        graph_generation=7,
+        normalized_query="opaque normalized query",
+        limit=3,
+        fingerprint=_B,
+        no_progress_signature=_C,
+        per_turn_expansion_budget=50,
+    )
+    return bundle.model_copy(
+        update={"fingerprint": stable_recall_fingerprint(bundle.cache_stable_prefix())}
+    )
+
+
+def _scorecard() -> dict[str, object]:
+    return {
+        "manifest_schema_version": 1,
+        "manifest_dataset_id": "synthetic-hard-negatives.v1",
+        "scorecard_fingerprint": _C,
+        "evaluation_scope": {"retrieval_only": True, "end_to_end_answer_evaluated": False},
+    }
+
+
+def _packet() -> P0EvidencePacket:
+    return P0EvidencePacket(
+        source_revision=_REVISION,
+        recall_ref=recall_contract_ref(_bundle()),
+        scorecard_ref=scorecard_payload_ref(_scorecard()),
+        archive_ref=archive_event_ref(_event()),
+    )
+
+
+def test_packet_is_byte_stable_immutable_and_content_free() -> None:
+    packet = _packet()
+
+    assert packet.schema_version == COORDINATION_SCHEMA_VERSION
+    assert canonical_packet_bytes(packet) == canonical_packet_bytes(packet)
+    assert len(packet.packet_id) == 64
+    assert b"opaque normalized query" not in canonical_packet_bytes(packet)
+    assert P0EvidencePacket.from_dict(packet.to_dict()) == packet
+    with pytest.raises(FrozenInstanceError):
+        packet.__setattr__("decision", "accepted")
+
+
+def test_packet_rejects_unknown_persisted_fields() -> None:
+    payload = _packet().to_dict() | {"raw_query": "must not persist"}
+    with pytest.raises(EvidenceContractError, match="unexpected_packet_fields"):
+        P0EvidencePacket.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        lambda packet: replace(packet, source_revision="e" * 40),
+        lambda packet: replace(packet, recall_ref=EvidenceRef("canonical-recall", _A, _C)),
+        lambda packet: replace(packet, scorecard_ref=EvidenceRef("benchmark-scorecard", _A, _C)),
+        lambda packet: replace(packet, archive_ref=EvidenceRef("evidence-archive-event", _A, _C)),
+    ],
+)
+def test_every_governed_reference_change_invalidates_packet_id(
+    changed: Callable[[P0EvidencePacket], P0EvidencePacket],
+) -> None:
+    packet = _packet()
+    assert changed(packet).packet_id != packet.packet_id
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("source_revision", "not-a-commit", "invalid_source_revision"),
+        ("claim_label", "end_to_end", "invalid_claim_label"),
+        ("metric_layers", ("retrieval", "answer"), "invalid_metric_layers"),
+        ("decision", "accepted", "invalid_decision"),
+        (
+            "schema_version",
+            "governed-evidence-packet.v2",
+            "unsupported_coordination_schema_version",
+        ),
+    ],
+)
+def test_packet_rejects_ungoverned_claim_expansion(
+    field: str,
+    value: str | tuple[str, ...],
+    error: str,
+) -> None:
+    payload = _packet().to_dict()
+    payload[field] = list(value) if field == "metric_layers" else value
+    with pytest.raises(EvidenceContractError, match=error):
+        P0EvidencePacket.from_dict(payload)
+
+
+def test_adapters_are_deterministic_and_never_open_external_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.memory.evidence_archive.EvidenceArchive.for_graph",
+        lambda *_args, **_kwargs: pytest.fail("coordination must not open the archive"),
+    )
+    assert recall_contract_ref(_bundle()) == recall_contract_ref(_bundle())
+    assert scorecard_payload_ref(_scorecard()) == scorecard_payload_ref(_scorecard())
+    assert archive_event_ref(_event()) == archive_event_ref(_event())
+
+
+def test_recall_adapter_rejects_a_forged_but_well_formed_fingerprint() -> None:
+    forged = _bundle().model_copy(update={"fingerprint": _A})
+
+    with pytest.raises(EvidenceContractError, match="recall_fingerprint_unproven"):
+        recall_contract_ref(forged)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "manifest_schema_version": "bad/path",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+        },
+        {
+            "manifest_schema_version": "scorecard.v1",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {"retrieval_only": False, "end_to_end_answer_evaluated": True},
+        },
+        {
+            "manifest_schema_version": 1,
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {
+                "retrieval_only": True,
+                "end_to_end_answer_evaluated": False,
+                "raw": "not accepted",
+            },
+        },
+    ],
+)
+def test_scorecard_adapter_rejects_unpinned_or_non_retrieval_claims(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(EvidenceContractError):
+        scorecard_payload_ref(payload)
+
+
+def test_scorecard_adapter_accepts_the_real_p0_scorecard_payload() -> None:
+    manifest_path = Path(__file__).parent / "fixtures" / "bm25_hard_negative_manifest_v1.json"
+    manifest, _manifest_digest = benchmark._read_manifest(manifest_path)  # noqa: SLF001
+    payload = benchmark._run_scorecard_benchmark(  # noqa: SLF001
+        manifest,
+        top_k=8,
+    )
+
+    reference = scorecard_payload_ref(payload)
+
+    assert reference.source_kind == "benchmark-scorecard"
+    assert reference.revision_digest == payload["scorecard_fingerprint"]
+
+
+def test_coordination_module_has_no_runtime_or_storage_dependency() -> None:
+    source = __import__("src.memory.evidence_coordination", fromlist=["__file__"]).__file__
+    assert source is not None
+    text = Path(source).read_text(encoding="utf-8")
+    for forbidden in ("sqlite3", "pathlib", "EvidenceArchive", "open_shadow", "os.", "subprocess"):
+        assert forbidden not in text

--- a/tests/test_evidence_models.py
+++ b/tests/test_evidence_models.py
@@ -67,3 +67,39 @@ def test_evidence_refs_must_be_canonical_and_unique() -> None:
             observed_at="2026-08-10T12:00:00Z",
             evidence_refs=(second, second),
         )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "source_kind": "benchmark",
+            "source_id": _DIGEST_B,
+            "revision_digest": _DIGEST_C,
+            "raw": "x",
+        },
+        {
+            "candidate_id": _DIGEST_A,
+            "candidate_kind": "semantic-claim",
+            "evidence_refs": [],
+            "observed_at": "2026-08-10T12:00:00Z",
+            "status": "proposed",
+            "raw": "x",
+        },
+        {
+            "candidate": _candidate().to_dict(),
+            "event_type": "candidate_observed",
+            "recorded_at": "2026-08-10T12:01:00Z",
+            "schema_version": 1,
+            "raw": "x",
+        },
+    ],
+)
+def test_replay_rejects_unmodeled_content_bearing_fields(payload: dict[str, object]) -> None:
+    with pytest.raises(EvidenceContractError, match="unexpected_fields"):
+        if "source_kind" in payload:
+            EvidenceRef.from_dict(payload)
+        elif "candidate_id" in payload:
+            MemoryCandidate.from_dict(payload)
+        else:
+            EvidenceEvent.from_dict(payload)


### PR DESCRIPTION
## Summary
- add a pure, byte-stable retrieval-only packet that joins canonical recall, scorecard, and append-only archive references
- fail closed on unmodeled persisted evidence fields and non-retrieval scorecard claims
- document the P0 closure boundary and prove the adapter against the real scorecard payload

## Test plan
- [x] `make ci`

Closes #447
Refs #446