### PR TITLE
feat(benchmark): add local LongMemEval adapter (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
+- **Local LongMemEval retrieval adapter (#448)** — normalize acquired cleaned/oracle JSON into digest-pinned, order-preserving in-memory cases with separate session and answer-marked-turn evidence, without downloads, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.
 - **Evidence archive foundation** — add an immutable, privacy-safe, externally stored and idempotent P0 evidence-event archive for future governed memory candidates.
 - **Governed P0 evidence packet (#447)** — add a byte-stable, retrieval-only coordination contract that binds exact source revision, canonical recall, benchmark scorecard, and append-only archive references without storage, model, remote, or canonical-write side effects.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -98,6 +98,13 @@ When publicly exposed, document in `.env.example` under **Advanced / high impact
 - Letta Evals, Mem0 memory-benchmarks, and Graphiti are treated as design/reference harness material.
 - No best/SOTA/world-leading claim is made before reproducible evidence with provenance.
 - Every claim must include task set, corpus/version, seed/config, and decision label.
+- Local suite adapters read only already acquired bytes, bind a source SHA-256, preserve
+  upstream order, and retain public benchmark text only in bounded in-memory cases; they
+  do not download, call models, access the vault, or persist results. LongMemEval's
+  session-level answer references and optional answer-marked turns remain separate, and
+  `_abs` IDs are metadata rather than inferred retrieval outcomes. Unknown upstream input
+  fields are deliberately ignored for forward compatibility; emitted evaluation contracts
+  remain closed and frozen.
 
 ## P0 canonical recall
 

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -18,6 +18,13 @@ from .decay import (
 )
 from .evidence_coordination import P0EvidencePacket
 from .locomo_adapter import LocomoDataset, LocomoRetrievalCase, load_locomo_retrieval_cases
+from .longmemeval_adapter import (
+    LongMemEvalDataset,
+    LongMemEvalRetrievalCase,
+    LongMemEvalSession,
+    LongMemEvalTurn,
+    load_longmemeval_retrieval_cases,
+)
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -26,6 +33,10 @@ __all__ = [
     "MemoryEdgeState",
     "LocomoDataset",
     "LocomoRetrievalCase",
+    "LongMemEvalDataset",
+    "LongMemEvalRetrievalCase",
+    "LongMemEvalSession",
+    "LongMemEvalTurn",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
     "calculate_decayed_weight",
@@ -38,5 +49,6 @@ __all__ = [
     "P0EvidencePacket",
     "recall_from_existing_retrieval",
     "load_locomo_retrieval_cases",
+    "load_longmemeval_retrieval_cases",
     "validate_comparative_cohort",
 ]

--- a/src/memory/longmemeval_adapter.py
+++ b/src/memory/longmemeval_adapter.py
@@ -1,0 +1,214 @@
+"""Local-only normalization for acquired LongMemEval cleaned JSON data.
+
+Unknown upstream fields are intentionally ignored for forward compatibility;
+the returned Pydantic models remain frozen and closed contracts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .evidence_models import EvidenceContractError
+
+_MAX_CASES = 10_000
+_MAX_SESSIONS = 10_000
+_MAX_TURNS_PER_SESSION = 10_000
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when a JSON object would otherwise silently overwrite a key."""
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LongMemEvalTurn(_ClosedModel):
+    """One retained public turn from an in-memory evaluation case."""
+
+    turn_id: str = Field(min_length=1, max_length=512)
+    role: Literal["user", "assistant"]
+    content: str = Field(min_length=1)
+    has_answer: bool = False
+
+
+class LongMemEvalSession(_ClosedModel):
+    """One haystack session, kept in the exact upstream sequence."""
+
+    session_id: str = Field(min_length=1, max_length=512)
+    date: str = Field(min_length=1, max_length=512)
+    turns: tuple[LongMemEvalTurn, ...] = Field(min_length=1)
+
+
+class LongMemEvalRetrievalCase(_ClosedModel):
+    """A deterministic LongMemEval question and its separate evidence views."""
+
+    case_id: str = Field(min_length=1, max_length=512)
+    question_id: str = Field(min_length=1, max_length=512)
+    question_type: str = Field(min_length=1, max_length=512)
+    question: str = Field(min_length=1)
+    expected_answer: str = Field(min_length=1)
+    question_date: str = Field(min_length=1, max_length=512)
+    sessions: tuple[LongMemEvalSession, ...] = Field(min_length=1)
+    evidence_session_ids: tuple[str, ...]
+    evidence_turn_ids: tuple[str, ...]
+    is_abstention: bool
+
+
+class LongMemEvalDataset(_ClosedModel):
+    """A locally loaded, digest-pinned LongMemEval dataset."""
+
+    source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    cases: tuple[LongMemEvalRetrievalCase, ...] = Field(min_length=1)
+
+
+def load_longmemeval_retrieval_cases(path: Path) -> LongMemEvalDataset:
+    """Load one acquired cleaned/oracle LongMemEval JSON file without side effects."""
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError("longmemeval_dataset_unreadable") from exc
+    try:
+        raw: Any = json.loads(raw_bytes, object_pairs_hook=_no_duplicate_json_keys)
+    except (_DuplicateJsonKeyError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceContractError("longmemeval_dataset_invalid_json") from exc
+    if not isinstance(raw, list) or not raw:
+        raise EvidenceContractError("longmemeval_dataset_must_be_nonempty_list")
+    if len(raw) > _MAX_CASES:
+        raise EvidenceContractError("longmemeval_dataset_too_many_cases")
+
+    cases: list[LongMemEvalRetrievalCase] = []
+    seen_case_ids: set[str] = set()
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise EvidenceContractError("longmemeval_case_invalid")
+        try:
+            case = _normalize_case(item)
+        except ValidationError as exc:
+            raise EvidenceContractError("longmemeval_case_invalid") from exc
+        if case.case_id in seen_case_ids:
+            raise EvidenceContractError("longmemeval_case_id_duplicate")
+        seen_case_ids.add(case.case_id)
+        cases.append(case)
+    try:
+        return LongMemEvalDataset(
+            source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+            cases=tuple(cases),
+        )
+    except ValidationError as exc:
+        raise EvidenceContractError("longmemeval_dataset_invalid") from exc
+
+
+def _normalize_case(item: Mapping[str, Any]) -> LongMemEvalRetrievalCase:
+    question_id = _required_text(item, "question_id", "longmemeval_question_id_invalid")
+    question_type = _required_text(item, "question_type", "longmemeval_question_type_invalid")
+    question = _required_text(item, "question", "longmemeval_question_invalid")
+    answer = _required_text(item, "answer", "longmemeval_answer_invalid")
+    question_date = _required_text(item, "question_date", "longmemeval_question_date_invalid")
+    session_ids = _required_text_list(item, "haystack_session_ids")
+    session_dates = _required_text_list(item, "haystack_dates")
+    raw_sessions = item.get("haystack_sessions")
+    answer_ids = _required_text_list(item, "answer_session_ids", allow_empty=True)
+    if not isinstance(raw_sessions, list) or not raw_sessions:
+        raise EvidenceContractError("longmemeval_haystack_sessions_invalid")
+    if len(raw_sessions) > _MAX_SESSIONS or len(session_ids) != len(raw_sessions):
+        raise EvidenceContractError("longmemeval_session_alignment_invalid")
+    if len(session_dates) != len(raw_sessions):
+        raise EvidenceContractError("longmemeval_date_alignment_invalid")
+    if len(set(session_ids)) != len(session_ids):
+        raise EvidenceContractError("longmemeval_session_id_duplicate")
+    if len(set(answer_ids)) != len(answer_ids):
+        raise EvidenceContractError("longmemeval_answer_session_id_duplicate")
+
+    sessions: list[LongMemEvalSession] = []
+    evidence_turn_ids: list[str] = []
+    for session_id, date, raw_turns in zip(session_ids, session_dates, raw_sessions, strict=True):
+        if not isinstance(raw_turns, list) or not raw_turns:
+            raise EvidenceContractError("longmemeval_session_invalid")
+        if len(raw_turns) > _MAX_TURNS_PER_SESSION:
+            raise EvidenceContractError("longmemeval_session_too_many_turns")
+        turns: list[LongMemEvalTurn] = []
+        for turn_index, raw_turn in enumerate(raw_turns, start=1):
+            if not isinstance(raw_turn, Mapping):
+                raise EvidenceContractError("longmemeval_turn_invalid")
+            role = raw_turn.get("role")
+            if role not in ("user", "assistant"):
+                raise EvidenceContractError("longmemeval_turn_role_invalid")
+            content = _required_text(raw_turn, "content", "longmemeval_turn_content_invalid")
+            has_answer = raw_turn.get("has_answer", False)
+            if not isinstance(has_answer, bool):
+                raise EvidenceContractError("longmemeval_turn_has_answer_invalid")
+            turn_id = f"{session_id}:turn-{turn_index}"
+            turns.append(
+                LongMemEvalTurn(
+                    turn_id=turn_id,
+                    role=role,
+                    content=content,
+                    has_answer=has_answer,
+                )
+            )
+            if has_answer:
+                evidence_turn_ids.append(turn_id)
+        sessions.append(LongMemEvalSession(session_id=session_id, date=date, turns=tuple(turns)))
+
+    session_id_set = set(session_ids)
+    if any(answer_id not in session_id_set for answer_id in answer_ids):
+        raise EvidenceContractError("longmemeval_answer_session_reference_invalid")
+    try:
+        return LongMemEvalRetrievalCase(
+            case_id=question_id,
+            question_id=question_id,
+            question_type=question_type,
+            question=question,
+            expected_answer=answer,
+            question_date=question_date,
+            sessions=tuple(sessions),
+            evidence_session_ids=tuple(answer_ids),
+            evidence_turn_ids=tuple(evidence_turn_ids),
+            is_abstention=question_id.endswith("_abs"),
+        )
+    except ValidationError as exc:
+        raise EvidenceContractError("longmemeval_case_invalid") from exc
+
+
+def _no_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Build one JSON object while rejecting duplicate members deterministically."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _required_text(value: Mapping[str, Any], key: str, error: str) -> str:
+    raw = value.get(key)
+    if not isinstance(raw, str) or not raw.strip():
+        raise EvidenceContractError(error)
+    return raw.strip()
+
+
+def _required_text_list(
+    value: Mapping[str, Any], key: str, *, allow_empty: bool = False
+) -> list[str]:
+    raw = value.get(key)
+    if not isinstance(raw, list) or (not raw and not allow_empty):
+        raise EvidenceContractError(f"longmemeval_{key}_invalid")
+    error = f"longmemeval_{key}_invalid"
+    normalized = [_required_text({"value": entry}, "value", error) for entry in raw]
+    return normalized
+
+
+__all__ = [
+    "LongMemEvalDataset",
+    "LongMemEvalRetrievalCase",
+    "LongMemEvalSession",
+    "LongMemEvalTurn",
+    "load_longmemeval_retrieval_cases",
+]

--- a/tests/test_longmemeval_adapter.py
+++ b/tests/test_longmemeval_adapter.py
@@ -1,0 +1,174 @@
+"""Tests for the local-only LongMemEval retrieval adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.longmemeval_adapter import load_longmemeval_retrieval_cases
+
+
+def _case(*, question_id: str = "q-1") -> dict[str, object]:
+    return {
+        "question_id": question_id,
+        "question_type": "multi_session",
+        "question": "What changed?",
+        "answer": "The revised plan.",
+        "question_date": "2024-01-03",
+        "haystack_session_ids": ["session-z", "session-a"],
+        "haystack_dates": ["2024-01-01", "2024-01-02"],
+        "haystack_sessions": [
+            [
+                {"role": "user", "content": "The old plan."},
+                {"role": "assistant", "content": "It was provisional."},
+            ],
+            [
+                {"role": "user", "content": "The revised plan.", "has_answer": True},
+            ],
+        ],
+        "answer_session_ids": ["session-a"],
+        "unknown_field": {"ignored": True},
+    }
+
+
+def _write_dataset(tmp_path: Path, payload: object) -> Path:
+    path = tmp_path / "longmemeval_s_cleaned.json"
+    path.write_bytes(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+    return path
+
+
+def test_normalizes_digest_evidence_and_preserves_upstream_order(tmp_path: Path) -> None:
+    payload = [_case()]
+    path = _write_dataset(tmp_path, payload)
+
+    dataset = load_longmemeval_retrieval_cases(path)
+    case = dataset.cases[0]
+
+    assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert case.case_id == "q-1"
+    assert [session.session_id for session in case.sessions] == ["session-z", "session-a"]
+    assert [session.date for session in case.sessions] == ["2024-01-01", "2024-01-02"]
+    assert case.evidence_session_ids == ("session-a",)
+    assert case.evidence_turn_ids == ("session-a:turn-1",)
+    assert case.is_abstention is False
+    assert case.sessions[0].turns[0].turn_id == "session-z:turn-1"
+    # Unknown upstream fields are intentionally ignored for forward compatibility.
+    assert case.question == "What changed?"
+    assert case.model_config["extra"] == "forbid"
+
+
+def test_digest_is_stable_and_abs_is_metadata_not_inferred_evidence(tmp_path: Path) -> None:
+    payload = [_case(question_id="q-2_abs")]
+    path = _write_dataset(tmp_path, payload)
+
+    first = load_longmemeval_retrieval_cases(path)
+    second = load_longmemeval_retrieval_cases(path)
+
+    assert first == second
+    assert first.cases[0].is_abstention is True
+    assert first.cases[0].evidence_session_ids == ("session-a",)
+
+    abstention_path = _write_dataset(
+        tmp_path,
+        [{**_case(question_id="q-3_abs"), "answer_session_ids": []}],
+    )
+    abstention = load_longmemeval_retrieval_cases(abstention_path).cases[0]
+    assert abstention.is_abstention is True
+    assert abstention.evidence_session_ids == ()
+    assert abstention.evidence_turn_ids == ("session-a:turn-1",)
+
+
+def test_preserves_multiple_evidence_and_oracle_style_nonchronological_order(
+    tmp_path: Path,
+) -> None:
+    payload = _case()
+    payload["haystack_dates"] = ["2024-12-31", "2023-01-01"]
+    payload["answer_session_ids"] = ["session-a", "session-z"]
+
+    case = load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload])).cases[0]
+
+    assert [session.session_id for session in case.sessions] == ["session-z", "session-a"]
+    assert [session.date for session in case.sessions] == ["2024-12-31", "2023-01-01"]
+    assert case.evidence_session_ids == ("session-a", "session-z")
+
+
+@pytest.mark.parametrize(
+    ("change", "error"),
+    [
+        ({"question": ""}, "longmemeval_question_invalid"),
+        ({"haystack_session_ids": ["session-z"]}, "longmemeval_session_alignment_invalid"),
+        (
+            {"haystack_sessions": [[{"role": "system", "content": "bad"}], []]},
+            "longmemeval_turn_role_invalid",
+        ),
+        ({"answer_session_ids": ["missing"]}, "longmemeval_answer_session_reference_invalid"),
+        (
+            {
+                "haystack_sessions": [
+                    [{"role": "user", "content": "x", "has_answer": "yes"}],
+                    [{"role": "user", "content": "y"}],
+                ]
+            },
+            "longmemeval_turn_has_answer_invalid",
+        ),
+    ],
+)
+def test_invalid_required_values_and_references_fail_closed(
+    tmp_path: Path, change: dict[str, object], error: str
+) -> None:
+    payload = _case()
+    payload.update(change)
+
+    with pytest.raises(EvidenceContractError, match=f"^{error}$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+
+def test_duplicate_question_ids_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_id_duplicate$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case(), _case()]))
+
+
+@pytest.mark.parametrize("payload", [[], {}, {"question_id": "q"}, ["not-a-case"]])
+def test_invalid_top_level_shape_fails_closed(tmp_path: Path, payload: object) -> None:
+    with pytest.raises(EvidenceContractError):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, payload))
+
+
+def test_invalid_json_and_unreadable_file_fail_closed(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_bytes(b"not-json")
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
+        load_longmemeval_retrieval_cases(invalid)
+
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_unreadable$"):
+        load_longmemeval_retrieval_cases(tmp_path / "missing.json")
+
+
+def test_duplicate_json_key_and_oversized_model_field_fail_closed(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_bytes(b'[{"question_id":"q-1","question_id":"q-2"}]')
+    with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
+        load_longmemeval_retrieval_cases(duplicate)
+
+    payload = _case()
+    payload["question_id"] = "q" * 513
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+    payload = _case()
+    payload["haystack_session_ids"] = ["s" * 513, "session-a"]
+    with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
+        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+
+
+def test_adapter_makes_no_network_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args: object, **kwargs: object) -> object:
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "create_connection", fail)
+    monkeypatch.setattr(socket, "socket", fail)
+    load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case()]))


### PR DESCRIPTION
## Summary
- normalize acquired LongMemEval cleaned/oracle JSON into deterministic retrieval cases
- preserve source order and separate session evidence from question metadata
- fail closed without downloads, model calls, vault reads, or persisted outcomes

## Test plan
- [x] focused adapter tests
- [x] mypy
- [x] ruff

Refs #448