### PR TITLE
feat(benchmark): add reproducible run contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
+- **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 
 ### Changed
 

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -103,3 +103,23 @@ The profile is synthetic and deterministic: no external data or network runtime 
 It intentionally does not report end-to-end answer quality: that belongs to the
 separate adapter layer, where answer model, judge, prompt, token budget, and
 failure policy can be pinned rather than conflated with retrieval quality.
+
+## Cross-system evidence contract
+
+`src.memory.benchmark_protocol` provides a closed, provider-free contract for
+the later public-suite adapter layer. It validates metadata only: no benchmark
+suite is downloaded, no model is invoked, and no prompt, answer, vault content,
+credential, path, or raw result is retained in the contract.
+
+Each run pins its suite and dataset revision, harness and Matryca revisions,
+dependency lock digest, system revision/configuration digest, hardware/runtime,
+budget, cache state, retry/failure policy, and model/judge configuration where applicable. Four
+opaque artifact digests are mandatory: item results, exclusions, failed runs,
+and run metadata. This makes omissions visible without publishing content.
+
+The comparative validator accepts only completed, like-for-like cohorts with
+one Matryca no-semantic-memory control, one Matryca candidate-feature control,
+and at least two distinct open external systems. It rejects mismatched dataset,
+model, judge, budget, or runtime context, and it keeps retrieval and end-to-end
+answer layers separate. The contract is evidence infrastructure, not a claim
+that a public suite or external system has already been executed.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -38,6 +38,25 @@ This OpenSpec is a projection contract that keeps external expectations aligned 
 #### P1: hybrid retrieval, cache, and clustering
 
 - Retrieval composition is activated only after P0 acceptance.
+
+#### P0: governed coordination packet
+
+`P0EvidencePacket` is the content-free joining contract for one **retrieval-only**
+claim. It binds an exact source commit plus opaque references to the #186 canonical
+recall envelope, the #448 reproducible scorecard, and the #449 append-only archive
+event. Its canonical JSON and packet ID are byte-stable.
+
+All P0 persisted contract loaders use closed schemas: unknown fields fail closed
+instead of being retained as ungoverned content. The #448 adapter accepts only a
+retrieval-only scorecard scope and its exact manifest schema/version, dataset ID,
+and scorecard fingerprint; a scorecard is benchmark evidence, never runtime recall
+provenance or proof of end-to-end agent quality.
+
+The packet is deliberately a `proposed` value only. It performs no archive I/O,
+Shadow query, model call, remote export, canonical write, approval, or state
+transition. Accepted or rejected curation requires a later human-governed,
+canonical-write-adjacent slice; an external runtime cannot manufacture authority by
+attaching a label to a P0 packet. See [the evidence archive contract](evidence-archive.md).
 - Cache/fallback rules are deterministic.
 
 #### P2: proposal queue and curation

--- a/docs/openspec/evidence-archive.md
+++ b/docs/openspec/evidence-archive.md
@@ -24,6 +24,11 @@ SHA-256 digests, UTC timestamps, and bounded classifications. Raw vault text,
 prompts, credentials, absolute paths, and reconstructed candidate prose are
 not accepted by this P0 contract.
 
+Its event identity may be referenced by the pure `P0EvidencePacket` coordination
+contract in [biological-memory.md](biological-memory.md). That reference never
+opens, replays, or writes this archive, and it does not turn a candidate into an
+accepted canonical memory.
+
 Events serialize as canonical JSON and derive an event ID from their canonical
 bytes. A replay of the same event is a no-op. A complete malformed record fails
 closed. A final unterminated JSON fragment is recoverable only when it has the

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -28,7 +28,15 @@ autonomous behavior is shipped; scaffolded later-phase components remain roadmap
 
 ### P0 — evidence controls, canonical recall/provenance/idempotence, and benchmark baseline
 
-1. Define governed evidence and provenance rules for recall envelope behavior.
+1. Define governed evidence and provenance rules for recall envelope behavior,
+   including a byte-stable `P0EvidencePacket` that joins recall, scorecard, and
+   append-only archive references without adding a write path.
+
+P0 is closed only when the four independently reviewable deliverables agree:
+the external append-only archive (#449), retrieval-only scorecard baseline (#448),
+gated canonical recall envelope (#186), and proposed-only governed packet (#447).
+Their completion is a prerequisite for P1; it is not a benchmark claim about
+end-to-end agent quality or authority to curate canonical memory.
 2. Define canonical recall fingerprints, invalidation behavior, and idempotent processing boundaries.
 3. Define benchmark baseline and acceptance policy.
 4. Define replay/rollback/freshness boundaries before any P1 rollout.

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,5 +1,10 @@
 """Biological memory graph layer (Nacre-inspired, Epic #99)."""
 
+from .benchmark_protocol import (
+    BenchmarkRunManifest,
+    BenchmarkRunReport,
+    validate_comparative_cohort,
+)
 from .config import memory_graph_enabled
 from .decay import (
     DEFAULT_DECAY_RATE,
@@ -18,6 +23,8 @@ __all__ = [
     "DEFAULT_DECAY_RATE",
     "DEFAULT_REINFORCEMENT_BOOST",
     "MemoryEdgeState",
+    "BenchmarkRunManifest",
+    "BenchmarkRunReport",
     "calculate_decayed_weight",
     "calculate_stability",
     "compute_decayed_weight_from_dates",
@@ -27,4 +34,5 @@ __all__ = [
     "RecallBundle",
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
+    "validate_comparative_cohort",
 ]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -11,6 +11,7 @@ from .decay import (
     days_between,
     half_life_days,
 )
+from .evidence_coordination import P0EvidencePacket
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -24,5 +25,6 @@ __all__ = [
     "half_life_days",
     "memory_graph_enabled",
     "RecallBundle",
+    "P0EvidencePacket",
     "recall_from_existing_retrieval",
 ]

--- a/src/memory/benchmark_protocol.py
+++ b/src/memory/benchmark_protocol.py
@@ -1,0 +1,368 @@
+"""Closed, content-free contracts for reproducible benchmark evidence.
+
+The contracts deliberately validate run provenance and opaque result artifacts;
+they do not download suites, invoke models, or retain prompts, answers, vault
+content, credentials, paths, or raw outputs.  A comparison is admissible only
+when its runs share the same evaluation context and contain the prespecified
+Matryca controls plus two reproducible external open-system controls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .evidence_models import EvidenceContractError
+
+BENCHMARK_PROTOCOL_SCHEMA_VERSION = "benchmark-protocol.v1"
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+SuiteName = Literal["beam", "locomo", "longmemeval", "longmemeval-v2", "memoryagentbench"]
+EvidenceClass = Literal[
+    "independently_reproduced",
+    "not_comparable",
+    "synthetic_design_evidence",
+    "upstream_reported_not_rerun",
+]
+EvaluationLayer = Literal["end_to_end_answer", "retrieval"]
+SystemRole = Literal[
+    "external_open_system",
+    "matryca_candidate_feature",
+    "matryca_without_semantic_memory",
+]
+RunStatus = Literal["completed", "excluded", "failed"]
+ArtifactKind = Literal["exclusions", "failed_runs", "item_results", "run_metadata"]
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _identifier(value: str, *, field: str) -> str:
+    normalized = value.strip()
+    if not _IDENTIFIER.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+def _git_revision(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not _GIT_REVISION.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+def _sha256(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not _SHA256.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+class DatasetPin(_ClosedModel):
+    """One legally attributable public-suite revision without local content."""
+
+    suite: SuiteName
+    dataset_id: str
+    repository_slug: str = Field(pattern=r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+    dataset_revision: str
+    license_id: str = Field(pattern=r"^[A-Za-z0-9_.-]+$")
+
+    @model_validator(mode="after")
+    def _validate_identifiers(self) -> DatasetPin:
+        object.__setattr__(self, "dataset_id", _identifier(self.dataset_id, field="dataset_id"))
+        object.__setattr__(
+            self,
+            "dataset_revision",
+            _git_revision(self.dataset_revision, field="dataset_revision"),
+        )
+        return self
+
+
+class ModelPin(_ClosedModel):
+    """Pinned evaluator model or the explicit provider-free sentinel."""
+
+    model_id: str
+    model_revision: str
+    prompt_digest: str
+    temperature_milli: int = Field(ge=0, le=2_000)
+    seed: int = Field(ge=0, le=2**31 - 1)
+
+    @model_validator(mode="after")
+    def _validate_pins(self) -> ModelPin:
+        object.__setattr__(self, "model_id", _identifier(self.model_id, field="model_id"))
+        object.__setattr__(
+            self,
+            "model_revision",
+            _identifier(self.model_revision, field="model_revision"),
+        )
+        object.__setattr__(
+            self,
+            "prompt_digest",
+            _sha256(self.prompt_digest, field="prompt_digest"),
+        )
+        return self
+
+
+class EvaluationBudget(_ClosedModel):
+    """Comparable retrieval and context limits for every system in a cohort."""
+
+    context_token_budget: int = Field(ge=1, le=10_000_000)
+    retrieval_call_budget: int = Field(ge=0, le=10_000)
+    top_k: int = Field(ge=1, le=1_000)
+    timeout_seconds: int = Field(ge=1, le=86_400)
+
+
+class RuntimePin(_ClosedModel):
+    """Content-free hardware and dependency provenance for one run."""
+
+    harness_revision: str
+    matryca_revision: str
+    dependency_lock_digest: str
+    hardware_class: str
+    os_family: str
+    runtime_version: str
+    concurrency: int = Field(ge=1, le=10_000)
+    cache_state: Literal["cold", "primed", "warm"]
+    failure_policy_id: str
+    retry_policy_id: str
+
+    @model_validator(mode="after")
+    def _validate_pins(self) -> RuntimePin:
+        object.__setattr__(
+            self,
+            "harness_revision",
+            _git_revision(self.harness_revision, field="harness_revision"),
+        )
+        object.__setattr__(
+            self,
+            "matryca_revision",
+            _git_revision(self.matryca_revision, field="matryca_revision"),
+        )
+        object.__setattr__(
+            self,
+            "dependency_lock_digest",
+            _sha256(self.dependency_lock_digest, field="dependency_lock_digest"),
+        )
+        object.__setattr__(
+            self,
+            "hardware_class",
+            _identifier(self.hardware_class, field="hardware_class"),
+        )
+        object.__setattr__(self, "os_family", _identifier(self.os_family, field="os_family"))
+        object.__setattr__(
+            self,
+            "runtime_version",
+            _identifier(self.runtime_version, field="runtime_version"),
+        )
+        object.__setattr__(
+            self,
+            "failure_policy_id",
+            _identifier(self.failure_policy_id, field="failure_policy_id"),
+        )
+        object.__setattr__(
+            self,
+            "retry_policy_id",
+            _identifier(self.retry_policy_id, field="retry_policy_id"),
+        )
+        return self
+
+
+class SystemPin(_ClosedModel):
+    """A reproducible system/control identity without configuration content."""
+
+    role: SystemRole
+    system_id: str
+    implementation_revision: str
+    configuration_digest: str
+    open_source: bool
+
+    @model_validator(mode="after")
+    def _validate_system(self) -> SystemPin:
+        object.__setattr__(self, "system_id", _identifier(self.system_id, field="system_id"))
+        object.__setattr__(
+            self,
+            "implementation_revision",
+            _git_revision(self.implementation_revision, field="implementation_revision"),
+        )
+        object.__setattr__(
+            self,
+            "configuration_digest",
+            _sha256(self.configuration_digest, field="configuration_digest"),
+        )
+        if self.role == "external_open_system" and not self.open_source:
+            raise EvidenceContractError("external_system_must_be_open_source")
+        if self.role != "external_open_system" and self.system_id != "matryca-plumber":
+            raise EvidenceContractError("matryca_control_must_use_matryca_id")
+        return self
+
+
+class OpaqueArtifact(_ClosedModel):
+    """Digest-pinned, retained result material stored outside the contract."""
+
+    kind: ArtifactKind
+    digest: str
+    record_count: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _validate_digest(self) -> OpaqueArtifact:
+        object.__setattr__(self, "digest", _sha256(self.digest, field=f"{self.kind}_digest"))
+        return self
+
+
+class BenchmarkRunManifest(_ClosedModel):
+    """Closed run manifest for one evaluation layer and one tested system."""
+
+    schema_version: str = BENCHMARK_PROTOCOL_SCHEMA_VERSION
+    cohort_id: str
+    dataset: DatasetPin
+    evaluation_layer: EvaluationLayer
+    system: SystemPin
+    answer_model: ModelPin | None
+    judge_model: ModelPin | None
+    budget: EvaluationBudget
+    runtime: RuntimePin
+    evidence_class: EvidenceClass
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> BenchmarkRunManifest:
+        if self.schema_version != BENCHMARK_PROTOCOL_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_benchmark_protocol_schema")
+        object.__setattr__(self, "cohort_id", _identifier(self.cohort_id, field="cohort_id"))
+        if self.evaluation_layer == "retrieval":
+            if self.answer_model is not None or self.judge_model is not None:
+                raise EvidenceContractError("retrieval_run_cannot_pin_answer_or_judge")
+        elif self.answer_model is None or self.judge_model is None:
+            raise EvidenceContractError("end_to_end_run_requires_answer_and_judge")
+        return self
+
+    @property
+    def manifest_id(self) -> str:
+        return hashlib.sha256(canonical_manifest_bytes(self)).hexdigest()
+
+
+class BenchmarkRunReport(_ClosedModel):
+    """Run outcome that retains all result categories as opaque artifacts."""
+
+    manifest: BenchmarkRunManifest
+    status: RunStatus
+    artifacts: tuple[OpaqueArtifact, ...]
+
+    @model_validator(mode="after")
+    def _validate_report(self) -> BenchmarkRunReport:
+        artifacts = tuple(self.artifacts)
+        expected = {"exclusions", "failed_runs", "item_results", "run_metadata"}
+        if {artifact.kind for artifact in artifacts} != expected or len(artifacts) != len(expected):
+            raise EvidenceContractError("incomplete_or_duplicate_run_artifacts")
+        object.__setattr__(self, "artifacts", tuple(sorted(artifacts, key=lambda item: item.kind)))
+        if self.status == "completed" and any(
+            artifact.record_count > 0 for artifact in artifacts if artifact.kind == "failed_runs"
+        ):
+            raise EvidenceContractError("completed_run_cannot_have_failed_items")
+        return self
+
+    @property
+    def report_id(self) -> str:
+        return hashlib.sha256(canonical_report_bytes(self)).hexdigest()
+
+
+def canonical_manifest_bytes(manifest: BenchmarkRunManifest) -> bytes:
+    """Serialize a manifest deterministically without raw benchmark content."""
+    return json.dumps(
+        manifest.model_dump(mode="json"), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def canonical_report_bytes(report: BenchmarkRunReport) -> bytes:
+    """Serialize a retained-artifact report deterministically."""
+    return json.dumps(
+        report.model_dump(mode="json"), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def validate_comparative_cohort(reports: tuple[BenchmarkRunReport, ...]) -> str:
+    """Return a cohort fingerprint only for a like-for-like four-system baseline.
+
+    The validator does not score systems.  It proves only that a resulting
+    comparison has the required controls and compatible measurement context.
+    """
+    if len(reports) < 4:
+        raise EvidenceContractError("comparative_cohort_requires_four_runs")
+    manifests = tuple(report.manifest for report in reports)
+    if any(report.status != "completed" for report in reports):
+        raise EvidenceContractError("comparative_cohort_requires_completed_runs")
+    if len({manifest.cohort_id for manifest in manifests}) != 1:
+        raise EvidenceContractError("comparative_cohort_id_mismatch")
+    if len({manifest.evaluation_layer for manifest in manifests}) != 1:
+        raise EvidenceContractError("comparative_cohort_mixes_evaluation_layers")
+    reference = manifests[0]
+    comparison_key = (
+        reference.dataset,
+        reference.answer_model,
+        reference.judge_model,
+        reference.budget,
+        reference.runtime,
+    )
+    if any(
+        (
+            manifest.dataset,
+            manifest.answer_model,
+            manifest.judge_model,
+            manifest.budget,
+            manifest.runtime,
+        )
+        != comparison_key
+        for manifest in manifests[1:]
+    ):
+        raise EvidenceContractError("comparative_cohort_context_mismatch")
+    roles = [manifest.system.role for manifest in manifests]
+    if roles.count("matryca_without_semantic_memory") != 1:
+        raise EvidenceContractError("missing_matryca_no_memory_control")
+    if roles.count("matryca_candidate_feature") != 1:
+        raise EvidenceContractError("missing_matryca_candidate_control")
+    external_ids = {
+        manifest.system.system_id
+        for manifest in manifests
+        if manifest.system.role == "external_open_system"
+    }
+    if len(external_ids) < 2:
+        raise EvidenceContractError("comparative_cohort_requires_two_external_systems")
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "manifest_ids": sorted(manifest.manifest_id for manifest in manifests),
+                "report_ids": sorted(report.report_id for report in reports),
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+__all__ = [
+    "ArtifactKind",
+    "BENCHMARK_PROTOCOL_SCHEMA_VERSION",
+    "BenchmarkRunManifest",
+    "BenchmarkRunReport",
+    "DatasetPin",
+    "EvaluationBudget",
+    "EvaluationLayer",
+    "EvidenceClass",
+    "ModelPin",
+    "OpaqueArtifact",
+    "RunStatus",
+    "RuntimePin",
+    "SuiteName",
+    "SystemPin",
+    "SystemRole",
+    "canonical_manifest_bytes",
+    "canonical_report_bytes",
+    "validate_comparative_cohort",
+]

--- a/src/memory/evidence_coordination.py
+++ b/src/memory/evidence_coordination.py
@@ -1,0 +1,241 @@
+"""Pure, privacy-safe coordination contracts for the Memory P0 evidence gate.
+
+This module joins the independently owned P0 outputs without persisting,
+executing, accepting, or promoting anything.  Its values contain only opaque
+identifiers and bounded labels, so a packet cannot become a second semantic
+memory store or a canonical-write authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from .evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    canonical_event_bytes,
+)
+from .recall import RECALL_SCHEMA_VERSION, RecallBundle, stable_recall_fingerprint
+
+COORDINATION_SCHEMA_VERSION = "governed-evidence-packet.v1"
+_GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+P0ClaimLabel = Literal["retrieval_only"]
+P0MetricLayer = Literal["retrieval"]
+P0Decision = Literal["proposed"]
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _identifier(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _digest_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _schema_version(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise EvidenceContractError("invalid_scorecard_schema")
+    return value
+
+
+def _required_string(value: Mapping[str, Any], *, field: str) -> str:
+    raw = value.get(field)
+    if not isinstance(raw, str):
+        raise EvidenceContractError(f"invalid_{field}")
+    return raw
+
+
+@dataclass(frozen=True, slots=True)
+class P0EvidencePacket:
+    """A content-free, byte-stable reference bundle for one P0 retrieval claim.
+
+    ``decision`` is intentionally restricted to ``proposed``.  Human curation
+    and any accepted/rejected transition belong to later canonical-write work;
+    constructing this packet never grants that authority.
+    """
+
+    source_revision: str
+    recall_ref: EvidenceRef
+    scorecard_ref: EvidenceRef
+    archive_ref: EvidenceRef
+    claim_label: P0ClaimLabel = "retrieval_only"
+    metric_layers: tuple[P0MetricLayer, ...] = ("retrieval",)
+    decision: P0Decision = "proposed"
+    schema_version: str = COORDINATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_revision, str) or not _GIT_REVISION.fullmatch(
+            self.source_revision
+        ):
+            raise EvidenceContractError("invalid_source_revision")
+        for field, value in (
+            ("recall_ref", self.recall_ref),
+            ("scorecard_ref", self.scorecard_ref),
+            ("archive_ref", self.archive_ref),
+        ):
+            if not isinstance(value, EvidenceRef):
+                raise EvidenceContractError(f"invalid_{field}")
+        if self.claim_label != "retrieval_only":
+            raise EvidenceContractError("invalid_claim_label")
+        layers = tuple(self.metric_layers)
+        if layers != ("retrieval",):
+            raise EvidenceContractError("invalid_metric_layers")
+        object.__setattr__(self, "metric_layers", layers)
+        if self.decision != "proposed":
+            raise EvidenceContractError("invalid_decision")
+        if self.schema_version != COORDINATION_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_coordination_schema_version")
+
+    @property
+    def packet_id(self) -> str:
+        """Return the stable content address of this packet's governed claim."""
+        return hashlib.sha256(canonical_packet_bytes(self)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "archive_ref": self.archive_ref.to_dict(),
+            "claim_label": self.claim_label,
+            "decision": self.decision,
+            "metric_layers": list(self.metric_layers),
+            "recall_ref": self.recall_ref.to_dict(),
+            "schema_version": self.schema_version,
+            "scorecard_ref": self.scorecard_ref.to_dict(),
+            "source_revision": self.source_revision,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> P0EvidencePacket:
+        expected = {
+            "archive_ref",
+            "claim_label",
+            "decision",
+            "metric_layers",
+            "recall_ref",
+            "schema_version",
+            "scorecard_ref",
+            "source_revision",
+        }
+        if set(value) != expected:
+            raise EvidenceContractError("unexpected_packet_fields")
+        raw_layers = value.get("metric_layers")
+        if not isinstance(raw_layers, list) or any(
+            not isinstance(layer, str) for layer in raw_layers
+        ):
+            raise EvidenceContractError("invalid_metric_layers")
+        refs: dict[str, EvidenceRef] = {}
+        for field in ("recall_ref", "scorecard_ref", "archive_ref"):
+            raw_ref = value.get(field)
+            if not isinstance(raw_ref, Mapping):
+                raise EvidenceContractError(f"invalid_{field}")
+            refs[field] = EvidenceRef.from_dict(raw_ref)
+        source_revision = _required_string(value, field="source_revision")
+        claim_label = _required_string(value, field="claim_label")
+        decision = _required_string(value, field="decision")
+        schema_version = _required_string(value, field="schema_version")
+        return cls(
+            source_revision=source_revision,
+            recall_ref=refs["recall_ref"],
+            scorecard_ref=refs["scorecard_ref"],
+            archive_ref=refs["archive_ref"],
+            claim_label=cast(P0ClaimLabel, claim_label),
+            metric_layers=tuple(cast(P0MetricLayer, layer) for layer in raw_layers),
+            decision=cast(P0Decision, decision),
+            schema_version=schema_version,
+        )
+
+
+def canonical_packet_bytes(packet: P0EvidencePacket) -> bytes:
+    """Return canonical JSON without semantic content, paths, or volatile metrics."""
+    return json.dumps(
+        packet.to_dict(), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def recall_contract_ref(bundle: RecallBundle) -> EvidenceRef:
+    """Pin a #186 recall bundle through its stable, generation-bound fingerprint."""
+    if not isinstance(bundle, RecallBundle) or bundle.schema_version != RECALL_SCHEMA_VERSION:
+        raise EvidenceContractError("invalid_recall_bundle")
+    fingerprint = _digest_string(bundle.fingerprint, field="recall_fingerprint")
+    if fingerprint != stable_recall_fingerprint(bundle.cache_stable_prefix()):
+        raise EvidenceContractError("recall_fingerprint_unproven")
+    return EvidenceRef(
+        source_kind="canonical-recall",
+        source_id=_digest({"kind": "canonical-recall", "fingerprint": fingerprint}),
+        revision_digest=fingerprint,
+    )
+
+
+def scorecard_payload_ref(payload: Mapping[str, Any]) -> EvidenceRef:
+    """Pin a retrieval-only #448 scorecard without retaining its raw payload."""
+    if not isinstance(payload, Mapping):
+        raise EvidenceContractError("invalid_scorecard_payload")
+    schema_version = _schema_version(payload.get("manifest_schema_version"))
+    dataset_id = _identifier(payload.get("manifest_dataset_id"), field="scorecard_dataset")
+    fingerprint = _digest_string(
+        payload.get("scorecard_fingerprint"), field="scorecard_fingerprint"
+    )
+    scope = payload.get("evaluation_scope")
+    if (
+        not isinstance(scope, Mapping)
+        or set(scope) != {"retrieval_only", "end_to_end_answer_evaluated"}
+        or scope.get("retrieval_only") is not True
+        or scope.get("end_to_end_answer_evaluated") is not False
+    ):
+        raise EvidenceContractError("invalid_scorecard_scope")
+    return EvidenceRef(
+        source_kind="benchmark-scorecard",
+        source_id=_digest(
+            {
+                "dataset_id": dataset_id,
+                "kind": "benchmark-scorecard",
+                "schema_version": schema_version,
+            }
+        ),
+        revision_digest=fingerprint,
+    )
+
+
+def archive_event_ref(event: EvidenceEvent) -> EvidenceRef:
+    """Pin one append-only #449 event without opening or writing its archive."""
+    if not isinstance(event, EvidenceEvent):
+        raise EvidenceContractError("invalid_evidence_event")
+    event_id = _digest_string(event.event_id, field="event_id")
+    if hashlib.sha256(canonical_event_bytes(event)).hexdigest() != event_id:
+        raise EvidenceContractError("invalid_evidence_event")
+    return EvidenceRef(
+        source_kind="evidence-archive-event",
+        source_id=event.candidate.candidate_id,
+        revision_digest=event_id,
+    )
+
+
+__all__ = [
+    "COORDINATION_SCHEMA_VERSION",
+    "P0ClaimLabel",
+    "P0Decision",
+    "P0EvidencePacket",
+    "P0MetricLayer",
+    "archive_event_ref",
+    "canonical_packet_bytes",
+    "recall_contract_ref",
+    "scorecard_payload_ref",
+]

--- a/src/memory/evidence_models.py
+++ b/src/memory/evidence_models.py
@@ -78,6 +78,7 @@ class EvidenceRef:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceRef:
+        _require_exact_keys(value, {"source_kind", "source_id", "revision_digest"})
         return cls(
             source_kind=_required_string(value, "source_kind"),
             source_id=_required_string(value, "source_id"),
@@ -129,6 +130,10 @@ class MemoryCandidate:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> MemoryCandidate:
+        _require_exact_keys(
+            value,
+            {"candidate_id", "candidate_kind", "evidence_refs", "observed_at", "status"},
+        )
         raw_refs = value.get("evidence_refs")
         if not isinstance(raw_refs, list):
             raise EvidenceContractError("invalid_evidence_refs")
@@ -181,6 +186,7 @@ class EvidenceEvent:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceEvent:
+        _require_exact_keys(value, {"candidate", "event_type", "recorded_at", "schema_version"})
         raw_candidate = value.get("candidate")
         if not isinstance(raw_candidate, Mapping):
             raise EvidenceContractError("invalid_candidate")
@@ -217,6 +223,12 @@ def _required_int(value: Mapping[str, Any], key: str) -> int:
     if isinstance(raw, bool) or not isinstance(raw, int):
         raise EvidenceContractError(f"invalid_{key}")
     return raw
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str]) -> None:
+    """Reject unmodeled persisted fields before they can bypass privacy validation."""
+    if set(value) != expected:
+        raise EvidenceContractError("unexpected_fields")
 
 
 def _ref_sort_key(value: EvidenceRef) -> tuple[str, str, str]:

--- a/src/memory/recall.py
+++ b/src/memory/recall.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sqlite3
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -113,6 +114,11 @@ def _digest(value: object) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def stable_recall_fingerprint(prefix: Mapping[str, Any]) -> str:
+    """Hash the exact reusable recall prefix used by the canonical envelope."""
+    return _digest(prefix)
+
+
 def _bundle(
     *,
     state: RecallState,
@@ -136,7 +142,7 @@ def _bundle(
         "results": [item.model_dump(mode="json") for item in results],
         "per_turn_expansion_budget": MAX_RECALL_RESULTS_PER_TURN,
     }
-    fingerprint = _digest(stable)
+    fingerprint = stable_recall_fingerprint(stable)
     return RecallBundle(
         schema_version=RECALL_SCHEMA_VERSION,
         state=state,
@@ -296,4 +302,5 @@ __all__ = [
     "RecallVolatileMetadata",
     "normalize_recall_query",
     "recall_from_existing_retrieval",
+    "stable_recall_fingerprint",
 ]

--- a/tests/test_benchmark_protocol.py
+++ b/tests/test_benchmark_protocol.py
@@ -1,0 +1,221 @@
+"""Tests for closed, reproducible cross-system benchmark contracts."""
+
+from __future__ import annotations
+
+import pytest
+from src.memory.benchmark_protocol import (
+    BENCHMARK_PROTOCOL_SCHEMA_VERSION,
+    BenchmarkRunManifest,
+    BenchmarkRunReport,
+    DatasetPin,
+    EvaluationBudget,
+    EvaluationLayer,
+    ModelPin,
+    OpaqueArtifact,
+    RuntimePin,
+    SystemPin,
+    SystemRole,
+    canonical_manifest_bytes,
+    canonical_report_bytes,
+    validate_comparative_cohort,
+)
+from src.memory.evidence_models import EvidenceContractError
+
+_A = "a" * 40
+_B = "b" * 40
+_C = "c" * 40
+_D = "d" * 40
+_E = "e" * 40
+_F = "f" * 40
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+_DIGEST_C = "c" * 64
+_DIGEST_D = "d" * 64
+_DIGEST_E = "e" * 64
+
+
+def _runtime() -> RuntimePin:
+    return RuntimePin(
+        harness_revision=_A,
+        matryca_revision=_B,
+        dependency_lock_digest=_DIGEST_A,
+        hardware_class="apple-m4-max-64gb",
+        os_family="macos-15",
+        runtime_version="python-3.12",
+        concurrency=1,
+        cache_state="cold",
+        failure_policy_id="retain-all-terminal-outcomes",
+        retry_policy_id="no-retry",
+    )
+
+
+def _manifest(
+    role: SystemRole,
+    system_id: str,
+    *,
+    layer: EvaluationLayer = "retrieval",
+) -> BenchmarkRunManifest:
+    return BenchmarkRunManifest(
+        schema_version=BENCHMARK_PROTOCOL_SCHEMA_VERSION,
+        cohort_id="locomo-retrieval-baseline-v1",
+        dataset=DatasetPin(
+            suite="locomo",
+            dataset_id="locomo-v1",
+            repository_slug="snap-research/locomo",
+            dataset_revision=_C,
+            license_id="CC-BY-4.0",
+        ),
+        evaluation_layer=layer,
+        system=SystemPin(
+            role=role,
+            system_id=system_id,
+            implementation_revision=_D if system_id == "matryca-plumber" else _E,
+            configuration_digest=_DIGEST_B,
+            open_source=True,
+        ),
+        answer_model=None,
+        judge_model=None,
+        budget=EvaluationBudget(
+            context_token_budget=8_192,
+            retrieval_call_budget=4,
+            top_k=8,
+            timeout_seconds=60,
+        ),
+        runtime=_runtime(),
+        evidence_class="independently_reproduced",
+    )
+
+
+def _report(role: SystemRole, system_id: str) -> BenchmarkRunReport:
+    return BenchmarkRunReport(
+        manifest=_manifest(role, system_id),
+        status="completed",
+        artifacts=(
+            OpaqueArtifact(kind="item_results", digest=_DIGEST_A, record_count=24),
+            OpaqueArtifact(kind="run_metadata", digest=_DIGEST_B, record_count=1),
+            OpaqueArtifact(kind="exclusions", digest=_DIGEST_C, record_count=0),
+            OpaqueArtifact(kind="failed_runs", digest=_DIGEST_D, record_count=0),
+        ),
+    )
+
+
+def test_manifest_and_report_are_closed_and_byte_stable() -> None:
+    report = _report("matryca_without_semantic_memory", "matryca-plumber")
+
+    assert canonical_manifest_bytes(report.manifest) == canonical_manifest_bytes(report.manifest)
+    assert canonical_report_bytes(report) == canonical_report_bytes(report)
+    assert len(report.manifest.manifest_id) == 64
+    assert len(report.report_id) == 64
+    with pytest.raises(ValueError):
+        BenchmarkRunManifest.model_validate(
+            {**report.manifest.model_dump(), "raw_prompt": "unsafe"}
+        )
+
+
+def test_retrieval_and_end_to_end_layers_cannot_be_conflated() -> None:
+    retrieval = _manifest("matryca_candidate_feature", "matryca-plumber")
+
+    with pytest.raises(ValueError, match="retrieval_run_cannot_pin_answer_or_judge"):
+        BenchmarkRunManifest.model_validate(
+            {**retrieval.model_dump(), "answer_model": _model().model_dump()}
+        )
+    with pytest.raises(ValueError, match="end_to_end_run_requires_answer_and_judge"):
+        BenchmarkRunManifest.model_validate(
+            {**retrieval.model_dump(), "evaluation_layer": "end_to_end_answer"}
+        )
+
+
+def _model() -> ModelPin:
+    return ModelPin(
+        model_id="local-judge",
+        model_revision="v1",
+        prompt_digest=_DIGEST_E,
+        temperature_milli=0,
+        seed=7,
+    )
+
+
+def test_report_requires_all_retained_result_categories() -> None:
+    report = _report("matryca_candidate_feature", "matryca-plumber")
+
+    with pytest.raises(ValueError, match="incomplete_or_duplicate_run_artifacts"):
+        BenchmarkRunReport(
+            manifest=report.manifest,
+            status="completed",
+            artifacts=report.artifacts[:-1],
+        )
+    failed = OpaqueArtifact(kind="failed_runs", digest=_DIGEST_D, record_count=1)
+    without_failed = tuple(item for item in report.artifacts if item.kind != "failed_runs")
+    with pytest.raises(ValueError, match="completed_run_cannot_have_failed_items"):
+        BenchmarkRunReport(
+            manifest=report.manifest,
+            status="completed",
+            artifacts=(*without_failed, failed),
+        )
+
+
+def test_comparative_cohort_requires_matryca_controls_and_two_open_systems() -> None:
+    reports = (
+        _report("matryca_without_semantic_memory", "matryca-plumber"),
+        _report("matryca_candidate_feature", "matryca-plumber"),
+        _report("external_open_system", "mem0"),
+        _report("external_open_system", "graphiti"),
+    )
+
+    assert validate_comparative_cohort(reports) == validate_comparative_cohort(reports)
+    duplicated_external = (*reports[:-1], _report("external_open_system", "mem0"))
+    with pytest.raises(
+        EvidenceContractError,
+        match="comparative_cohort_requires_two_external_systems",
+    ):
+        validate_comparative_cohort(duplicated_external)
+
+
+def test_comparative_cohort_rejects_context_or_layer_mismatch() -> None:
+    reports = list(
+        (
+            _report("matryca_without_semantic_memory", "matryca-plumber"),
+            _report("matryca_candidate_feature", "matryca-plumber"),
+            _report("external_open_system", "mem0"),
+            _report("external_open_system", "graphiti"),
+        )
+    )
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {
+                **reports[-1].manifest.model_dump(),
+                "budget": {**reports[-1].manifest.budget.model_dump(), "top_k": 9},
+            }
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
+
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
+        validate_comparative_cohort(tuple(reports))
+
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {
+                **reports[-1].manifest.model_dump(),
+                "budget": reports[0].manifest.budget.model_dump(),
+                "runtime": {
+                    **reports[-1].manifest.runtime.model_dump(),
+                    "cache_state": "warm",
+                    "retry_policy_id": "one-bounded-retry",
+                },
+            }
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
+        validate_comparative_cohort(tuple(reports))
+    with pytest.raises(ValueError, match="external_system_must_be_open_source"):
+        SystemPin(
+            role="external_open_system",
+            system_id="closed-memory",
+            implementation_revision=_F,
+            configuration_digest=_DIGEST_A,
+            open_source=False,
+        )

--- a/tests/test_evidence_coordination.py
+++ b/tests/test_evidence_coordination.py
@@ -1,0 +1,210 @@
+"""Deterministic, side-effect-free contract tests for Memory P0 coordination (#447)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+from scripts import bench_bm25_query_cache as benchmark
+from src.memory.evidence_coordination import (
+    COORDINATION_SCHEMA_VERSION,
+    P0EvidencePacket,
+    archive_event_ref,
+    canonical_packet_bytes,
+    recall_contract_ref,
+    scorecard_payload_ref,
+)
+from src.memory.evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    MemoryCandidate,
+)
+from src.memory.recall import RecallBundle, stable_recall_fingerprint
+
+_A = "a" * 64
+_B = "b" * 64
+_C = "c" * 64
+_REVISION = "d" * 40
+
+
+def _event() -> EvidenceEvent:
+    return EvidenceEvent(
+        candidate=MemoryCandidate(
+            candidate_id=_A,
+            candidate_kind="semantic-claim",
+            observed_at="2026-08-10T12:00:00Z",
+            evidence_refs=(EvidenceRef("benchmark", _B, _C),),
+        ),
+        recorded_at="2026-08-10T12:01:00Z",
+    )
+
+
+def _bundle() -> RecallBundle:
+    bundle = RecallBundle(
+        state="completed",
+        code="recall_completed",
+        graph_generation=7,
+        normalized_query="opaque normalized query",
+        limit=3,
+        fingerprint=_B,
+        no_progress_signature=_C,
+        per_turn_expansion_budget=50,
+    )
+    return bundle.model_copy(
+        update={"fingerprint": stable_recall_fingerprint(bundle.cache_stable_prefix())}
+    )
+
+
+def _scorecard() -> dict[str, object]:
+    return {
+        "manifest_schema_version": 1,
+        "manifest_dataset_id": "synthetic-hard-negatives.v1",
+        "scorecard_fingerprint": _C,
+        "evaluation_scope": {"retrieval_only": True, "end_to_end_answer_evaluated": False},
+    }
+
+
+def _packet() -> P0EvidencePacket:
+    return P0EvidencePacket(
+        source_revision=_REVISION,
+        recall_ref=recall_contract_ref(_bundle()),
+        scorecard_ref=scorecard_payload_ref(_scorecard()),
+        archive_ref=archive_event_ref(_event()),
+    )
+
+
+def test_packet_is_byte_stable_immutable_and_content_free() -> None:
+    packet = _packet()
+
+    assert packet.schema_version == COORDINATION_SCHEMA_VERSION
+    assert canonical_packet_bytes(packet) == canonical_packet_bytes(packet)
+    assert len(packet.packet_id) == 64
+    assert b"opaque normalized query" not in canonical_packet_bytes(packet)
+    assert P0EvidencePacket.from_dict(packet.to_dict()) == packet
+    with pytest.raises(FrozenInstanceError):
+        packet.__setattr__("decision", "accepted")
+
+
+def test_packet_rejects_unknown_persisted_fields() -> None:
+    payload = _packet().to_dict() | {"raw_query": "must not persist"}
+    with pytest.raises(EvidenceContractError, match="unexpected_packet_fields"):
+        P0EvidencePacket.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        lambda packet: replace(packet, source_revision="e" * 40),
+        lambda packet: replace(packet, recall_ref=EvidenceRef("canonical-recall", _A, _C)),
+        lambda packet: replace(packet, scorecard_ref=EvidenceRef("benchmark-scorecard", _A, _C)),
+        lambda packet: replace(packet, archive_ref=EvidenceRef("evidence-archive-event", _A, _C)),
+    ],
+)
+def test_every_governed_reference_change_invalidates_packet_id(
+    changed: Callable[[P0EvidencePacket], P0EvidencePacket],
+) -> None:
+    packet = _packet()
+    assert changed(packet).packet_id != packet.packet_id
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("source_revision", "not-a-commit", "invalid_source_revision"),
+        ("claim_label", "end_to_end", "invalid_claim_label"),
+        ("metric_layers", ("retrieval", "answer"), "invalid_metric_layers"),
+        ("decision", "accepted", "invalid_decision"),
+        (
+            "schema_version",
+            "governed-evidence-packet.v2",
+            "unsupported_coordination_schema_version",
+        ),
+    ],
+)
+def test_packet_rejects_ungoverned_claim_expansion(
+    field: str,
+    value: str | tuple[str, ...],
+    error: str,
+) -> None:
+    payload = _packet().to_dict()
+    payload[field] = list(value) if field == "metric_layers" else value
+    with pytest.raises(EvidenceContractError, match=error):
+        P0EvidencePacket.from_dict(payload)
+
+
+def test_adapters_are_deterministic_and_never_open_external_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.memory.evidence_archive.EvidenceArchive.for_graph",
+        lambda *_args, **_kwargs: pytest.fail("coordination must not open the archive"),
+    )
+    assert recall_contract_ref(_bundle()) == recall_contract_ref(_bundle())
+    assert scorecard_payload_ref(_scorecard()) == scorecard_payload_ref(_scorecard())
+    assert archive_event_ref(_event()) == archive_event_ref(_event())
+
+
+def test_recall_adapter_rejects_a_forged_but_well_formed_fingerprint() -> None:
+    forged = _bundle().model_copy(update={"fingerprint": _A})
+
+    with pytest.raises(EvidenceContractError, match="recall_fingerprint_unproven"):
+        recall_contract_ref(forged)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "manifest_schema_version": "bad/path",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+        },
+        {
+            "manifest_schema_version": "scorecard.v1",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {"retrieval_only": False, "end_to_end_answer_evaluated": True},
+        },
+        {
+            "manifest_schema_version": 1,
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {
+                "retrieval_only": True,
+                "end_to_end_answer_evaluated": False,
+                "raw": "not accepted",
+            },
+        },
+    ],
+)
+def test_scorecard_adapter_rejects_unpinned_or_non_retrieval_claims(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(EvidenceContractError):
+        scorecard_payload_ref(payload)
+
+
+def test_scorecard_adapter_accepts_the_real_p0_scorecard_payload() -> None:
+    manifest_path = Path(__file__).parent / "fixtures" / "bm25_hard_negative_manifest_v1.json"
+    manifest, _manifest_digest = benchmark._read_manifest(manifest_path)  # noqa: SLF001
+    payload = benchmark._run_scorecard_benchmark(  # noqa: SLF001
+        manifest,
+        top_k=8,
+    )
+
+    reference = scorecard_payload_ref(payload)
+
+    assert reference.source_kind == "benchmark-scorecard"
+    assert reference.revision_digest == payload["scorecard_fingerprint"]
+
+
+def test_coordination_module_has_no_runtime_or_storage_dependency() -> None:
+    source = __import__("src.memory.evidence_coordination", fromlist=["__file__"]).__file__
+    assert source is not None
+    text = Path(source).read_text(encoding="utf-8")
+    for forbidden in ("sqlite3", "pathlib", "EvidenceArchive", "open_shadow", "os.", "subprocess"):
+        assert forbidden not in text

--- a/tests/test_evidence_models.py
+++ b/tests/test_evidence_models.py
@@ -67,3 +67,39 @@ def test_evidence_refs_must_be_canonical_and_unique() -> None:
             observed_at="2026-08-10T12:00:00Z",
             evidence_refs=(second, second),
         )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "source_kind": "benchmark",
+            "source_id": _DIGEST_B,
+            "revision_digest": _DIGEST_C,
+            "raw": "x",
+        },
+        {
+            "candidate_id": _DIGEST_A,
+            "candidate_kind": "semantic-claim",
+            "evidence_refs": [],
+            "observed_at": "2026-08-10T12:00:00Z",
+            "status": "proposed",
+            "raw": "x",
+        },
+        {
+            "candidate": _candidate().to_dict(),
+            "event_type": "candidate_observed",
+            "recorded_at": "2026-08-10T12:01:00Z",
+            "schema_version": 1,
+            "raw": "x",
+        },
+    ],
+)
+def test_replay_rejects_unmodeled_content_bearing_fields(payload: dict[str, object]) -> None:
+    with pytest.raises(EvidenceContractError, match="unexpected_fields"):
+        if "source_kind" in payload:
+            EvidenceRef.from_dict(payload)
+        elif "candidate_id" in payload:
+            MemoryCandidate.from_dict(payload)
+        else:
+            EvidenceEvent.from_dict(payload)


### PR DESCRIPTION
## Summary
- add closed, content-free manifests and retained-artifact reports for public-suite evaluation runs
- enforce like-for-like Matryca controls plus two distinct open external-system controls
- keep retrieval and end-to-end answer evaluation separate while pinning cache state and retry/failure policy

## Test plan
- [x] Focused pytest suite
- [x] mypy
- [x] Ruff
- [x] Documentation checks

Refs #448