### PR TITLE
feat(benchmark): add retained clustering scorecard (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
 - **Local LongMemEval retrieval adapter (#448)** — normalize acquired cleaned/oracle JSON into digest-pinned, order-preserving in-memory cases with separate session and answer-marked-turn evidence, without downloads, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
+- **Synthetic clustering scorecard metrics (#448)** — extend the existing no-vault, no-model benchmark with schema-versioned ARI, cluster count, and fixture-specific collapse rate output plus deterministic machine-readable artifacts.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
+- **Local LongMemEval retrieval adapter (#448)** — normalize acquired cleaned/oracle JSON into digest-pinned, order-preserving in-memory cases with separate session and answer-marked-turn evidence, without downloads, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
+- **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.
 
 ### Changed
 

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -123,3 +123,19 @@ and at least two distinct open external systems. It rejects mismatched dataset,
 model, judge, budget, or runtime context, and it keeps retrieval and end-to-end
 answer layers separate. The contract is evidence infrastructure, not a claim
 that a public suite or external system has already been executed.
+
+### LoCoMo local-data adapter
+
+`src.memory.locomo_adapter` accepts an already acquired LoCoMo JSON file and
+normalizes its documented ordered sessions, dialogue IDs, QA categories, and
+evidence IDs into deterministic retrieval cases. An empty upstream evidence
+list is represented as unavailable retrieval evidence, not an abstention label.
+The documented category-5 `adversarial_answer` is retained when the standard
+answer is absent. It does not download the
+dataset, resolve optional image URLs, call a model, read a vault, or persist
+outcomes. Missing or inconsistent required evidence fails closed.
+
+Its public conversation text is available only in memory to an evaluator. A
+later runner must retain outcomes, exclusions, and failures through the opaque
+artifact digests required by the cross-system evidence contract; loading LoCoMo
+alone is neither an executed benchmark nor a comparative claim.

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -103,3 +103,23 @@ The profile is synthetic and deterministic: no external data or network runtime 
 It intentionally does not report end-to-end answer quality: that belongs to the
 separate adapter layer, where answer model, judge, prompt, token budget, and
 failure policy can be pinned rather than conflated with retrieval quality.
+
+## Cross-system evidence contract
+
+`src.memory.benchmark_protocol` provides a closed, provider-free contract for
+the later public-suite adapter layer. It validates metadata only: no benchmark
+suite is downloaded, no model is invoked, and no prompt, answer, vault content,
+credential, path, or raw result is retained in the contract.
+
+Each run pins its suite and dataset revision, harness and Matryca revisions,
+dependency lock digest, system revision/configuration digest, hardware/runtime,
+budget, cache state, retry/failure policy, and model/judge configuration where applicable. Four
+opaque artifact digests are mandatory: item results, exclusions, failed runs,
+and run metadata. This makes omissions visible without publishing content.
+
+The comparative validator accepts only completed, like-for-like cohorts with
+one Matryca no-semantic-memory control, one Matryca candidate-feature control,
+and at least two distinct open external systems. It rejects mismatched dataset,
+model, judge, budget, or runtime context, and it keeps retrieval and end-to-end
+answer layers separate. The contract is evidence infrastructure, not a claim
+that a public suite or external system has already been executed.

--- a/docs/knowledge/architecture/llm-free-cluster-recognition.md
+++ b/docs/knowledge/architecture/llm-free-cluster-recognition.md
@@ -138,11 +138,23 @@ Run:
 
 ```bash
 uv run python scripts/bench_semantic_clustering_quality.py
+uv run python scripts/bench_semantic_clustering_quality.py \
+  --output benchmarks/results/semantic_clustering_scorecard.json
 ```
 
 The benchmark uses 288 opaque-titled synthetic notes, 12 labelled topics, five
 fixed random seeds, and no vault or model. It measures pairwise precision,
-recall, F1, purity, latency, and stability after reversing catalog input order.
+recall, F1, purity, adjusted Rand index (ARI), predicted cluster count,
+fixture-specific collapse rate, latency, and stability after reversing catalog
+input order. The JSON output is schema-versioned and records the synthetic
+fixture provenance, fixed seeds, and exact source commit. Artifact generation
+fails closed from a dirty source tree so that the recorded commit always names
+the code that produced it.
+
+Collapse rate is the normalized excess share of the largest predicted cluster
+above the balanced fixture's nominal 24-item topic size: `0` is ideal balanced
+separation and `1` means every item collapsed into one cluster. It is a
+diagnostic for this fixture, not a cross-system or real-vault quality claim.
 
 Observed on the development Mac:
 

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -38,6 +38,25 @@ This OpenSpec is a projection contract that keeps external expectations aligned 
 #### P1: hybrid retrieval, cache, and clustering
 
 - Retrieval composition is activated only after P0 acceptance.
+
+#### P0: governed coordination packet
+
+`P0EvidencePacket` is the content-free joining contract for one **retrieval-only**
+claim. It binds an exact source commit plus opaque references to the #186 canonical
+recall envelope, the #448 reproducible scorecard, and the #449 append-only archive
+event. Its canonical JSON and packet ID are byte-stable.
+
+All P0 persisted contract loaders use closed schemas: unknown fields fail closed
+instead of being retained as ungoverned content. The #448 adapter accepts only a
+retrieval-only scorecard scope and its exact manifest schema/version, dataset ID,
+and scorecard fingerprint; a scorecard is benchmark evidence, never runtime recall
+provenance or proof of end-to-end agent quality.
+
+The packet is deliberately a `proposed` value only. It performs no archive I/O,
+Shadow query, model call, remote export, canonical write, approval, or state
+transition. Accepted or rejected curation requires a later human-governed,
+canonical-write-adjacent slice; an external runtime cannot manufacture authority by
+attaching a label to a P0 packet. See [the evidence archive contract](evidence-archive.md).
 - Cache/fallback rules are deterministic.
 
 #### P2: proposal queue and curation

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -98,6 +98,13 @@ When publicly exposed, document in `.env.example` under **Advanced / high impact
 - Letta Evals, Mem0 memory-benchmarks, and Graphiti are treated as design/reference harness material.
 - No best/SOTA/world-leading claim is made before reproducible evidence with provenance.
 - Every claim must include task set, corpus/version, seed/config, and decision label.
+- Local suite adapters read only already acquired bytes, bind a source SHA-256, preserve
+  upstream order, and retain public benchmark text only in bounded in-memory cases; they
+  do not download, call models, access the vault, or persist results. LongMemEval's
+  session-level answer references and optional answer-marked turns remain separate, and
+  `_abs` IDs are metadata rather than inferred retrieval outcomes. Unknown upstream input
+  fields are deliberately ignored for forward compatibility; emitted evaluation contracts
+  remain closed and frozen.
 
 ## P0 canonical recall
 

--- a/docs/openspec/evidence-archive.md
+++ b/docs/openspec/evidence-archive.md
@@ -24,6 +24,11 @@ SHA-256 digests, UTC timestamps, and bounded classifications. Raw vault text,
 prompts, credentials, absolute paths, and reconstructed candidate prose are
 not accepted by this P0 contract.
 
+Its event identity may be referenced by the pure `P0EvidencePacket` coordination
+contract in [biological-memory.md](biological-memory.md). That reference never
+opens, replays, or writes this archive, and it does not turn a candidate into an
+accepted canonical memory.
+
 Events serialize as canonical JSON and derive an event ID from their canonical
 bytes. A replay of the same event is a no-op. A complete malformed record fails
 closed. A final unterminated JSON fragment is recoverable only when it has the

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -28,7 +28,15 @@ autonomous behavior is shipped; scaffolded later-phase components remain roadmap
 
 ### P0 — evidence controls, canonical recall/provenance/idempotence, and benchmark baseline
 
-1. Define governed evidence and provenance rules for recall envelope behavior.
+1. Define governed evidence and provenance rules for recall envelope behavior,
+   including a byte-stable `P0EvidencePacket` that joins recall, scorecard, and
+   append-only archive references without adding a write path.
+
+P0 is closed only when the four independently reviewable deliverables agree:
+the external append-only archive (#449), retrieval-only scorecard baseline (#448),
+gated canonical recall envelope (#186), and proposed-only governed packet (#447).
+Their completion is a prerequisite for P1; it is not a benchmark claim about
+end-to-end agent quality or authority to curate canonical memory.
 2. Define canonical recall fingerprints, invalidation behavior, and idempotent processing boundaries.
 3. Define benchmark baseline and acceptance policy.
 4. Define replay/rollback/freshness boundaries before any P1 rollout.

--- a/scripts/bench_semantic_clustering_quality.py
+++ b/scripts/bench_semantic_clustering_quality.py
@@ -7,9 +7,12 @@ import json
 import math
 import random
 import statistics
+import subprocess
 import time
+from argparse import ArgumentParser
 from collections import Counter
-from typing import Any
+from pathlib import Path
+from typing import Any, TypedDict
 
 from src.graph.semantic_clustering import compute_semantic_clusters
 
@@ -17,6 +20,20 @@ _SEEDS = (20260802, 20260803, 20260804, 20260805, 20260806)
 _TOPICS = 12
 _PAGES_PER_TOPIC = 24
 _MAX_CLUSTER_SIZE = 32
+_BENCHMARK_SCHEMA_VERSION = 2
+_FIXTURE_ID = "semantic-clustering-balanced-opaque-v1"
+
+
+class QualityScores(TypedDict):
+    """Deterministic quality measures for one clustering partition."""
+
+    ari: float
+    cluster_count: int
+    collapse_rate: float
+    pair_f1: float
+    pair_precision: float
+    pair_recall: float
+    purity: float
 
 
 def _opaque_title(seed: int, topic: int, page: int) -> str:
@@ -63,7 +80,7 @@ def _canonical(clusters: dict[str, list[str]]) -> tuple[tuple[str, ...], ...]:
     return tuple(sorted(tuple(sorted(members)) for members in clusters.values()))
 
 
-def _quality(clusters: dict[str, list[str]], labels: dict[str, int]) -> dict[str, float]:
+def _quality(clusters: dict[str, list[str]], labels: dict[str, int]) -> QualityScores:
     predicted_pairs = 0
     true_positive_pairs = 0
     purity_hits = 0
@@ -72,15 +89,45 @@ def _quality(clusters: dict[str, list[str]], labels: dict[str, int]) -> dict[str
         purity_hits += max(counts.values(), default=0)
         predicted_pairs += math.comb(len(members), 2)
         true_positive_pairs += sum(math.comb(count, 2) for count in counts.values())
-    true_pairs = _TOPICS * math.comb(_PAGES_PER_TOPIC, 2)
+    label_sizes = Counter(labels.values())
+    true_pairs = sum(math.comb(size, 2) for size in label_sizes.values())
     precision = true_positive_pairs / predicted_pairs if predicted_pairs else 0.0
     recall = true_positive_pairs / true_pairs if true_pairs else 0.0
     f1 = 2.0 * precision * recall / (precision + recall) if precision + recall else 0.0
+    cluster_sizes = [len(members) for members in clusters.values()]
+    predicted_cluster_pairs = sum(math.comb(size, 2) for size in cluster_sizes)
+    label_pairs = sum(math.comb(size, 2) for size in label_sizes.values())
+    total_pairs = math.comb(len(labels), 2)
+    expected_index = predicted_cluster_pairs * label_pairs / total_pairs if total_pairs else 0.0
+    maximum_index = (predicted_cluster_pairs + label_pairs) / 2.0
+    ari_denominator = maximum_index - expected_index
+    if ari_denominator:
+        adjusted_rand = (true_positive_pairs - expected_index) / ari_denominator
+    else:
+        predicted_partition = _canonical(clusters)
+        true_partition = _canonical(
+            {
+                str(label): [title for title, value in labels.items() if value == label]
+                for label in label_sizes
+            }
+        )
+        adjusted_rand = 1.0 if predicted_partition == true_partition else 0.0
+    largest_cluster_size = max(cluster_sizes, default=0)
+    nominal_cluster_size = len(labels) / len(label_sizes) if label_sizes else 0.0
+    collapse_denominator = len(labels) - nominal_cluster_size
+    collapse_rate = (
+        max(0.0, (largest_cluster_size - nominal_cluster_size) / collapse_denominator)
+        if collapse_denominator > 0
+        else 0.0
+    )
     return {
+        "ari": round(adjusted_rand, 4),
+        "cluster_count": len(cluster_sizes),
+        "collapse_rate": round(collapse_rate, 4),
         "pair_f1": round(f1, 4),
         "pair_precision": round(precision, 4),
         "pair_recall": round(recall, 4),
-        "purity": round(purity_hits / len(labels), 4),
+        "purity": round(purity_hits / len(labels), 4) if labels else 0.0,
     }
 
 
@@ -91,7 +138,7 @@ def _percentile(samples: list[float], percentile: float) -> float:
 
 
 def _run_scenario(scenario: str) -> dict[str, Any]:
-    runs: list[dict[str, float]] = []
+    runs: list[QualityScores] = []
     latencies: list[float] = []
     deterministic = True
     for seed in _SEEDS:
@@ -114,12 +161,67 @@ def _run_scenario(scenario: str) -> dict[str, Any]:
         "pair_precision_mean": round(statistics.mean(run["pair_precision"] for run in runs), 4),
         "pair_recall_mean": round(statistics.mean(run["pair_recall"] for run in runs), 4),
         "purity_mean": round(statistics.mean(run["purity"] for run in runs), 4),
+        "ari_mean": round(statistics.mean(run["ari"] for run in runs), 4),
+        "cluster_count_mean": round(statistics.mean(run["cluster_count"] for run in runs), 4),
+        "collapse_rate_mean": round(statistics.mean(run["collapse_rate"] for run in runs), 4),
     }
 
 
-def main() -> None:
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def _source_commit() -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError("unable to determine benchmark source commit") from exc
+    commit = completed.stdout.strip()
+    if not commit:
+        raise RuntimeError("git rev-parse HEAD returned an empty source commit")
+    return commit
+
+
+def _require_clean_source_tree() -> None:
+    try:
+        completed = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=Path(__file__).resolve().parents[1],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError("unable to determine benchmark source-tree cleanliness") from exc
+    if completed.stdout:
+        raise RuntimeError("refusing to write benchmark artifact from a dirty source tree")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    _require_clean_source_tree()
     scenarios = ("summary_and_tags", "summary_only", "tags_only", "no_features")
     payload = {
+        "benchmark_schema_version": _BENCHMARK_SCHEMA_VERSION,
+        "source_commit": _source_commit(),
+        "fixture": {
+            "id": _FIXTURE_ID,
+            "kind": "synthetic",
+            "provenance": (
+                "Generated in-memory by this benchmark from fixed opaque titles and labels."
+            ),
+            "evidence_boundary": "No vault, model, or remote content is used or represented.",
+        },
         "max_cluster_size": _MAX_CLUSTER_SIZE,
         "pages": _TOPICS * _PAGES_PER_TOPIC,
         "pages_per_topic": _PAGES_PER_TOPIC,
@@ -127,8 +229,14 @@ def main() -> None:
         "seeds": list(_SEEDS),
         "topics": _TOPICS,
     }
-    print(json.dumps(payload, sort_keys=True))
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is None:
+        print(rendered)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -17,12 +17,15 @@ from .decay import (
     half_life_days,
 )
 from .evidence_coordination import P0EvidencePacket
+from .locomo_adapter import LocomoDataset, LocomoRetrievalCase, load_locomo_retrieval_cases
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
     "DEFAULT_DECAY_RATE",
     "DEFAULT_REINFORCEMENT_BOOST",
     "MemoryEdgeState",
+    "LocomoDataset",
+    "LocomoRetrievalCase",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
     "calculate_decayed_weight",
@@ -34,5 +37,6 @@ __all__ = [
     "RecallBundle",
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
+    "load_locomo_retrieval_cases",
     "validate_comparative_cohort",
 ]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -18,6 +18,13 @@ from .decay import (
 )
 from .evidence_coordination import P0EvidencePacket
 from .locomo_adapter import LocomoDataset, LocomoRetrievalCase, load_locomo_retrieval_cases
+from .longmemeval_adapter import (
+    LongMemEvalDataset,
+    LongMemEvalRetrievalCase,
+    LongMemEvalSession,
+    LongMemEvalTurn,
+    load_longmemeval_retrieval_cases,
+)
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -26,6 +33,10 @@ __all__ = [
     "MemoryEdgeState",
     "LocomoDataset",
     "LocomoRetrievalCase",
+    "LongMemEvalDataset",
+    "LongMemEvalRetrievalCase",
+    "LongMemEvalSession",
+    "LongMemEvalTurn",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
     "calculate_decayed_weight",
@@ -38,5 +49,6 @@ __all__ = [
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
     "load_locomo_retrieval_cases",
+    "load_longmemeval_retrieval_cases",
     "validate_comparative_cohort",
 ]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,5 +1,10 @@
 """Biological memory graph layer (Nacre-inspired, Epic #99)."""
 
+from .benchmark_protocol import (
+    BenchmarkRunManifest,
+    BenchmarkRunReport,
+    validate_comparative_cohort,
+)
 from .config import memory_graph_enabled
 from .decay import (
     DEFAULT_DECAY_RATE,
@@ -18,6 +23,8 @@ __all__ = [
     "DEFAULT_DECAY_RATE",
     "DEFAULT_REINFORCEMENT_BOOST",
     "MemoryEdgeState",
+    "BenchmarkRunManifest",
+    "BenchmarkRunReport",
     "calculate_decayed_weight",
     "calculate_stability",
     "compute_decayed_weight_from_dates",
@@ -27,4 +34,5 @@ __all__ = [
     "RecallBundle",
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
+    "validate_comparative_cohort",
 ]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -11,6 +11,7 @@ from .decay import (
     days_between,
     half_life_days,
 )
+from .evidence_coordination import P0EvidencePacket
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -24,5 +25,6 @@ __all__ = [
     "half_life_days",
     "memory_graph_enabled",
     "RecallBundle",
+    "P0EvidencePacket",
     "recall_from_existing_retrieval",
 ]

--- a/src/memory/benchmark_protocol.py
+++ b/src/memory/benchmark_protocol.py
@@ -1,0 +1,368 @@
+"""Closed, content-free contracts for reproducible benchmark evidence.
+
+The contracts deliberately validate run provenance and opaque result artifacts;
+they do not download suites, invoke models, or retain prompts, answers, vault
+content, credentials, paths, or raw outputs.  A comparison is admissible only
+when its runs share the same evaluation context and contain the prespecified
+Matryca controls plus two reproducible external open-system controls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .evidence_models import EvidenceContractError
+
+BENCHMARK_PROTOCOL_SCHEMA_VERSION = "benchmark-protocol.v1"
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+SuiteName = Literal["beam", "locomo", "longmemeval", "longmemeval-v2", "memoryagentbench"]
+EvidenceClass = Literal[
+    "independently_reproduced",
+    "not_comparable",
+    "synthetic_design_evidence",
+    "upstream_reported_not_rerun",
+]
+EvaluationLayer = Literal["end_to_end_answer", "retrieval"]
+SystemRole = Literal[
+    "external_open_system",
+    "matryca_candidate_feature",
+    "matryca_without_semantic_memory",
+]
+RunStatus = Literal["completed", "excluded", "failed"]
+ArtifactKind = Literal["exclusions", "failed_runs", "item_results", "run_metadata"]
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _identifier(value: str, *, field: str) -> str:
+    normalized = value.strip()
+    if not _IDENTIFIER.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+def _git_revision(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not _GIT_REVISION.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+def _sha256(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not _SHA256.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+class DatasetPin(_ClosedModel):
+    """One legally attributable public-suite revision without local content."""
+
+    suite: SuiteName
+    dataset_id: str
+    repository_slug: str = Field(pattern=r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+    dataset_revision: str
+    license_id: str = Field(pattern=r"^[A-Za-z0-9_.-]+$")
+
+    @model_validator(mode="after")
+    def _validate_identifiers(self) -> DatasetPin:
+        object.__setattr__(self, "dataset_id", _identifier(self.dataset_id, field="dataset_id"))
+        object.__setattr__(
+            self,
+            "dataset_revision",
+            _git_revision(self.dataset_revision, field="dataset_revision"),
+        )
+        return self
+
+
+class ModelPin(_ClosedModel):
+    """Pinned evaluator model or the explicit provider-free sentinel."""
+
+    model_id: str
+    model_revision: str
+    prompt_digest: str
+    temperature_milli: int = Field(ge=0, le=2_000)
+    seed: int = Field(ge=0, le=2**31 - 1)
+
+    @model_validator(mode="after")
+    def _validate_pins(self) -> ModelPin:
+        object.__setattr__(self, "model_id", _identifier(self.model_id, field="model_id"))
+        object.__setattr__(
+            self,
+            "model_revision",
+            _identifier(self.model_revision, field="model_revision"),
+        )
+        object.__setattr__(
+            self,
+            "prompt_digest",
+            _sha256(self.prompt_digest, field="prompt_digest"),
+        )
+        return self
+
+
+class EvaluationBudget(_ClosedModel):
+    """Comparable retrieval and context limits for every system in a cohort."""
+
+    context_token_budget: int = Field(ge=1, le=10_000_000)
+    retrieval_call_budget: int = Field(ge=0, le=10_000)
+    top_k: int = Field(ge=1, le=1_000)
+    timeout_seconds: int = Field(ge=1, le=86_400)
+
+
+class RuntimePin(_ClosedModel):
+    """Content-free hardware and dependency provenance for one run."""
+
+    harness_revision: str
+    matryca_revision: str
+    dependency_lock_digest: str
+    hardware_class: str
+    os_family: str
+    runtime_version: str
+    concurrency: int = Field(ge=1, le=10_000)
+    cache_state: Literal["cold", "primed", "warm"]
+    failure_policy_id: str
+    retry_policy_id: str
+
+    @model_validator(mode="after")
+    def _validate_pins(self) -> RuntimePin:
+        object.__setattr__(
+            self,
+            "harness_revision",
+            _git_revision(self.harness_revision, field="harness_revision"),
+        )
+        object.__setattr__(
+            self,
+            "matryca_revision",
+            _git_revision(self.matryca_revision, field="matryca_revision"),
+        )
+        object.__setattr__(
+            self,
+            "dependency_lock_digest",
+            _sha256(self.dependency_lock_digest, field="dependency_lock_digest"),
+        )
+        object.__setattr__(
+            self,
+            "hardware_class",
+            _identifier(self.hardware_class, field="hardware_class"),
+        )
+        object.__setattr__(self, "os_family", _identifier(self.os_family, field="os_family"))
+        object.__setattr__(
+            self,
+            "runtime_version",
+            _identifier(self.runtime_version, field="runtime_version"),
+        )
+        object.__setattr__(
+            self,
+            "failure_policy_id",
+            _identifier(self.failure_policy_id, field="failure_policy_id"),
+        )
+        object.__setattr__(
+            self,
+            "retry_policy_id",
+            _identifier(self.retry_policy_id, field="retry_policy_id"),
+        )
+        return self
+
+
+class SystemPin(_ClosedModel):
+    """A reproducible system/control identity without configuration content."""
+
+    role: SystemRole
+    system_id: str
+    implementation_revision: str
+    configuration_digest: str
+    open_source: bool
+
+    @model_validator(mode="after")
+    def _validate_system(self) -> SystemPin:
+        object.__setattr__(self, "system_id", _identifier(self.system_id, field="system_id"))
+        object.__setattr__(
+            self,
+            "implementation_revision",
+            _git_revision(self.implementation_revision, field="implementation_revision"),
+        )
+        object.__setattr__(
+            self,
+            "configuration_digest",
+            _sha256(self.configuration_digest, field="configuration_digest"),
+        )
+        if self.role == "external_open_system" and not self.open_source:
+            raise EvidenceContractError("external_system_must_be_open_source")
+        if self.role != "external_open_system" and self.system_id != "matryca-plumber":
+            raise EvidenceContractError("matryca_control_must_use_matryca_id")
+        return self
+
+
+class OpaqueArtifact(_ClosedModel):
+    """Digest-pinned, retained result material stored outside the contract."""
+
+    kind: ArtifactKind
+    digest: str
+    record_count: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _validate_digest(self) -> OpaqueArtifact:
+        object.__setattr__(self, "digest", _sha256(self.digest, field=f"{self.kind}_digest"))
+        return self
+
+
+class BenchmarkRunManifest(_ClosedModel):
+    """Closed run manifest for one evaluation layer and one tested system."""
+
+    schema_version: str = BENCHMARK_PROTOCOL_SCHEMA_VERSION
+    cohort_id: str
+    dataset: DatasetPin
+    evaluation_layer: EvaluationLayer
+    system: SystemPin
+    answer_model: ModelPin | None
+    judge_model: ModelPin | None
+    budget: EvaluationBudget
+    runtime: RuntimePin
+    evidence_class: EvidenceClass
+
+    @model_validator(mode="after")
+    def _validate_manifest(self) -> BenchmarkRunManifest:
+        if self.schema_version != BENCHMARK_PROTOCOL_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_benchmark_protocol_schema")
+        object.__setattr__(self, "cohort_id", _identifier(self.cohort_id, field="cohort_id"))
+        if self.evaluation_layer == "retrieval":
+            if self.answer_model is not None or self.judge_model is not None:
+                raise EvidenceContractError("retrieval_run_cannot_pin_answer_or_judge")
+        elif self.answer_model is None or self.judge_model is None:
+            raise EvidenceContractError("end_to_end_run_requires_answer_and_judge")
+        return self
+
+    @property
+    def manifest_id(self) -> str:
+        return hashlib.sha256(canonical_manifest_bytes(self)).hexdigest()
+
+
+class BenchmarkRunReport(_ClosedModel):
+    """Run outcome that retains all result categories as opaque artifacts."""
+
+    manifest: BenchmarkRunManifest
+    status: RunStatus
+    artifacts: tuple[OpaqueArtifact, ...]
+
+    @model_validator(mode="after")
+    def _validate_report(self) -> BenchmarkRunReport:
+        artifacts = tuple(self.artifacts)
+        expected = {"exclusions", "failed_runs", "item_results", "run_metadata"}
+        if {artifact.kind for artifact in artifacts} != expected or len(artifacts) != len(expected):
+            raise EvidenceContractError("incomplete_or_duplicate_run_artifacts")
+        object.__setattr__(self, "artifacts", tuple(sorted(artifacts, key=lambda item: item.kind)))
+        if self.status == "completed" and any(
+            artifact.record_count > 0 for artifact in artifacts if artifact.kind == "failed_runs"
+        ):
+            raise EvidenceContractError("completed_run_cannot_have_failed_items")
+        return self
+
+    @property
+    def report_id(self) -> str:
+        return hashlib.sha256(canonical_report_bytes(self)).hexdigest()
+
+
+def canonical_manifest_bytes(manifest: BenchmarkRunManifest) -> bytes:
+    """Serialize a manifest deterministically without raw benchmark content."""
+    return json.dumps(
+        manifest.model_dump(mode="json"), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def canonical_report_bytes(report: BenchmarkRunReport) -> bytes:
+    """Serialize a retained-artifact report deterministically."""
+    return json.dumps(
+        report.model_dump(mode="json"), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def validate_comparative_cohort(reports: tuple[BenchmarkRunReport, ...]) -> str:
+    """Return a cohort fingerprint only for a like-for-like four-system baseline.
+
+    The validator does not score systems.  It proves only that a resulting
+    comparison has the required controls and compatible measurement context.
+    """
+    if len(reports) < 4:
+        raise EvidenceContractError("comparative_cohort_requires_four_runs")
+    manifests = tuple(report.manifest for report in reports)
+    if any(report.status != "completed" for report in reports):
+        raise EvidenceContractError("comparative_cohort_requires_completed_runs")
+    if len({manifest.cohort_id for manifest in manifests}) != 1:
+        raise EvidenceContractError("comparative_cohort_id_mismatch")
+    if len({manifest.evaluation_layer for manifest in manifests}) != 1:
+        raise EvidenceContractError("comparative_cohort_mixes_evaluation_layers")
+    reference = manifests[0]
+    comparison_key = (
+        reference.dataset,
+        reference.answer_model,
+        reference.judge_model,
+        reference.budget,
+        reference.runtime,
+    )
+    if any(
+        (
+            manifest.dataset,
+            manifest.answer_model,
+            manifest.judge_model,
+            manifest.budget,
+            manifest.runtime,
+        )
+        != comparison_key
+        for manifest in manifests[1:]
+    ):
+        raise EvidenceContractError("comparative_cohort_context_mismatch")
+    roles = [manifest.system.role for manifest in manifests]
+    if roles.count("matryca_without_semantic_memory") != 1:
+        raise EvidenceContractError("missing_matryca_no_memory_control")
+    if roles.count("matryca_candidate_feature") != 1:
+        raise EvidenceContractError("missing_matryca_candidate_control")
+    external_ids = {
+        manifest.system.system_id
+        for manifest in manifests
+        if manifest.system.role == "external_open_system"
+    }
+    if len(external_ids) < 2:
+        raise EvidenceContractError("comparative_cohort_requires_two_external_systems")
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "manifest_ids": sorted(manifest.manifest_id for manifest in manifests),
+                "report_ids": sorted(report.report_id for report in reports),
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+__all__ = [
+    "ArtifactKind",
+    "BENCHMARK_PROTOCOL_SCHEMA_VERSION",
+    "BenchmarkRunManifest",
+    "BenchmarkRunReport",
+    "DatasetPin",
+    "EvaluationBudget",
+    "EvaluationLayer",
+    "EvidenceClass",
+    "ModelPin",
+    "OpaqueArtifact",
+    "RunStatus",
+    "RuntimePin",
+    "SuiteName",
+    "SystemPin",
+    "SystemRole",
+    "canonical_manifest_bytes",
+    "canonical_report_bytes",
+    "validate_comparative_cohort",
+]

--- a/src/memory/evidence_coordination.py
+++ b/src/memory/evidence_coordination.py
@@ -1,0 +1,241 @@
+"""Pure, privacy-safe coordination contracts for the Memory P0 evidence gate.
+
+This module joins the independently owned P0 outputs without persisting,
+executing, accepting, or promoting anything.  Its values contain only opaque
+identifiers and bounded labels, so a packet cannot become a second semantic
+memory store or a canonical-write authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+from .evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    canonical_event_bytes,
+)
+from .recall import RECALL_SCHEMA_VERSION, RecallBundle, stable_recall_fingerprint
+
+COORDINATION_SCHEMA_VERSION = "governed-evidence-packet.v1"
+_GIT_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+P0ClaimLabel = Literal["retrieval_only"]
+P0MetricLayer = Literal["retrieval"]
+P0Decision = Literal["proposed"]
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _identifier(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _digest_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise EvidenceContractError(f"invalid_{field}")
+    return value
+
+
+def _schema_version(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise EvidenceContractError("invalid_scorecard_schema")
+    return value
+
+
+def _required_string(value: Mapping[str, Any], *, field: str) -> str:
+    raw = value.get(field)
+    if not isinstance(raw, str):
+        raise EvidenceContractError(f"invalid_{field}")
+    return raw
+
+
+@dataclass(frozen=True, slots=True)
+class P0EvidencePacket:
+    """A content-free, byte-stable reference bundle for one P0 retrieval claim.
+
+    ``decision`` is intentionally restricted to ``proposed``.  Human curation
+    and any accepted/rejected transition belong to later canonical-write work;
+    constructing this packet never grants that authority.
+    """
+
+    source_revision: str
+    recall_ref: EvidenceRef
+    scorecard_ref: EvidenceRef
+    archive_ref: EvidenceRef
+    claim_label: P0ClaimLabel = "retrieval_only"
+    metric_layers: tuple[P0MetricLayer, ...] = ("retrieval",)
+    decision: P0Decision = "proposed"
+    schema_version: str = COORDINATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_revision, str) or not _GIT_REVISION.fullmatch(
+            self.source_revision
+        ):
+            raise EvidenceContractError("invalid_source_revision")
+        for field, value in (
+            ("recall_ref", self.recall_ref),
+            ("scorecard_ref", self.scorecard_ref),
+            ("archive_ref", self.archive_ref),
+        ):
+            if not isinstance(value, EvidenceRef):
+                raise EvidenceContractError(f"invalid_{field}")
+        if self.claim_label != "retrieval_only":
+            raise EvidenceContractError("invalid_claim_label")
+        layers = tuple(self.metric_layers)
+        if layers != ("retrieval",):
+            raise EvidenceContractError("invalid_metric_layers")
+        object.__setattr__(self, "metric_layers", layers)
+        if self.decision != "proposed":
+            raise EvidenceContractError("invalid_decision")
+        if self.schema_version != COORDINATION_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_coordination_schema_version")
+
+    @property
+    def packet_id(self) -> str:
+        """Return the stable content address of this packet's governed claim."""
+        return hashlib.sha256(canonical_packet_bytes(self)).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "archive_ref": self.archive_ref.to_dict(),
+            "claim_label": self.claim_label,
+            "decision": self.decision,
+            "metric_layers": list(self.metric_layers),
+            "recall_ref": self.recall_ref.to_dict(),
+            "schema_version": self.schema_version,
+            "scorecard_ref": self.scorecard_ref.to_dict(),
+            "source_revision": self.source_revision,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> P0EvidencePacket:
+        expected = {
+            "archive_ref",
+            "claim_label",
+            "decision",
+            "metric_layers",
+            "recall_ref",
+            "schema_version",
+            "scorecard_ref",
+            "source_revision",
+        }
+        if set(value) != expected:
+            raise EvidenceContractError("unexpected_packet_fields")
+        raw_layers = value.get("metric_layers")
+        if not isinstance(raw_layers, list) or any(
+            not isinstance(layer, str) for layer in raw_layers
+        ):
+            raise EvidenceContractError("invalid_metric_layers")
+        refs: dict[str, EvidenceRef] = {}
+        for field in ("recall_ref", "scorecard_ref", "archive_ref"):
+            raw_ref = value.get(field)
+            if not isinstance(raw_ref, Mapping):
+                raise EvidenceContractError(f"invalid_{field}")
+            refs[field] = EvidenceRef.from_dict(raw_ref)
+        source_revision = _required_string(value, field="source_revision")
+        claim_label = _required_string(value, field="claim_label")
+        decision = _required_string(value, field="decision")
+        schema_version = _required_string(value, field="schema_version")
+        return cls(
+            source_revision=source_revision,
+            recall_ref=refs["recall_ref"],
+            scorecard_ref=refs["scorecard_ref"],
+            archive_ref=refs["archive_ref"],
+            claim_label=cast(P0ClaimLabel, claim_label),
+            metric_layers=tuple(cast(P0MetricLayer, layer) for layer in raw_layers),
+            decision=cast(P0Decision, decision),
+            schema_version=schema_version,
+        )
+
+
+def canonical_packet_bytes(packet: P0EvidencePacket) -> bytes:
+    """Return canonical JSON without semantic content, paths, or volatile metrics."""
+    return json.dumps(
+        packet.to_dict(), ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def recall_contract_ref(bundle: RecallBundle) -> EvidenceRef:
+    """Pin a #186 recall bundle through its stable, generation-bound fingerprint."""
+    if not isinstance(bundle, RecallBundle) or bundle.schema_version != RECALL_SCHEMA_VERSION:
+        raise EvidenceContractError("invalid_recall_bundle")
+    fingerprint = _digest_string(bundle.fingerprint, field="recall_fingerprint")
+    if fingerprint != stable_recall_fingerprint(bundle.cache_stable_prefix()):
+        raise EvidenceContractError("recall_fingerprint_unproven")
+    return EvidenceRef(
+        source_kind="canonical-recall",
+        source_id=_digest({"kind": "canonical-recall", "fingerprint": fingerprint}),
+        revision_digest=fingerprint,
+    )
+
+
+def scorecard_payload_ref(payload: Mapping[str, Any]) -> EvidenceRef:
+    """Pin a retrieval-only #448 scorecard without retaining its raw payload."""
+    if not isinstance(payload, Mapping):
+        raise EvidenceContractError("invalid_scorecard_payload")
+    schema_version = _schema_version(payload.get("manifest_schema_version"))
+    dataset_id = _identifier(payload.get("manifest_dataset_id"), field="scorecard_dataset")
+    fingerprint = _digest_string(
+        payload.get("scorecard_fingerprint"), field="scorecard_fingerprint"
+    )
+    scope = payload.get("evaluation_scope")
+    if (
+        not isinstance(scope, Mapping)
+        or set(scope) != {"retrieval_only", "end_to_end_answer_evaluated"}
+        or scope.get("retrieval_only") is not True
+        or scope.get("end_to_end_answer_evaluated") is not False
+    ):
+        raise EvidenceContractError("invalid_scorecard_scope")
+    return EvidenceRef(
+        source_kind="benchmark-scorecard",
+        source_id=_digest(
+            {
+                "dataset_id": dataset_id,
+                "kind": "benchmark-scorecard",
+                "schema_version": schema_version,
+            }
+        ),
+        revision_digest=fingerprint,
+    )
+
+
+def archive_event_ref(event: EvidenceEvent) -> EvidenceRef:
+    """Pin one append-only #449 event without opening or writing its archive."""
+    if not isinstance(event, EvidenceEvent):
+        raise EvidenceContractError("invalid_evidence_event")
+    event_id = _digest_string(event.event_id, field="event_id")
+    if hashlib.sha256(canonical_event_bytes(event)).hexdigest() != event_id:
+        raise EvidenceContractError("invalid_evidence_event")
+    return EvidenceRef(
+        source_kind="evidence-archive-event",
+        source_id=event.candidate.candidate_id,
+        revision_digest=event_id,
+    )
+
+
+__all__ = [
+    "COORDINATION_SCHEMA_VERSION",
+    "P0ClaimLabel",
+    "P0Decision",
+    "P0EvidencePacket",
+    "P0MetricLayer",
+    "archive_event_ref",
+    "canonical_packet_bytes",
+    "recall_contract_ref",
+    "scorecard_payload_ref",
+]

--- a/src/memory/evidence_models.py
+++ b/src/memory/evidence_models.py
@@ -78,6 +78,7 @@ class EvidenceRef:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceRef:
+        _require_exact_keys(value, {"source_kind", "source_id", "revision_digest"})
         return cls(
             source_kind=_required_string(value, "source_kind"),
             source_id=_required_string(value, "source_id"),
@@ -129,6 +130,10 @@ class MemoryCandidate:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> MemoryCandidate:
+        _require_exact_keys(
+            value,
+            {"candidate_id", "candidate_kind", "evidence_refs", "observed_at", "status"},
+        )
         raw_refs = value.get("evidence_refs")
         if not isinstance(raw_refs, list):
             raise EvidenceContractError("invalid_evidence_refs")
@@ -181,6 +186,7 @@ class EvidenceEvent:
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> EvidenceEvent:
+        _require_exact_keys(value, {"candidate", "event_type", "recorded_at", "schema_version"})
         raw_candidate = value.get("candidate")
         if not isinstance(raw_candidate, Mapping):
             raise EvidenceContractError("invalid_candidate")
@@ -217,6 +223,12 @@ def _required_int(value: Mapping[str, Any], key: str) -> int:
     if isinstance(raw, bool) or not isinstance(raw, int):
         raise EvidenceContractError(f"invalid_{key}")
     return raw
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str]) -> None:
+    """Reject unmodeled persisted fields before they can bypass privacy validation."""
+    if set(value) != expected:
+        raise EvidenceContractError("unexpected_fields")
 
 
 def _ref_sort_key(value: EvidenceRef) -> tuple[str, str, str]:

--- a/src/memory/locomo_adapter.py
+++ b/src/memory/locomo_adapter.py
@@ -1,0 +1,206 @@
+"""Local-only LoCoMo normalization for retrieval evaluation.
+
+The adapter accepts an already acquired public ``locomo10.json``-shaped file.
+It never downloads data, follows image URLs, invokes models, writes results, or
+touches a vault.  Public conversation text lives only in the returned in-memory
+cases; callers must retain produced outcomes through ``benchmark_protocol``'s
+opaque artifact boundary rather than serializing this adapter's values.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .evidence_models import EvidenceContractError
+
+_SESSION_KEY = re.compile(r"^session_(?P<index>[1-9][0-9]*)$")
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LocomoTurn(_ClosedModel):
+    """One public LoCoMo dialogue turn retained only for a local evaluation."""
+
+    turn_id: str = Field(min_length=1, max_length=256)
+    session_index: int = Field(ge=1)
+    speaker: str = Field(min_length=1, max_length=256)
+    text: str = Field(min_length=1)
+
+
+class LocomoRetrievalCase(_ClosedModel):
+    """A normalized QA item with its document-level retrieval evidence."""
+
+    case_id: str = Field(min_length=1, max_length=256)
+    sample_id: str = Field(min_length=1, max_length=256)
+    category: str = Field(min_length=1, max_length=256)
+    question: str = Field(min_length=1)
+    expected_answer: str = Field(min_length=1)
+    turns: tuple[LocomoTurn, ...] = Field(min_length=1)
+    evidence_turn_ids: tuple[str, ...]
+    evidence_available: bool
+
+
+class LocomoDataset(_ClosedModel):
+    """A deterministic, locally loaded LoCoMo retrieval-evaluation dataset."""
+
+    source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    cases: tuple[LocomoRetrievalCase, ...] = Field(min_length=1)
+
+
+def load_locomo_retrieval_cases(path: Path) -> LocomoDataset:
+    """Load documented LoCoMo conversations and QA evidence from one local file.
+
+    Unknown upstream fields, including optional image metadata, are deliberately
+    ignored. Required fields are validated fail-closed so malformed data cannot
+    silently become a benchmark result.
+    """
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError("locomo_dataset_unreadable") from exc
+    try:
+        raw: Any = json.loads(raw_bytes)
+    except json.JSONDecodeError as exc:
+        raise EvidenceContractError("locomo_dataset_invalid_json") from exc
+    if not isinstance(raw, list) or not raw:
+        raise EvidenceContractError("locomo_dataset_must_be_nonempty_list")
+
+    cases: list[LocomoRetrievalCase] = []
+    seen_case_ids: set[str] = set()
+    for sample_index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise EvidenceContractError("locomo_sample_invalid")
+        sample_id = _required_text(item, "sample_id", error="locomo_sample_id_invalid")
+        conversation = item.get("conversation")
+        if not isinstance(conversation, Mapping):
+            raise EvidenceContractError("locomo_conversation_invalid")
+        turns = _turns(conversation)
+        turn_ids = {turn.turn_id for turn in turns}
+        questions = item.get("qa")
+        if not isinstance(questions, list) or not questions:
+            raise EvidenceContractError("locomo_qa_invalid")
+        for question_index, question in enumerate(questions):
+            if not isinstance(question, Mapping):
+                raise EvidenceContractError("locomo_qa_invalid")
+            case_id = f"{sample_id}:{question_index + 1}"
+            if case_id in seen_case_ids:
+                raise EvidenceContractError("locomo_case_id_duplicate")
+            seen_case_ids.add(case_id)
+            if "evidence" not in question:
+                raise EvidenceContractError("locomo_evidence_invalid")
+            evidence_turn_ids = _evidence_ids(question["evidence"], turn_ids)
+            cases.append(
+                LocomoRetrievalCase(
+                    case_id=case_id,
+                    sample_id=sample_id,
+                    category=_required_scalar_text(
+                        question,
+                        "category",
+                        error="locomo_category_invalid",
+                    ),
+                    question=_required_text(question, "question", error="locomo_question_invalid"),
+                    expected_answer=_answer(question),
+                    turns=turns,
+                    evidence_turn_ids=evidence_turn_ids,
+                    evidence_available=bool(evidence_turn_ids),
+                )
+            )
+        if sample_index >= 10_000:
+            raise EvidenceContractError("locomo_dataset_too_many_samples")
+    return LocomoDataset(
+        source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+        cases=tuple(cases),
+    )
+
+
+def _turns(conversation: Mapping[str, Any]) -> tuple[LocomoTurn, ...]:
+    sessions: list[tuple[int, Sequence[Any]]] = []
+    for key, value in conversation.items():
+        match = _SESSION_KEY.fullmatch(key) if isinstance(key, str) else None
+        if match is None:
+            continue
+        if not isinstance(value, list) or not value:
+            raise EvidenceContractError("locomo_session_invalid")
+        sessions.append((int(match.group("index")), value))
+    if not sessions:
+        raise EvidenceContractError("locomo_sessions_missing")
+    if len({index for index, _turns_value in sessions}) != len(sessions):
+        raise EvidenceContractError("locomo_session_duplicate")
+
+    turns: list[LocomoTurn] = []
+    turn_ids: set[str] = set()
+    for session_index, session_turns in sorted(sessions):
+        for turn in session_turns:
+            if not isinstance(turn, Mapping):
+                raise EvidenceContractError("locomo_turn_invalid")
+            raw_turn_id = turn.get("dia_id")
+            if isinstance(raw_turn_id, bool) or not isinstance(raw_turn_id, (int, str)):
+                raise EvidenceContractError("locomo_turn_id_invalid")
+            turn_id = str(raw_turn_id).strip()
+            if not turn_id or turn_id in turn_ids:
+                raise EvidenceContractError("locomo_turn_id_invalid")
+            turn_ids.add(turn_id)
+            turns.append(
+                LocomoTurn(
+                    turn_id=turn_id,
+                    session_index=session_index,
+                    speaker=_required_text(turn, "speaker", error="locomo_speaker_invalid"),
+                    text=_required_text(turn, "text", error="locomo_turn_text_invalid"),
+                )
+            )
+    return tuple(turns)
+
+
+def _evidence_ids(value: object, turn_ids: set[str]) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise EvidenceContractError("locomo_evidence_invalid")
+    normalized: list[str] = []
+    for raw_turn_id in value:
+        if isinstance(raw_turn_id, bool) or not isinstance(raw_turn_id, (int, str)):
+            raise EvidenceContractError("locomo_evidence_invalid")
+        turn_id = str(raw_turn_id).strip()
+        if not turn_id or turn_id not in turn_ids or turn_id in normalized:
+            raise EvidenceContractError("locomo_evidence_invalid")
+        normalized.append(turn_id)
+    return tuple(normalized)
+
+
+def _required_text(value: Mapping[str, Any], key: str, *, error: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        raise EvidenceContractError(error)
+    return raw.strip()
+
+
+def _required_scalar_text(value: Mapping[str, Any], key: str, *, error: str) -> str:
+    raw = value.get(key)
+    if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+        raise EvidenceContractError(error)
+    normalized = str(raw).strip()
+    if not normalized:
+        raise EvidenceContractError(error)
+    return normalized
+
+
+def _answer(value: Mapping[str, Any]) -> str:
+    """Read the standard answer or the documented category-5 adversarial answer."""
+    if "answer" in value:
+        return _required_scalar_text(value, "answer", error="locomo_answer_invalid")
+    return _required_scalar_text(value, "adversarial_answer", error="locomo_answer_invalid")
+
+
+__all__ = [
+    "LocomoDataset",
+    "LocomoRetrievalCase",
+    "LocomoTurn",
+    "load_locomo_retrieval_cases",
+]

--- a/src/memory/longmemeval_adapter.py
+++ b/src/memory/longmemeval_adapter.py
@@ -1,0 +1,214 @@
+"""Local-only normalization for acquired LongMemEval cleaned JSON data.
+
+Unknown upstream fields are intentionally ignored for forward compatibility;
+the returned Pydantic models remain frozen and closed contracts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .evidence_models import EvidenceContractError
+
+_MAX_CASES = 10_000
+_MAX_SESSIONS = 10_000
+_MAX_TURNS_PER_SESSION = 10_000
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when a JSON object would otherwise silently overwrite a key."""
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LongMemEvalTurn(_ClosedModel):
+    """One retained public turn from an in-memory evaluation case."""
+
+    turn_id: str = Field(min_length=1, max_length=512)
+    role: Literal["user", "assistant"]
+    content: str = Field(min_length=1)
+    has_answer: bool = False
+
+
+class LongMemEvalSession(_ClosedModel):
+    """One haystack session, kept in the exact upstream sequence."""
+
+    session_id: str = Field(min_length=1, max_length=512)
+    date: str = Field(min_length=1, max_length=512)
+    turns: tuple[LongMemEvalTurn, ...] = Field(min_length=1)
+
+
+class LongMemEvalRetrievalCase(_ClosedModel):
+    """A deterministic LongMemEval question and its separate evidence views."""
+
+    case_id: str = Field(min_length=1, max_length=512)
+    question_id: str = Field(min_length=1, max_length=512)
+    question_type: str = Field(min_length=1, max_length=512)
+    question: str = Field(min_length=1)
+    expected_answer: str = Field(min_length=1)
+    question_date: str = Field(min_length=1, max_length=512)
+    sessions: tuple[LongMemEvalSession, ...] = Field(min_length=1)
+    evidence_session_ids: tuple[str, ...]
+    evidence_turn_ids: tuple[str, ...]
+    is_abstention: bool
+
+
+class LongMemEvalDataset(_ClosedModel):
+    """A locally loaded, digest-pinned LongMemEval dataset."""
+
+    source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    cases: tuple[LongMemEvalRetrievalCase, ...] = Field(min_length=1)
+
+
+def load_longmemeval_retrieval_cases(path: Path) -> LongMemEvalDataset:
+    """Load one acquired cleaned/oracle LongMemEval JSON file without side effects."""
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError("longmemeval_dataset_unreadable") from exc
+    try:
+        raw: Any = json.loads(raw_bytes, object_pairs_hook=_no_duplicate_json_keys)
+    except (_DuplicateJsonKeyError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceContractError("longmemeval_dataset_invalid_json") from exc
+    if not isinstance(raw, list) or not raw:
+        raise EvidenceContractError("longmemeval_dataset_must_be_nonempty_list")
+    if len(raw) > _MAX_CASES:
+        raise EvidenceContractError("longmemeval_dataset_too_many_cases")
+
+    cases: list[LongMemEvalRetrievalCase] = []
+    seen_case_ids: set[str] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise EvidenceContractError("longmemeval_case_invalid")
+        try:
+            case = _normalize_case(item)
+        except ValidationError as exc:
+            raise EvidenceContractError("longmemeval_case_invalid") from exc
+        if case.case_id in seen_case_ids:
+            raise EvidenceContractError("longmemeval_case_id_duplicate")
+        seen_case_ids.add(case.case_id)
+        cases.append(case)
+    try:
+        return LongMemEvalDataset(
+            source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+            cases=tuple(cases),
+        )
+    except ValidationError as exc:
+        raise EvidenceContractError("longmemeval_dataset_invalid") from exc
+
+
+def _normalize_case(item: Mapping[str, Any]) -> LongMemEvalRetrievalCase:
+    question_id = _required_text(item, "question_id", "longmemeval_question_id_invalid")
+    question_type = _required_text(item, "question_type", "longmemeval_question_type_invalid")
+    question = _required_text(item, "question", "longmemeval_question_invalid")
+    answer = _required_text(item, "answer", "longmemeval_answer_invalid")
+    question_date = _required_text(item, "question_date", "longmemeval_question_date_invalid")
+    session_ids = _required_text_list(item, "haystack_session_ids")
+    session_dates = _required_text_list(item, "haystack_dates")
+    raw_sessions = item.get("haystack_sessions")
+    answer_ids = _required_text_list(item, "answer_session_ids", allow_empty=True)
+    if not isinstance(raw_sessions, list) or not raw_sessions:
+        raise EvidenceContractError("longmemeval_haystack_sessions_invalid")
+    if len(raw_sessions) > _MAX_SESSIONS or len(session_ids) != len(raw_sessions):
+        raise EvidenceContractError("longmemeval_session_alignment_invalid")
+    if len(session_dates) != len(raw_sessions):
+        raise EvidenceContractError("longmemeval_date_alignment_invalid")
+    if len(set(session_ids)) != len(session_ids):
+        raise EvidenceContractError("longmemeval_session_id_duplicate")
+    if len(set(answer_ids)) != len(answer_ids):
+        raise EvidenceContractError("longmemeval_answer_session_id_duplicate")
+
+    sessions: list[LongMemEvalSession] = []
+    evidence_turn_ids: list[str] = []
+    for session_id, date, raw_turns in zip(session_ids, session_dates, raw_sessions, strict=True):
+        if not isinstance(raw_turns, list) or not raw_turns:
+            raise EvidenceContractError("longmemeval_session_invalid")
+        if len(raw_turns) > _MAX_TURNS_PER_SESSION:
+            raise EvidenceContractError("longmemeval_session_too_many_turns")
+        turns: list[LongMemEvalTurn] = []
+        for turn_index, raw_turn in enumerate(raw_turns, start=1):
+            if not isinstance(raw_turn, Mapping):
+                raise EvidenceContractError("longmemeval_turn_invalid")
+            role = raw_turn.get("role")
+            if role not in ("user", "assistant"):
+                raise EvidenceContractError("longmemeval_turn_role_invalid")
+            content = _required_text(raw_turn, "content", "longmemeval_turn_content_invalid")
+            has_answer = raw_turn.get("has_answer", False)
+            if not isinstance(has_answer, bool):
+                raise EvidenceContractError("longmemeval_turn_has_answer_invalid")
+            turn_id = f"{session_id}:turn-{turn_index}"
+            turns.append(
+                LongMemEvalTurn(
+                    turn_id=turn_id,
+                    role=role,
+                    content=content,
+                    has_answer=has_answer,
+                )
+            )
+            if has_answer:
+                evidence_turn_ids.append(turn_id)
+        sessions.append(LongMemEvalSession(session_id=session_id, date=date, turns=tuple(turns)))
+
+    session_id_set = set(session_ids)
+    if any(answer_id not in session_id_set for answer_id in answer_ids):
+        raise EvidenceContractError("longmemeval_answer_session_reference_invalid")
+    try:
+        return LongMemEvalRetrievalCase(
+            case_id=question_id,
+            question_id=question_id,
+            question_type=question_type,
+            question=question,
+            expected_answer=answer,
+            question_date=question_date,
+            sessions=tuple(sessions),
+            evidence_session_ids=tuple(answer_ids),
+            evidence_turn_ids=tuple(evidence_turn_ids),
+            is_abstention=question_id.endswith("_abs"),
+        )
+    except ValidationError as exc:
+        raise EvidenceContractError("longmemeval_case_invalid") from exc
+
+
+def _no_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while rejecting duplicate members deterministically."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _required_text(value: Mapping[str, Any], key: str, error: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        raise EvidenceContractError(error)
+    return raw.strip()
+
+
+def _required_text_list(
+    value: Mapping[str, Any], key: str, *, allow_empty: bool = False
+) -> list[str]:
+    raw = value.get(key)
+    if not isinstance(raw, list) or (not raw and not allow_empty):
+        raise EvidenceContractError(f"longmemeval_{key}_invalid")
+    error = f"longmemeval_{key}_invalid"
+    normalized = [_required_text({"value": entry}, "value", error) for entry in raw]
+    return normalized
+
+
+__all__ = [
+    "LongMemEvalDataset",
+    "LongMemEvalRetrievalCase",
+    "LongMemEvalSession",
+    "LongMemEvalTurn",
+    "load_longmemeval_retrieval_cases",
+]

--- a/src/memory/recall.py
+++ b/src/memory/recall.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sqlite3
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -113,6 +114,11 @@ def _digest(value: object) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def stable_recall_fingerprint(prefix: Mapping[str, Any]) -> str:
+    """Hash the exact reusable recall prefix used by the canonical envelope."""
+    return _digest(prefix)
+
+
 def _bundle(
     *,
     state: RecallState,
@@ -136,7 +142,7 @@ def _bundle(
         "results": [item.model_dump(mode="json") for item in results],
         "per_turn_expansion_budget": MAX_RECALL_RESULTS_PER_TURN,
     }
-    fingerprint = _digest(stable)
+    fingerprint = stable_recall_fingerprint(stable)
     return RecallBundle(
         schema_version=RECALL_SCHEMA_VERSION,
         state=state,
@@ -296,4 +302,5 @@ __all__ = [
     "RecallVolatileMetadata",
     "normalize_recall_query",
     "recall_from_existing_retrieval",
+    "stable_recall_fingerprint",
 ]

--- a/tests/test_benchmark_protocol.py
+++ b/tests/test_benchmark_protocol.py
@@ -1,0 +1,221 @@
+"""Tests for closed, reproducible cross-system benchmark contracts."""
+
+from __future__ import annotations
+
+import pytest
+from src.memory.benchmark_protocol import (
+    BENCHMARK_PROTOCOL_SCHEMA_VERSION,
+    BenchmarkRunManifest,
+    BenchmarkRunReport,
+    DatasetPin,
+    EvaluationBudget,
+    EvaluationLayer,
+    ModelPin,
+    OpaqueArtifact,
+    RuntimePin,
+    SystemPin,
+    SystemRole,
+    canonical_manifest_bytes,
+    canonical_report_bytes,
+    validate_comparative_cohort,
+)
+from src.memory.evidence_models import EvidenceContractError
+
+_A = "a" * 40
+_B = "b" * 40
+_C = "c" * 40
+_D = "d" * 40
+_E = "e" * 40
+_F = "f" * 40
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+_DIGEST_C = "c" * 64
+_DIGEST_D = "d" * 64
+_DIGEST_E = "e" * 64
+
+
+def _runtime() -> RuntimePin:
+    return RuntimePin(
+        harness_revision=_A,
+        matryca_revision=_B,
+        dependency_lock_digest=_DIGEST_A,
+        hardware_class="apple-m4-max-64gb",
+        os_family="macos-15",
+        runtime_version="python-3.12",
+        concurrency=1,
+        cache_state="cold",
+        failure_policy_id="retain-all-terminal-outcomes",
+        retry_policy_id="no-retry",
+    )
+
+
+def _manifest(
+    role: SystemRole,
+    system_id: str,
+    *,
+    layer: EvaluationLayer = "retrieval",
+) -> BenchmarkRunManifest:
+    return BenchmarkRunManifest(
+        schema_version=BENCHMARK_PROTOCOL_SCHEMA_VERSION,
+        cohort_id="locomo-retrieval-baseline-v1",
+        dataset=DatasetPin(
+            suite="locomo",
+            dataset_id="locomo-v1",
+            repository_slug="snap-research/locomo",
+            dataset_revision=_C,
+            license_id="CC-BY-4.0",
+        ),
+        evaluation_layer=layer,
+        system=SystemPin(
+            role=role,
+            system_id=system_id,
+            implementation_revision=_D if system_id == "matryca-plumber" else _E,
+            configuration_digest=_DIGEST_B,
+            open_source=True,
+        ),
+        answer_model=None,
+        judge_model=None,
+        budget=EvaluationBudget(
+            context_token_budget=8_192,
+            retrieval_call_budget=4,
+            top_k=8,
+            timeout_seconds=60,
+        ),
+        runtime=_runtime(),
+        evidence_class="independently_reproduced",
+    )
+
+
+def _report(role: SystemRole, system_id: str) -> BenchmarkRunReport:
+    return BenchmarkRunReport(
+        manifest=_manifest(role, system_id),
+        status="completed",
+        artifacts=(
+            OpaqueArtifact(kind="item_results", digest=_DIGEST_A, record_count=24),
+            OpaqueArtifact(kind="run_metadata", digest=_DIGEST_B, record_count=1),
+            OpaqueArtifact(kind="exclusions", digest=_DIGEST_C, record_count=0),
+            OpaqueArtifact(kind="failed_runs", digest=_DIGEST_D, record_count=0),
+        ),
+    )
+
+
+def test_manifest_and_report_are_closed_and_byte_stable() -> None:
+    report = _report("matryca_without_semantic_memory", "matryca-plumber")
+
+    assert canonical_manifest_bytes(report.manifest) == canonical_manifest_bytes(report.manifest)
+    assert canonical_report_bytes(report) == canonical_report_bytes(report)
+    assert len(report.manifest.manifest_id) == 64
+    assert len(report.report_id) == 64
+    with pytest.raises(ValueError):
+        BenchmarkRunManifest.model_validate(
+            {**report.manifest.model_dump(), "raw_prompt": "unsafe"}
+        )
+
+
+def test_retrieval_and_end_to_end_layers_cannot_be_conflated() -> None:
+    retrieval = _manifest("matryca_candidate_feature", "matryca-plumber")
+
+    with pytest.raises(ValueError, match="retrieval_run_cannot_pin_answer_or_judge"):
+        BenchmarkRunManifest.model_validate(
+            {**retrieval.model_dump(), "answer_model": _model().model_dump()}
+        )
+    with pytest.raises(ValueError, match="end_to_end_run_requires_answer_and_judge"):
+        BenchmarkRunManifest.model_validate(
+            {**retrieval.model_dump(), "evaluation_layer": "end_to_end_answer"}
+        )
+
+
+def _model() -> ModelPin:
+    return ModelPin(
+        model_id="local-judge",
+        model_revision="v1",
+        prompt_digest=_DIGEST_E,
+        temperature_milli=0,
+        seed=7,
+    )
+
+
+def test_report_requires_all_retained_result_categories() -> None:
+    report = _report("matryca_candidate_feature", "matryca-plumber")
+
+    with pytest.raises(ValueError, match="incomplete_or_duplicate_run_artifacts"):
+        BenchmarkRunReport(
+            manifest=report.manifest,
+            status="completed",
+            artifacts=report.artifacts[:-1],
+        )
+    failed = OpaqueArtifact(kind="failed_runs", digest=_DIGEST_D, record_count=1)
+    without_failed = tuple(item for item in report.artifacts if item.kind != "failed_runs")
+    with pytest.raises(ValueError, match="completed_run_cannot_have_failed_items"):
+        BenchmarkRunReport(
+            manifest=report.manifest,
+            status="completed",
+            artifacts=(*without_failed, failed),
+        )
+
+
+def test_comparative_cohort_requires_matryca_controls_and_two_open_systems() -> None:
+    reports = (
+        _report("matryca_without_semantic_memory", "matryca-plumber"),
+        _report("matryca_candidate_feature", "matryca-plumber"),
+        _report("external_open_system", "mem0"),
+        _report("external_open_system", "graphiti"),
+    )
+
+    assert validate_comparative_cohort(reports) == validate_comparative_cohort(reports)
+    duplicated_external = (*reports[:-1], _report("external_open_system", "mem0"))
+    with pytest.raises(
+        EvidenceContractError,
+        match="comparative_cohort_requires_two_external_systems",
+    ):
+        validate_comparative_cohort(duplicated_external)
+
+
+def test_comparative_cohort_rejects_context_or_layer_mismatch() -> None:
+    reports = list(
+        (
+            _report("matryca_without_semantic_memory", "matryca-plumber"),
+            _report("matryca_candidate_feature", "matryca-plumber"),
+            _report("external_open_system", "mem0"),
+            _report("external_open_system", "graphiti"),
+        )
+    )
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {
+                **reports[-1].manifest.model_dump(),
+                "budget": {**reports[-1].manifest.budget.model_dump(), "top_k": 9},
+            }
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
+
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
+        validate_comparative_cohort(tuple(reports))
+
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {
+                **reports[-1].manifest.model_dump(),
+                "budget": reports[0].manifest.budget.model_dump(),
+                "runtime": {
+                    **reports[-1].manifest.runtime.model_dump(),
+                    "cache_state": "warm",
+                    "retry_policy_id": "one-bounded-retry",
+                },
+            }
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
+        validate_comparative_cohort(tuple(reports))
+    with pytest.raises(ValueError, match="external_system_must_be_open_source"):
+        SystemPin(
+            role="external_open_system",
+            system_id="closed-memory",
+            implementation_revision=_F,
+            configuration_digest=_DIGEST_A,
+            open_source=False,
+        )

--- a/tests/test_evidence_coordination.py
+++ b/tests/test_evidence_coordination.py
@@ -1,0 +1,210 @@
+"""Deterministic, side-effect-free contract tests for Memory P0 coordination (#447)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+from scripts import bench_bm25_query_cache as benchmark
+from src.memory.evidence_coordination import (
+    COORDINATION_SCHEMA_VERSION,
+    P0EvidencePacket,
+    archive_event_ref,
+    canonical_packet_bytes,
+    recall_contract_ref,
+    scorecard_payload_ref,
+)
+from src.memory.evidence_models import (
+    EvidenceContractError,
+    EvidenceEvent,
+    EvidenceRef,
+    MemoryCandidate,
+)
+from src.memory.recall import RecallBundle, stable_recall_fingerprint
+
+_A = "a" * 64
+_B = "b" * 64
+_C = "c" * 64
+_REVISION = "d" * 40
+
+
+def _event() -> EvidenceEvent:
+    return EvidenceEvent(
+        candidate=MemoryCandidate(
+            candidate_id=_A,
+            candidate_kind="semantic-claim",
+            observed_at="2026-08-10T12:00:00Z",
+            evidence_refs=(EvidenceRef("benchmark", _B, _C),),
+        ),
+        recorded_at="2026-08-10T12:01:00Z",
+    )
+
+
+def _bundle() -> RecallBundle:
+    bundle = RecallBundle(
+        state="completed",
+        code="recall_completed",
+        graph_generation=7,
+        normalized_query="opaque normalized query",
+        limit=3,
+        fingerprint=_B,
+        no_progress_signature=_C,
+        per_turn_expansion_budget=50,
+    )
+    return bundle.model_copy(
+        update={"fingerprint": stable_recall_fingerprint(bundle.cache_stable_prefix())}
+    )
+
+
+def _scorecard() -> dict[str, object]:
+    return {
+        "manifest_schema_version": 1,
+        "manifest_dataset_id": "synthetic-hard-negatives.v1",
+        "scorecard_fingerprint": _C,
+        "evaluation_scope": {"retrieval_only": True, "end_to_end_answer_evaluated": False},
+    }
+
+
+def _packet() -> P0EvidencePacket:
+    return P0EvidencePacket(
+        source_revision=_REVISION,
+        recall_ref=recall_contract_ref(_bundle()),
+        scorecard_ref=scorecard_payload_ref(_scorecard()),
+        archive_ref=archive_event_ref(_event()),
+    )
+
+
+def test_packet_is_byte_stable_immutable_and_content_free() -> None:
+    packet = _packet()
+
+    assert packet.schema_version == COORDINATION_SCHEMA_VERSION
+    assert canonical_packet_bytes(packet) == canonical_packet_bytes(packet)
+    assert len(packet.packet_id) == 64
+    assert b"opaque normalized query" not in canonical_packet_bytes(packet)
+    assert P0EvidencePacket.from_dict(packet.to_dict()) == packet
+    with pytest.raises(FrozenInstanceError):
+        packet.__setattr__("decision", "accepted")
+
+
+def test_packet_rejects_unknown_persisted_fields() -> None:
+    payload = _packet().to_dict() | {"raw_query": "must not persist"}
+    with pytest.raises(EvidenceContractError, match="unexpected_packet_fields"):
+        P0EvidencePacket.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        lambda packet: replace(packet, source_revision="e" * 40),
+        lambda packet: replace(packet, recall_ref=EvidenceRef("canonical-recall", _A, _C)),
+        lambda packet: replace(packet, scorecard_ref=EvidenceRef("benchmark-scorecard", _A, _C)),
+        lambda packet: replace(packet, archive_ref=EvidenceRef("evidence-archive-event", _A, _C)),
+    ],
+)
+def test_every_governed_reference_change_invalidates_packet_id(
+    changed: Callable[[P0EvidencePacket], P0EvidencePacket],
+) -> None:
+    packet = _packet()
+    assert changed(packet).packet_id != packet.packet_id
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("source_revision", "not-a-commit", "invalid_source_revision"),
+        ("claim_label", "end_to_end", "invalid_claim_label"),
+        ("metric_layers", ("retrieval", "answer"), "invalid_metric_layers"),
+        ("decision", "accepted", "invalid_decision"),
+        (
+            "schema_version",
+            "governed-evidence-packet.v2",
+            "unsupported_coordination_schema_version",
+        ),
+    ],
+)
+def test_packet_rejects_ungoverned_claim_expansion(
+    field: str,
+    value: str | tuple[str, ...],
+    error: str,
+) -> None:
+    payload = _packet().to_dict()
+    payload[field] = list(value) if field == "metric_layers" else value
+    with pytest.raises(EvidenceContractError, match=error):
+        P0EvidencePacket.from_dict(payload)
+
+
+def test_adapters_are_deterministic_and_never_open_external_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.memory.evidence_archive.EvidenceArchive.for_graph",
+        lambda *_args, **_kwargs: pytest.fail("coordination must not open the archive"),
+    )
+    assert recall_contract_ref(_bundle()) == recall_contract_ref(_bundle())
+    assert scorecard_payload_ref(_scorecard()) == scorecard_payload_ref(_scorecard())
+    assert archive_event_ref(_event()) == archive_event_ref(_event())
+
+
+def test_recall_adapter_rejects_a_forged_but_well_formed_fingerprint() -> None:
+    forged = _bundle().model_copy(update={"fingerprint": _A})
+
+    with pytest.raises(EvidenceContractError, match="recall_fingerprint_unproven"):
+        recall_contract_ref(forged)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "manifest_schema_version": "bad/path",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+        },
+        {
+            "manifest_schema_version": "scorecard.v1",
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {"retrieval_only": False, "end_to_end_answer_evaluated": True},
+        },
+        {
+            "manifest_schema_version": 1,
+            "manifest_dataset_id": "dataset",
+            "scorecard_fingerprint": _C,
+            "evaluation_scope": {
+                "retrieval_only": True,
+                "end_to_end_answer_evaluated": False,
+                "raw": "not accepted",
+            },
+        },
+    ],
+)
+def test_scorecard_adapter_rejects_unpinned_or_non_retrieval_claims(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(EvidenceContractError):
+        scorecard_payload_ref(payload)
+
+
+def test_scorecard_adapter_accepts_the_real_p0_scorecard_payload() -> None:
+    manifest_path = Path(__file__).parent / "fixtures" / "bm25_hard_negative_manifest_v1.json"
+    manifest, _manifest_digest = benchmark._read_manifest(manifest_path)  # noqa: SLF001
+    payload = benchmark._run_scorecard_benchmark(  # noqa: SLF001
+        manifest,
+        top_k=8,
+    )
+
+    reference = scorecard_payload_ref(payload)
+
+    assert reference.source_kind == "benchmark-scorecard"
+    assert reference.revision_digest == payload["scorecard_fingerprint"]
+
+
+def test_coordination_module_has_no_runtime_or_storage_dependency() -> None:
+    source = __import__("src.memory.evidence_coordination", fromlist=["__file__"]).__file__
+    assert source is not None
+    text = Path(source).read_text(encoding="utf-8")
+    for forbidden in ("sqlite3", "pathlib", "EvidenceArchive", "open_shadow", "os.", "subprocess"):
+        assert forbidden not in text

--- a/tests/test_evidence_models.py
+++ b/tests/test_evidence_models.py
@@ -67,3 +67,39 @@ def test_evidence_refs_must_be_canonical_and_unique() -> None:
             observed_at="2026-08-10T12:00:00Z",
             evidence_refs=(second, second),
         )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "source_kind": "benchmark",
+            "source_id": _DIGEST_B,
+            "revision_digest": _DIGEST_C,
+            "raw": "x",
+        },
+        {
+            "candidate_id": _DIGEST_A,
+            "candidate_kind": "semantic-claim",
+            "evidence_refs": [],
+            "observed_at": "2026-08-10T12:00:00Z",
+            "status": "proposed",
+            "raw": "x",
+        },
+        {
+            "candidate": _candidate().to_dict(),
+            "event_type": "candidate_observed",
+            "recorded_at": "2026-08-10T12:01:00Z",
+            "schema_version": 1,
+            "raw": "x",
+        },
+    ],
+)
+def test_replay_rejects_unmodeled_content_bearing_fields(payload: dict[str, object]) -> None:
+    with pytest.raises(EvidenceContractError, match="unexpected_fields"):
+        if "source_kind" in payload:
+            EvidenceRef.from_dict(payload)
+        elif "candidate_id" in payload:
+            MemoryCandidate.from_dict(payload)
+        else:
+            EvidenceEvent.from_dict(payload)

--- a/tests/test_locomo_adapter.py
+++ b/tests/test_locomo_adapter.py
@@ -1,0 +1,128 @@
+"""Tests for the local-only LoCoMo retrieval adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.locomo_adapter import load_locomo_retrieval_cases
+
+
+def _dataset() -> list[object]:
+    return [
+        {
+            "sample_id": "locomo-sample-1",
+            "conversation": {
+                "speaker_a": "A",
+                "speaker_b": "B",
+                "session_2_date_time": "2024-01-02",
+                "session_2": [
+                    {"speaker": "B", "dia_id": "turn-2", "text": "The revised plan is active."},
+                ],
+                "session_1": [
+                    {
+                        "speaker": "A",
+                        "dia_id": "turn-1",
+                        "text": "The earlier plan was provisional.",
+                        "img_url": "https://example.invalid/not-followed",
+                    },
+                ],
+            },
+            "qa": [
+                {
+                    "question": "Which plan is active?",
+                    "answer": "The revised plan.",
+                    "category": 2,
+                    "evidence": ["turn-2"],
+                },
+                {
+                    "question": "What is the unreleased codename?",
+                    "adversarial_answer": 2022,
+                    "category": 5,
+                    "evidence": [],
+                },
+            ],
+        }
+    ]
+
+
+def _write_dataset(tmp_path: Path, payload: object | None = None) -> Path:
+    path = tmp_path / "locomo10.json"
+    path.write_text(json.dumps(_dataset() if payload is None else payload), encoding="utf-8")
+    return path
+
+
+def test_adapter_normalizes_sessions_evidence_and_abstention_deterministically(
+    tmp_path: Path,
+) -> None:
+    path = _write_dataset(tmp_path)
+
+    dataset = load_locomo_retrieval_cases(path)
+
+    assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert [case.case_id for case in dataset.cases] == ["locomo-sample-1:1", "locomo-sample-1:2"]
+    assert [turn.turn_id for turn in dataset.cases[0].turns] == ["turn-1", "turn-2"]
+    assert dataset.cases[0].evidence_turn_ids == ("turn-2",)
+    assert dataset.cases[0].category == "2"
+    assert dataset.cases[0].evidence_available is True
+    assert dataset.cases[1].evidence_turn_ids == ()
+    assert dataset.cases[1].category == "5"
+    assert dataset.cases[1].expected_answer == "2022"
+    assert dataset.cases[1].evidence_available is False
+
+
+def test_adapter_never_opens_network_or_follows_optional_image_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_dataset(tmp_path)
+
+    def reject_network(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("Unexpected network access")
+
+    monkeypatch.setattr(socket, "create_connection", reject_network)
+    monkeypatch.setattr(socket, "gethostbyname", reject_network)
+
+    assert len(load_locomo_retrieval_cases(path).cases) == 2
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        ([], "locomo_dataset_must_be_nonempty_list"),
+        ([{"sample_id": "x", "conversation": {}, "qa": []}], "locomo_sessions_missing"),
+        (
+            [
+                {
+                    "sample_id": "x",
+                    "conversation": {"session_1": [{"speaker": "a", "dia_id": "t", "text": "x"}]},
+                    "qa": [
+                        {"question": "q", "answer": "a", "category": "c", "evidence": ["missing"]}
+                    ],
+                }
+            ],
+            "locomo_evidence_invalid",
+        ),
+        (
+            [
+                {
+                    "sample_id": "x",
+                    "conversation": {"session_1": [{"speaker": "a", "dia_id": "t", "text": "x"}]},
+                    "qa": [{"question": "q", "answer": "a", "category": 1}],
+                }
+            ],
+            "locomo_evidence_invalid",
+        ),
+    ],
+)
+def test_adapter_fails_closed_for_malformed_required_evidence(
+    tmp_path: Path,
+    payload: object,
+    error: str,
+) -> None:
+    with pytest.raises(EvidenceContractError, match=error):
+        load_locomo_retrieval_cases(_write_dataset(tmp_path, payload))

--- a/tests/test_longmemeval_adapter.py
+++ b/tests/test_longmemeval_adapter.py
@@ -1,0 +1,174 @@
+"""Tests for the local-only LongMemEval retrieval adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.longmemeval_adapter import load_longmemeval_retrieval_cases
+
+
+def _case(*, question_id: str = "q-1") -> dict[str, object]:
+    return {
+        "question_id": question_id,
+        "question_type": "multi_session",
+        "question": "What changed?",
+        "answer": "The revised plan.",
+        "question_date": "2024-01-03",
+        "haystack_session_ids": ["session-z", "session-a"],
+        "haystack_dates": ["2024-01-01", "2024-01-02"],
+        "haystack_sessions": [
+            [
+                {"role": "user", "content": "The old plan."},
+                {"role": "assistant", "content": "It was provisional."},
+            ],
+            [
+                {"role": "user", "content": "The revised plan.", "has_answer": True},
+            ],
+        ],
+        "answer_session_ids": ["session-a"],
+        "unknown_field": {"ignored": True},
+    }
+
+
+def _write_dataset(tmp_path: Path, payload: object) -> Path:
+    path = tmp_path / "longmemeval_s_cleaned.json"
+    path.write_bytes(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+    return path
+
+
+def test_normalizes_digest_evidence_and_preserves_upstream_order(tmp_path: Path) -> None:
+    payload = [_case()]
+    path = _write_dataset(tmp_path, payload)
+
+    dataset = load_longmemeval_retrieval_cases(path)
+    case = dataset.cases[0]
+
+    assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert case.case_id == "q-1"
+    assert [session.session_id for session in case.sessions] == ["session-z", "session-a"]
+    assert [session.date for session in case.sessions] == ["2024-01-01", "2024-01-02"]
+    assert case.evidence_session_ids == ("session-a",)
+    assert case.evidence_turn_ids == ("session-a:turn-1",)
+    assert case.is_abstention is False
+    assert case.sessions[0].turns[0].turn_id == "session-z:turn-1"
+    # Unknown upstream fields are intentionally ignored for forward compatibility.
+    assert case.question == "What changed?"
+    assert case.model_config["extra"] == "forbid"
+
+
+def test_digest_is_stable_and_abs_is_metadata_not_inferred_evidence(tmp_path: Path) -> None:
+    payload = [_case(question_id="q-2_abs")]
+    path = _write_dataset(tmp_path, payload)
+
+    first = load_longmemeval_retrieval_cases(path)
+    second = load_longmemeval_retrieval_cases(path)
+
+    assert first == second
+    assert first.cases[0].is_abstention is True
+    assert first.cases[0].evidence_session_ids == ("session-a",)
+
+    abstention_path = _write_dataset(
+        tmp_path,
+        [{**_case(question_id="q-3_abs"), "answer_session_ids": []}],
+    )
+    abstention = load_longmemeval_retrieval_cases(abstention_path).cases[0]
+    assert abstention.is_abstention is True
+    assert abstention.evidence_session_ids == ()
+    assert abstention.evidence_turn_ids == ("session-a:turn-1",)
+
+
+def test_preserves_multiple_evidence_and_oracle_style_nonchronological_order(
+    tmp_path: Path,
+) -> None:
+    payload = _case()
+    payload["haystack_dates"] = ["2024-12-31", "2023-01-01"]
+    payload["answer_session_ids"] = ["session-a", "session-z"]
+
+    case = load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload])).cases[0]
+
+    assert [session.session_id for session in case.sessions] == ["session-z", "session-a"]
+    assert [session.date for session in case.sessions] == ["2024-12-31", "2023-01-01"]
+    assert case.evidence_session_ids == ("session-a", "session-z")
+
+
+@pytest.mark.parametrize(
+    ("change", "error"),
+    [
+        ({"question": ""}, "longmemeval_question_invalid"),
+        ({"haystack_session_ids": ["session-z"]}, "longmemeval_session_alignment_invalid"),
+        (
+            {"haystack_sessions": [[{"role": "system", "content": "bad"}], []]},
+            "longmemeval_turn_role_invalid",
+        ),
+        ({"answer_session_ids": ["missing"]}, "longmemeval_answer_session_reference_invalid"),
+        (
+            {
+                "haystack_sessions": [
+                    [{"role": "user", "content": "x", "has_answer": "yes"}],
+                    [{"role": "user", "content": "y"}],
+                ]
+            },
+            "longmemeval_turn_has_answer_invalid",
+        ),
+    ],
+)
+def test_invalid_required_values_and_references_fail_closed(
+    tmp_path: Path, change: dict[str, object], error: str
+) -> None:
+    payload = _case()
+    payload.update(change)
+
+    with pytest.raises(EvidenceContractError, match=f"^{error}$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+
+def test_duplicate_question_ids_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_id_duplicate$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case(), _case()]))
+
+
+@pytest.mark.parametrize("payload", [[], {}, {"question_id": "q"}, ["not-a-case"]])
+def test_invalid_top_level_shape_fails_closed(tmp_path: Path, payload: object) -> None:
+    with pytest.raises(EvidenceContractError):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, payload))
+
+
+def test_invalid_json_and_unreadable_file_fail_closed(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_bytes(b"not-json")
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
+        load_longmemeval_retrieval_cases(invalid)
+
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_unreadable$"):
+        load_longmemeval_retrieval_cases(tmp_path / "missing.json")
+
+
+def test_duplicate_json_key_and_oversized_model_field_fail_closed(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_bytes(b'[{"question_id":"q-1","question_id":"q-2"}]')
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
+        load_longmemeval_retrieval_cases(duplicate)
+
+    payload = _case()
+    payload["question_id"] = "q" * 513
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+    payload = _case()
+    payload["haystack_session_ids"] = ["s" * 513, "session-a"]
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+
+def test_adapter_makes_no_network_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args: object, **kwargs: object) -> object:
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "create_connection", fail)
+    monkeypatch.setattr(socket, "socket", fail)
+    load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case()]))

--- a/tests/test_semantic_clustering.py
+++ b/tests/test_semantic_clustering.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from types import TracebackType
 
 import pytest
+import scripts.bench_semantic_clustering_quality as clustering_benchmark
 from src.graph.master_catalog import clear_master_catalog_cache
 from src.graph.semantic_clustering import (
     LOUVAIN_MAX_ITERATIONS,
@@ -61,6 +63,124 @@ def test_compute_semantic_clusters_partitions_catalog() -> None:
     assert len(titles) == 120
     assert len(set(titles)) == 120
     assert all(5 <= len(page_titles) <= 35 for page_titles in clusters.values())
+
+
+def test_quality_scorecard_metrics_cover_perfect_and_collapsed_partitions() -> None:
+    labels = {"A": 0, "B": 0, "C": 1, "D": 1}
+
+    perfect = clustering_benchmark._quality(
+        {"cluster_1": ["A", "B"], "cluster_2": ["C", "D"]}, labels
+    )
+    collapsed = clustering_benchmark._quality({"cluster_1": list(labels)}, labels)
+
+    assert perfect["ari"] == 1.0
+    assert perfect["cluster_count"] == 2
+    assert perfect["collapse_rate"] == 0.0
+    assert collapsed["ari"] == 0.0
+    assert collapsed["cluster_count"] == 1
+    assert collapsed["collapse_rate"] == 1.0
+
+
+def test_quality_scorecard_metrics_are_stable_for_input_order_and_degenerate_cases() -> None:
+    labels = {"A": 0, "B": 0, "C": 1, "D": 1}
+    first = clustering_benchmark._quality(
+        {"cluster_1": ["A", "B"], "cluster_2": ["C", "D"]}, labels
+    )
+    reordered = clustering_benchmark._quality(
+        {"cluster_2": ["D", "C"], "cluster_1": ["B", "A"]},
+        dict(reversed(labels.items())),
+    )
+
+    assert first == reordered
+    assert clustering_benchmark._quality({"only": ["A"]}, {"A": 0}) == {
+        "ari": 1.0,
+        "cluster_count": 1,
+        "collapse_rate": 0.0,
+        "pair_f1": 0.0,
+        "pair_precision": 0.0,
+        "pair_recall": 0.0,
+        "purity": 1.0,
+    }
+    assert clustering_benchmark._quality({}, {})["ari"] == 1.0
+
+
+def test_quality_scorecard_metrics_cover_partial_and_crossed_partitions() -> None:
+    labels = {"A": 0, "B": 0, "C": 1, "D": 1}
+    partial = clustering_benchmark._quality(
+        {"cluster_1": ["A", "B", "C"], "cluster_2": ["D"]}, labels
+    )
+    crossed = clustering_benchmark._quality(
+        {"cluster_1": ["A", "C"], "cluster_2": ["B", "D"]}, labels
+    )
+
+    assert partial == {
+        "ari": 0.0,
+        "cluster_count": 2,
+        "collapse_rate": 0.5,
+        "pair_f1": 0.4,
+        "pair_precision": 0.3333,
+        "pair_recall": 0.5,
+        "purity": 0.75,
+    }
+    assert crossed["ari"] == -0.5
+    assert 0.0 <= partial["collapse_rate"] <= 1.0
+    assert 0.0 <= crossed["collapse_rate"] <= 1.0
+
+
+def test_scorecard_main_writes_schema_versioned_synthetic_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "nested" / "clustering.json"
+    monkeypatch.setattr(clustering_benchmark, "_source_commit", lambda: "a" * 40)
+    monkeypatch.setattr(clustering_benchmark, "_require_clean_source_tree", lambda: None)
+
+    assert clustering_benchmark.main(["--output", str(output)]) == 0
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["benchmark_schema_version"] == 2
+    assert payload["source_commit"] == "a" * 40
+    assert payload["fixture"] == {
+        "id": "semantic-clustering-balanced-opaque-v1",
+        "kind": "synthetic",
+        "provenance": "Generated in-memory by this benchmark from fixed opaque titles and labels.",
+        "evidence_boundary": "No vault, model, or remote content is used or represented.",
+    }
+    assert payload["seeds"] == [20260802, 20260803, 20260804, 20260805, 20260806]
+    assert set(payload["scenarios"]["summary_and_tags"]) >= {
+        "ari_mean",
+        "cluster_count_mean",
+        "collapse_rate_mean",
+    }
+
+
+def test_scorecard_source_commit_is_resolved_from_the_repository_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, stdout="a" * 40)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert clustering_benchmark._source_commit() == "a" * 40
+    assert captured["cwd"] == Path(clustering_benchmark.__file__).resolve().parents[1]
+
+
+def test_scorecard_rejects_a_dirty_source_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout=" M script.py\n")
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        fake_run,
+    )
+
+    with pytest.raises(RuntimeError, match="dirty source tree"):
+        clustering_benchmark._require_clean_source_tree()
 
 
 def test_save_and_load_semantic_clusters(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add deterministic ARI, cluster-count, and collapse-rate metrics to the synthetic clustering scorecard
- retain schema-versioned JSON only from a clean source tree, bound to its exact commit
- document the metric boundary and add deterministic, degenerate, partial, and crossed-partition coverage

## Test plan
- [x] focused clustering tests
- [x] mypy
- [x] ruff
- [x] knowledge documentation checks

Refs #448