### PR TITLE
fix(read-only): serialize external alias state writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- **Read-only alias concurrency** — serialize concurrent external X-Ray alias-state writes until the in-process lock is available, preserving bounded lock failure for all other page writes.
 - **Gate B RC2 artifact binding** — bind fresh dual-profile qualification to the exact installed `2.0.0rc2` public wheel instead of rejecting it through the historical RC1 package identity.
 
 ## [2.0.0-rc.2] - 2026-08-09

--- a/src/agent/alias_state.py
+++ b/src/agent/alias_state.py
@@ -140,7 +140,7 @@ def save_alias_registry(graph_root: str | Path, registry: SessionAliasRegistry) 
             atomic_write_bytes(path, data, graph_root=root)
     else:
         _ensure_private_parent(path)
-        with page_rmw_lock(path):
+        with page_rmw_lock(path, wait_for_thread_lock=True):
             _atomic_write_private_state(path, data)
     return path
 

--- a/src/graph/page_write_lock.py
+++ b/src/graph/page_write_lock.py
@@ -114,26 +114,38 @@ def probe_page_rmw_lock(page_path: str | Path) -> None:
 
 
 @contextmanager
-def page_rmw_lock(page_path: str | Path) -> Iterator[None]:
-    """Hold an exclusive lock for one file's full RMW lifecycle (thread- and process-safe)."""
+def page_rmw_lock(
+    page_path: str | Path,
+    *,
+    wait_for_thread_lock: bool = False,
+) -> Iterator[None]:
+    """Hold an exclusive lock for one file's full RMW lifecycle (thread- and process-safe).
+
+    ``wait_for_thread_lock`` is reserved for small private runtime state whose
+    concurrent writes must serialize instead of failing after the bounded
+    default retry window. The cross-process sidecar lock remains unchanged.
+    """
     guard_graph_mutation_from_env(page_path, operation="page_rmw_lock")
     key = normalize_page_lock_key(page_path)
     thread_lock = _lock_for_key(key)
-    delay = IO_RETRY_INITIAL_DELAY_S
-    for attempt in range(IO_RETRY_ATTEMPTS):
-        if thread_lock.acquire(blocking=False):
-            break
-        if attempt >= IO_RETRY_ATTEMPTS - 1:
-            logger.warning(
-                "In-process page lock still held after {} retries: {}",
-                IO_RETRY_ATTEMPTS - 1,
-                page_path,
-            )
-            raise PageLockUnavailableError(
-                f"Could not acquire in-process page lock for {page_path} after retries",
-            )
-        time.sleep(min(IO_RETRY_MAX_DELAY_S, delay))
-        delay = min(IO_RETRY_MAX_DELAY_S, delay * 2)
+    if wait_for_thread_lock:
+        thread_lock.acquire()
+    else:
+        delay = IO_RETRY_INITIAL_DELAY_S
+        for attempt in range(IO_RETRY_ATTEMPTS):
+            if thread_lock.acquire(blocking=False):
+                break
+            if attempt >= IO_RETRY_ATTEMPTS - 1:
+                logger.warning(
+                    "In-process page lock still held after {} retries: {}",
+                    IO_RETRY_ATTEMPTS - 1,
+                    page_path,
+                )
+                raise PageLockUnavailableError(
+                    f"Could not acquire in-process page lock for {page_path} after retries",
+                )
+            time.sleep(min(IO_RETRY_MAX_DELAY_S, delay))
+            delay = min(IO_RETRY_MAX_DELAY_S, delay * 2)
     try:
         with _cross_process_file_lock(page_path):
             yield

--- a/tests/test_phase1_hardening.py
+++ b/tests/test_phase1_hardening.py
@@ -70,6 +70,34 @@ def test_page_rmw_lock_raises_after_retry_exhaustion(
     lock.release()
 
 
+def test_page_rmw_lock_can_wait_for_private_runtime_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_page_write_locks()
+    target = tmp_path / "private-state.json"
+    lock = threading.Lock()
+    lock.acquire()
+    started = threading.Event()
+    acquired = threading.Event()
+
+    monkeypatch.setattr("src.graph.page_write_lock._lock_for_key", lambda _key: lock)
+
+    def _wait_for_lock() -> None:
+        started.set()
+        with page_rmw_lock(target, wait_for_thread_lock=True):
+            acquired.set()
+
+    worker = threading.Thread(target=_wait_for_lock, daemon=True)
+    worker.start()
+    assert started.wait(timeout=1.0)
+    assert not acquired.wait(timeout=0.05)
+    lock.release()
+    assert acquired.wait(timeout=1.0)
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()
+
+
 def test_graceful_shutdown_waits_for_inflight_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- serialize concurrent external X-Ray alias-state writes instead of exhausting the bounded in-process lock retry window
- preserve bounded fail-closed lock behavior for every existing page-write caller
- cover the opt-in wait path and retain read-only alias isolation coverage

## Test plan
- [x] focused alias-state and lock tests
- [x] Ruff
- [x] strict mypy

Refs #448