### PR TITLE
feat(benchmark): add local LoCoMo adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -123,3 +123,19 @@ and at least two distinct open external systems. It rejects mismatched dataset,
 model, judge, budget, or runtime context, and it keeps retrieval and end-to-end
 answer layers separate. The contract is evidence infrastructure, not a claim
 that a public suite or external system has already been executed.
+
+### LoCoMo local-data adapter
+
+`src.memory.locomo_adapter` accepts an already acquired LoCoMo JSON file and
+normalizes its documented ordered sessions, dialogue IDs, QA categories, and
+evidence IDs into deterministic retrieval cases. An empty upstream evidence
+list is represented as unavailable retrieval evidence, not an abstention label.
+The documented category-5 `adversarial_answer` is retained when the standard
+answer is absent. It does not download the
+dataset, resolve optional image URLs, call a model, read a vault, or persist
+outcomes. Missing or inconsistent required evidence fails closed.
+
+Its public conversation text is available only in memory to an evaluator. A
+later runner must retain outcomes, exclusions, and failures through the opaque
+artifact digests required by the cross-system evidence contract; loading LoCoMo
+alone is neither an executed benchmark nor a comparative claim.

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -17,12 +17,15 @@ from .decay import (
     half_life_days,
 )
 from .evidence_coordination import P0EvidencePacket
+from .locomo_adapter import LocomoDataset, LocomoRetrievalCase, load_locomo_retrieval_cases
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
     "DEFAULT_DECAY_RATE",
     "DEFAULT_REINFORCEMENT_BOOST",
     "MemoryEdgeState",
+    "LocomoDataset",
+    "LocomoRetrievalCase",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
     "calculate_decayed_weight",
@@ -34,5 +37,6 @@ __all__ = [
     "RecallBundle",
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
+    "load_locomo_retrieval_cases",
     "validate_comparative_cohort",
 ]

--- a/src/memory/locomo_adapter.py
+++ b/src/memory/locomo_adapter.py
@@ -1,0 +1,206 @@
+"""Local-only LoCoMo normalization for retrieval evaluation.
+
+The adapter accepts an already acquired public ``locomo10.json``-shaped file.
+It never downloads data, follows image URLs, invokes models, writes results, or
+touches a vault.  Public conversation text lives only in the returned in-memory
+cases; callers must retain produced outcomes through ``benchmark_protocol``'s
+opaque artifact boundary rather than serializing this adapter's values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .evidence_models import EvidenceContractError
+
+_SESSION_KEY = re.compile(r"^session_(?P<index>[1-9][0-9]*)$")
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LocomoTurn(_ClosedModel):
+    """One public LoCoMo dialogue turn retained only for a local evaluation."""
+
+    turn_id: str = Field(min_length=1, max_length=256)
+    session_index: int = Field(ge=1)
+    speaker: str = Field(min_length=1, max_length=256)
+    text: str = Field(min_length=1)
+
+
+class LocomoRetrievalCase(_ClosedModel):
+    """A normalized QA item with its document-level retrieval evidence."""
+
+    case_id: str = Field(min_length=1, max_length=256)
+    sample_id: str = Field(min_length=1, max_length=256)
+    category: str = Field(min_length=1, max_length=256)
+    question: str = Field(min_length=1)
+    expected_answer: str = Field(min_length=1)
+    turns: tuple[LocomoTurn, ...] = Field(min_length=1)
+    evidence_turn_ids: tuple[str, ...]
+    evidence_available: bool
+
+
+class LocomoDataset(_ClosedModel):
+    """A deterministic, locally loaded LoCoMo retrieval-evaluation dataset."""
+
+    source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    cases: tuple[LocomoRetrievalCase, ...] = Field(min_length=1)
+
+
+def load_locomo_retrieval_cases(path: Path) -> LocomoDataset:
+    """Load documented LoCoMo conversations and QA evidence from one local file.
+
+    Unknown upstream fields, including optional image metadata, are deliberately
+    ignored. Required fields are validated fail-closed so malformed data cannot
+    silently become a benchmark result.
+    """
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError("locomo_dataset_unreadable") from exc
+    try:
+        raw: Any = json.loads(raw_bytes)
+    except json.JSONDecodeError as exc:
+        raise EvidenceContractError("locomo_dataset_invalid_json") from exc
+    if not isinstance(raw, list) or not raw:
+        raise EvidenceContractError("locomo_dataset_must_be_nonempty_list")
+
+    cases: list[LocomoRetrievalCase] = []
+    seen_case_ids: set[str] = set()
+    for sample_index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise EvidenceContractError("locomo_sample_invalid")
+        sample_id = _required_text(item, "sample_id", error="locomo_sample_id_invalid")
+        conversation = item.get("conversation")
+        if not isinstance(conversation, Mapping):
+            raise EvidenceContractError("locomo_conversation_invalid")
+        turns = _turns(conversation)
+        turn_ids = {turn.turn_id for turn in turns}
+        questions = item.get("qa")
+        if not isinstance(questions, list) or not questions:
+            raise EvidenceContractError("locomo_qa_invalid")
+        for question_index, question in enumerate(questions):
+            if not isinstance(question, Mapping):
+                raise EvidenceContractError("locomo_qa_invalid")
+            case_id = f"{sample_id}:{question_index + 1}"
+            if case_id in seen_case_ids:
+                raise EvidenceContractError("locomo_case_id_duplicate")
+            seen_case_ids.add(case_id)
+            if "evidence" not in question:
+                raise EvidenceContractError("locomo_evidence_invalid")
+            evidence_turn_ids = _evidence_ids(question["evidence"], turn_ids)
+            cases.append(
+                LocomoRetrievalCase(
+                    case_id=case_id,
+                    sample_id=sample_id,
+                    category=_required_scalar_text(
+                        question,
+                        "category",
+                        error="locomo_category_invalid",
+                    ),
+                    question=_required_text(question, "question", error="locomo_question_invalid"),
+                    expected_answer=_answer(question),
+                    turns=turns,
+                    evidence_turn_ids=evidence_turn_ids,
+                    evidence_available=bool(evidence_turn_ids),
+                )
+            )
+        if sample_index >= 10_000:
+            raise EvidenceContractError("locomo_dataset_too_many_samples")
+    return LocomoDataset(
+        source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+        cases=tuple(cases),
+    )
+
+
+def _turns(conversation: Mapping[str, Any]) -> tuple[LocomoTurn, ...]:
+    sessions: list[tuple[int, Sequence[Any]]] = []
+    for key, value in conversation.items():
+        match = _SESSION_KEY.fullmatch(key) if isinstance(key, str) else None
+        if match is None:
+            continue
+        if not isinstance(value, list) or not value:
+            raise EvidenceContractError("locomo_session_invalid")
+        sessions.append((int(match.group("index")), value))
+    if not sessions:
+        raise EvidenceContractError("locomo_sessions_missing")
+    if len({index for index, _turns_value in sessions}) != len(sessions):
+        raise EvidenceContractError("locomo_session_duplicate")
+
+    turns: list[LocomoTurn] = []
+    turn_ids: set[str] = set()
+    for session_index, session_turns in sorted(sessions):
+        for turn in session_turns:
+            if not isinstance(turn, Mapping):
+                raise EvidenceContractError("locomo_turn_invalid")
+            raw_turn_id = turn.get("dia_id")
+            if isinstance(raw_turn_id, bool) or not isinstance(raw_turn_id, (int, str)):
+                raise EvidenceContractError("locomo_turn_id_invalid")
+            turn_id = str(raw_turn_id).strip()
+            if not turn_id or turn_id in turn_ids:
+                raise EvidenceContractError("locomo_turn_id_invalid")
+            turn_ids.add(turn_id)
+            turns.append(
+                LocomoTurn(
+                    turn_id=turn_id,
+                    session_index=session_index,
+                    speaker=_required_text(turn, "speaker", error="locomo_speaker_invalid"),
+                    text=_required_text(turn, "text", error="locomo_turn_text_invalid"),
+                )
+            )
+    return tuple(turns)
+
+
+def _evidence_ids(value: object, turn_ids: set[str]) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise EvidenceContractError("locomo_evidence_invalid")
+    normalized: list[str] = []
+    for raw_turn_id in value:
+        if isinstance(raw_turn_id, bool) or not isinstance(raw_turn_id, (int, str)):
+            raise EvidenceContractError("locomo_evidence_invalid")
+        turn_id = str(raw_turn_id).strip()
+        if not turn_id or turn_id not in turn_ids or turn_id in normalized:
+            raise EvidenceContractError("locomo_evidence_invalid")
+        normalized.append(turn_id)
+    return tuple(normalized)
+
+
+def _required_text(value: Mapping[str, Any], key: str, *, error: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        raise EvidenceContractError(error)
+    return raw.strip()
+
+
+def _required_scalar_text(value: Mapping[str, Any], key: str, *, error: str) -> str:
+    raw = value.get(key)
+    if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+        raise EvidenceContractError(error)
+    normalized = str(raw).strip()
+    if not normalized:
+        raise EvidenceContractError(error)
+    return normalized
+
+
+def _answer(value: Mapping[str, Any]) -> str:
+    """Read the standard answer or the documented category-5 adversarial answer."""
+    if "answer" in value:
+        return _required_scalar_text(value, "answer", error="locomo_answer_invalid")
+    return _required_scalar_text(value, "adversarial_answer", error="locomo_answer_invalid")
+
+
+__all__ = [
+    "LocomoDataset",
+    "LocomoRetrievalCase",
+    "LocomoTurn",
+    "load_locomo_retrieval_cases",
+]

--- a/tests/test_locomo_adapter.py
+++ b/tests/test_locomo_adapter.py
@@ -1,0 +1,128 @@
+"""Tests for the local-only LoCoMo retrieval adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.locomo_adapter import load_locomo_retrieval_cases
+
+
+def _dataset() -> list[object]:
+    return [
+        {
+            "sample_id": "locomo-sample-1",
+            "conversation": {
+                "speaker_a": "A",
+                "speaker_b": "B",
+                "session_2_date_time": "2024-01-02",
+                "session_2": [
+                    {"speaker": "B", "dia_id": "turn-2", "text": "The revised plan is active."},
+                ],
+                "session_1": [
+                    {
+                        "speaker": "A",
+                        "dia_id": "turn-1",
+                        "text": "The earlier plan was provisional.",
+                        "img_url": "https://example.invalid/not-followed",
+                    },
+                ],
+            },
+            "qa": [
+                {
+                    "question": "Which plan is active?",
+                    "answer": "The revised plan.",
+                    "category": 2,
+                    "evidence": ["turn-2"],
+                },
+                {
+                    "question": "What is the unreleased codename?",
+                    "adversarial_answer": 2022,
+                    "category": 5,
+                    "evidence": [],
+                },
+            ],
+        }
+    ]
+
+
+def _write_dataset(tmp_path: Path, payload: object | None = None) -> Path:
+    path = tmp_path / "locomo10.json"
+    path.write_text(json.dumps(_dataset() if payload is None else payload), encoding="utf-8")
+    return path
+
+
+def test_adapter_normalizes_sessions_evidence_and_abstention_deterministically(
+    tmp_path: Path,
+) -> None:
+    path = _write_dataset(tmp_path)
+
+    dataset = load_locomo_retrieval_cases(path)
+
+    assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert [case.case_id for case in dataset.cases] == ["locomo-sample-1:1", "locomo-sample-1:2"]
+    assert [turn.turn_id for turn in dataset.cases[0].turns] == ["turn-1", "turn-2"]
+    assert dataset.cases[0].evidence_turn_ids == ("turn-2",)
+    assert dataset.cases[0].category == "2"
+    assert dataset.cases[0].evidence_available is True
+    assert dataset.cases[1].evidence_turn_ids == ()
+    assert dataset.cases[1].category == "5"
+    assert dataset.cases[1].expected_answer == "2022"
+    assert dataset.cases[1].evidence_available is False
+
+
+def test_adapter_never_opens_network_or_follows_optional_image_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_dataset(tmp_path)
+
+    def reject_network(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("Unexpected network access")
+
+    monkeypatch.setattr(socket, "create_connection", reject_network)
+    monkeypatch.setattr(socket, "gethostbyname", reject_network)
+
+    assert len(load_locomo_retrieval_cases(path).cases) == 2
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        ([], "locomo_dataset_must_be_nonempty_list"),
+        ([{"sample_id": "x", "conversation": {}, "qa": []}], "locomo_sessions_missing"),
+        (
+            [
+                {
+                    "sample_id": "x",
+                    "conversation": {"session_1": [{"speaker": "a", "dia_id": "t", "text": "x"}]},
+                    "qa": [
+                        {"question": "q", "answer": "a", "category": "c", "evidence": ["missing"]}
+                    ],
+                }
+            ],
+            "locomo_evidence_invalid",
+        ),
+        (
+            [
+                {
+                    "sample_id": "x",
+                    "conversation": {"session_1": [{"speaker": "a", "dia_id": "t", "text": "x"}]},
+                    "qa": [{"question": "q", "answer": "a", "category": 1}],
+                }
+            ],
+            "locomo_evidence_invalid",
+        ),
+    ],
+)
+def test_adapter_fails_closed_for_malformed_required_evidence(
+    tmp_path: Path,
+    payload: object,
+    error: str,
+) -> None:
+    with pytest.raises(EvidenceContractError, match=error):
+        load_locomo_retrieval_cases(_write_dataset(tmp_path, payload))


### PR DESCRIPTION
## Summary
- normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence retrieval cases
- support documented numeric categories/answers and category-5 adversarial answers
- fail closed on missing or inconsistent evidence without downloading data, following image URLs, invoking models, reading a vault, or persisting outcomes

## Test plan
- [x] Focused pytest suite
- [x] mypy
- [x] Ruff
- [x] Documentation checks

Refs #448