### PR TITLE
feat(benchmark): harden deterministic scorecard semantics (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - **Evidence-first agentic-memory programme** — sequence v2.1+ delivery through governed evidence, deterministic canonical recall, reproducible benchmarks, human-governed curation, and derived-only Shadow state before typed decay, procedural memory, or opt-in proactivity.
-- **BM25 scorecard benchmark schema** — add manifest-driven synthetic Italian hard-negative scorecard mode (`--manifest-path`) with deterministic Recall@K, MRR, nDCG, stale/contradiction, abstention, and manifest digest/environment signatures for reproducible ranking evidence without runtime behavior changes.
+- **BM25 scorecard benchmark schema** — evolve the manifest-driven synthetic Italian hard-negative scorecard mode (`--manifest-path`) to schema v3 with explicit update/superseded labels, update-only accuracy, abstention precision/recall/confusion, deterministic ordered evidence fingerprints, and manifest digest/environment signatures; no runtime behavior changes.
 
 ### Added
 

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -91,15 +91,22 @@ uv run python scripts/bench_bm25_query_cache.py \
 
 Scorecard output includes:
 
-- `benchmark_schema_version: 2`
+- `benchmark_schema_version: 3`, with manifest schema v2
 - `manifest` identity and SHA-256 digest
 - retrieval-only Recall@K, MRR, nDCG, stale, contradiction, and abstention metrics
+- explicit `update_gold` / `superseded_gold` case classification; update accuracy is
+  measured only over `update_gold` cases, while stale metrics remain independent
+- abstention precision, recall, and confusion counts, with zero-denominator ratios
+  reported as `0.0`
 - deterministic 95% percentile-bootstrap confidence intervals for mean ranking metrics
 - the `no_retrieval` signal ablation, which makes the lexical BM25 contribution explicit
 - latency micro-profile and RSS/payload-context measurements, including a transparent
   byte-derived context-token estimate and zero external-model cost
 
 The profile is synthetic and deterministic: no external data or network runtime dependency is required.
+Cases are ordered by `(seed, query)` before output and fingerprinting. The fingerprint
+binds deterministic retrieval evidence only; it intentionally excludes timing and RSS
+measurements, which remain diagnostic rather than reproducibility claims.
 It intentionally does not report end-to-end answer quality: that belongs to the
 separate adapter layer, where answer model, judge, prompt, token budget, and
 failure policy can be pinned rather than conflated with retrieval quality.

--- a/scripts/bench_bm25_query_cache.py
+++ b/scripts/bench_bm25_query_cache.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from statistics import median
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import src.graph.generational_cache as generational_cache
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -45,9 +45,10 @@ _SEED = 20260802
 _CAPACITIES = (512, 2_048, 8_192, 16_384)
 _DEFAULT_CAPACITY = 8_192
 _RESULT_LIMITS = (1, 8, 32, 100)
-_MANIFEST_SCHEMA_VERSION = 1
-_SCORECARD_SCHEMA_VERSION = 2
+_MANIFEST_SCHEMA_VERSION = 2
+_SCORECARD_SCHEMA_VERSION = 3
 _DEFAULT_TOP_K = 8
+GoldClassification = Literal["update_gold", "superseded_gold"]
 
 
 class ManifestDocument(BaseModel):
@@ -65,6 +66,7 @@ class ManifestCase(BaseModel):
     relevant: list[str]
     hard_negatives: list[str] = Field(default_factory=list)
     abstain_when_no_candidates: bool = False
+    gold_classification: GoldClassification
 
     model_config = ConfigDict(extra="forbid")
 
@@ -125,7 +127,7 @@ def _read_manifest(path: Path) -> tuple[ManifestPayload, str]:
         raise ValueError(f"Manifest {manifest.dataset_id} has duplicated document ids")
 
     seen_seeds: set[int] = set()
-    for case in manifest.cases:
+    for case in sorted(manifest.cases, key=lambda item: (item.seed, item.query)):
         if case.seed in seen_seeds:
             raise ValueError(
                 f"Manifest {manifest.dataset_id} contains duplicate case seed {case.seed}"
@@ -221,6 +223,8 @@ def _rank_metrics(
     top_k: int,
     *,
     has_reference: bool,
+    update_expected: bool = False,
+    abstention_expected: bool = False,
 ) -> dict[str, float | int | bool]:
     top = retrieved_rels[:top_k]
     relevance = [1 if rel in relevant_rels else 0 for rel in top]
@@ -244,6 +248,9 @@ def _rank_metrics(
         "stale_hits": stale_hits,
         "contradiction_hits": contradiction_hits,
         "abstained": has_reference is False and len(top) == 0,
+        "update_expected": update_expected,
+        "update_predicted": bool(relevant_rels.intersection(top)),
+        "abstention_expected": abstention_expected,
     }
 
 
@@ -283,6 +290,33 @@ def _aggregate_rank_metrics(
     contradiction_hits = sum(int(metrics["contradiction_hits"]) for metrics in case_metrics)
     stale_queries = sum(1 for metrics in case_metrics if metrics["stale_hits"])
     contradiction_queries = sum(1 for metrics in case_metrics if metrics["contradiction_hits"])
+
+    def ratio(numerator: int, denominator: int) -> float:
+        return round(numerator / denominator, 6) if denominator else 0.0
+
+    def confusion(expected: Sequence[bool], predicted: Sequence[bool]) -> dict[str, int]:
+        return {
+            "true_positive": sum(
+                actual and guess for actual, guess in zip(expected, predicted, strict=True)
+            ),
+            "true_negative": sum(
+                not actual and not guess for actual, guess in zip(expected, predicted, strict=True)
+            ),
+            "false_positive": sum(
+                not actual and guess for actual, guess in zip(expected, predicted, strict=True)
+            ),
+            "false_negative": sum(
+                actual and not guess for actual, guess in zip(expected, predicted, strict=True)
+            ),
+        }
+
+    update_cases = [metrics for metrics in case_metrics if metrics["update_expected"]]
+    update_predictions = [bool(metrics["update_predicted"]) for metrics in update_cases]
+    update_confusion = confusion([True] * len(update_predictions), update_predictions)
+    abstention_confusion = confusion(
+        [bool(metrics["abstention_expected"]) for metrics in case_metrics],
+        [bool(metrics["abstained"]) for metrics in case_metrics],
+    )
     return {
         "recall_at_k": round(sum(recalls) / query_count, 4),
         "mrr": round(sum(mrrs) / query_count, 4),
@@ -308,6 +342,36 @@ def _aggregate_rank_metrics(
             "rate": round(abstention_passed / abstention_expected, 6)
             if abstention_expected
             else 0.0,
+            "precision": ratio(
+                abstention_confusion["true_positive"],
+                abstention_confusion["true_positive"] + abstention_confusion["false_positive"],
+            ),
+            "recall": ratio(
+                abstention_confusion["true_positive"],
+                abstention_confusion["true_positive"] + abstention_confusion["false_negative"],
+            ),
+            "confusion": abstention_confusion,
+        },
+        "update": {
+            "cases": len(update_cases),
+            "accuracy": ratio(
+                update_confusion["true_positive"] + update_confusion["true_negative"],
+                sum(update_confusion.values()),
+            ),
+            "confusion": update_confusion,
+            "by_class": {
+                "update_gold": {
+                    "cases": len(update_cases),
+                    "accuracy": ratio(
+                        update_confusion["true_positive"] + update_confusion["true_negative"],
+                        sum(update_confusion.values()),
+                    ),
+                    "confusion": update_confusion,
+                },
+                "superseded_gold": {
+                    "cases": len(case_metrics) - len(update_cases),
+                },
+            },
         },
     }
 
@@ -320,7 +384,8 @@ def _run_scorecard_benchmark(manifest: ManifestPayload, *, top_k: int) -> dict[s
     abstention_total = 0
     ranked_case_metrics: list[dict[str, float | int | bool]] = []
 
-    for case in manifest.cases:
+    sorted_cases = sorted(manifest.cases, key=lambda item: (item.seed, item.query))
+    for case in sorted_cases:
         relevant_rels = {_to_relation(doc_id) for doc_id in case.relevant}
         hard_negative_rels = {_to_relation(doc_id) for doc_id in case.hard_negatives}
         started = time.perf_counter_ns()
@@ -338,6 +403,8 @@ def _run_scorecard_benchmark(manifest: ManifestPayload, *, top_k: int) -> dict[s
             stale_rels=stale_rels,
             top_k=top_k,
             has_reference=bool(relevant_rels),
+            update_expected=case.gold_classification == "update_gold",
+            abstention_expected=case.abstain_when_no_candidates,
         )
         if not relevant_rels and case.abstain_when_no_candidates:
             abstention_total += 1
@@ -348,12 +415,13 @@ def _run_scorecard_benchmark(manifest: ManifestPayload, *, top_k: int) -> dict[s
             {
                 "seed": case.seed,
                 "query": case.query,
+                "gold_classification": case.gold_classification,
                 "retrieved_relations": retrieved[:top_k],
                 "metrics": metrics,
             }
         )
 
-    bootstrap_seed = sum(case.seed for case in manifest.cases)
+    bootstrap_seed = sum(case.seed for case in sorted_cases)
     metrics_summary = _aggregate_rank_metrics(
         ranked_case_metrics,
         top_k=top_k,
@@ -370,8 +438,10 @@ def _run_scorecard_benchmark(manifest: ManifestPayload, *, top_k: int) -> dict[s
                 stale_rels=stale_rels,
                 top_k=top_k,
                 has_reference=bool(case.relevant),
+                update_expected=case.gold_classification == "update_gold",
+                abstention_expected=case.abstain_when_no_candidates,
             )
-            for case in manifest.cases
+            for case in sorted_cases
         ],
         top_k=top_k,
         bootstrap_seed=bootstrap_seed + 100,

--- a/tests/fixtures/bm25_hard_negative_manifest_v1.json
+++ b/tests/fixtures/bm25_hard_negative_manifest_v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "dataset_id": "matryca-bm25-hard-negative-it-v1",
   "description": "Deterministic Italian hard-negative retrieval cases for BM25 scorecard benchmarking.",
   "top_k": 8,
@@ -152,126 +152,147 @@
   "cases": [
     {
       "seed": 20260802,
+      "gold_classification": "update_gold",
       "query": "cache bm25 invalidazione limit row",
       "relevant": ["cache_bm25"],
       "hard_negatives": ["indice_semantico", "vecchio_manifesto"]
     },
     {
       "seed": 20260803,
+      "gold_classification": "superseded_gold",
       "query": "banca dati grafi relazioni pagine",
       "relevant": ["banca_dati_grafi"],
       "hard_negatives": ["diario_lavoro", "agenda_sprint"]
     },
     {
       "seed": 20260804,
+      "gold_classification": "superseded_gold",
       "query": "pipeline riassunto entit\u00e0 titolo sommario",
       "relevant": ["pipeline_riassunto"],
       "hard_negatives": ["indice_semantico", "api_rest"]
     },
     {
       "seed": 20260805,
+      "gold_classification": "superseded_gold",
       "query": "onboarding team checklist",
       "relevant": ["onboarding_team"],
       "hard_negatives": ["agenda_sprint", "modello_llm"]
     },
     {
       "seed": 20260806,
+      "gold_classification": "superseded_gold",
       "query": "backup locale snapshot ripristino",
       "relevant": ["backup_locale", "backup_offline"],
       "hard_negatives": ["query_plausibile", "metrica_precisione"]
     },
     {
       "seed": 20260807,
+      "gold_classification": "update_gold",
       "query": "sicurezza oauth token privilegio autorizzazione",
       "relevant": ["sicurezza_oauth"],
       "hard_negatives": ["utente_privilegiato", "modello_llm"]
     },
     {
       "seed": 20260808,
+      "gold_classification": "superseded_gold",
       "query": "api rest payload codice errore",
       "relevant": ["api_rest"],
       "hard_negatives": ["cache_bm25", "monitoraggio_risorse"]
     },
     {
       "seed": 20260809,
+      "gold_classification": "superseded_gold",
       "query": "indice semantico vettori tag struttura",
       "relevant": ["indice_semantico"],
       "hard_negatives": ["pipeline_riassunto", "progetto_alfa"]
     },
     {
       "seed": 20260810,
+      "gold_classification": "superseded_gold",
       "query": "query plausibile precisione recall",
       "relevant": ["metriche_mrc", "metrica_precisione"],
       "hard_negatives": ["query_plausibile", "vecchio_manifesto"]
     },
     {
       "seed": 20260811,
+      "gold_classification": "superseded_gold",
       "query": "contratti energia tariffa",
       "relevant": ["contratti_energia"],
       "hard_negatives": ["backup_locale", "progetto_alfa"]
     },
     {
       "seed": 20260812,
+      "gold_classification": "superseded_gold",
       "query": "agenda sprint revisione criteri",
       "relevant": ["agenda_sprint"],
       "hard_negatives": ["onboarding_team", "cronologia_patch"]
     },
     {
       "seed": 20260813,
+      "gold_classification": "superseded_gold",
       "query": "metrica mrr ndcg top-k",
       "relevant": ["metriche_mrc"],
       "hard_negatives": ["metrica_precisione", "cache_bm25"]
     },
     {
       "seed": 20260814,
+      "gold_classification": "superseded_gold",
       "query": "cronologia patch hash firma",
       "relevant": ["cronologia_patch"],
       "hard_negatives": ["backup_offline", "monitoraggio_risorse"]
     },
     {
       "seed": 20260815,
+      "gold_classification": "superseded_gold",
       "query": "utente privilegiato verifica multifattore",
       "relevant": ["utente_privilegiato"],
       "hard_negatives": ["sicurezza_oauth", "modello_llm"]
     },
     {
       "seed": 20260816,
+      "gold_classification": "superseded_gold",
       "query": "orchestrazione k8s risorse workload",
       "relevant": ["orchestrazione_k8s"],
       "hard_negatives": ["backup_offline", "monitoraggio_risorse"]
     },
     {
       "seed": 20260817,
+      "gold_classification": "superseded_gold",
       "query": "modello llm sintesi controllo",
       "relevant": ["modello_llm"],
       "hard_negatives": ["progetto_alfa", "indice_semantico"]
     },
     {
       "seed": 20260818,
+      "gold_classification": "superseded_gold",
       "query": "backup offline checksum rete",
       "relevant": ["backup_offline"],
       "hard_negatives": ["backup_locale", "cronologia_patch"]
     },
     {
       "seed": 20260819,
+      "gold_classification": "superseded_gold",
       "query": "monitoraggio risorse memoria rss latenza",
       "relevant": ["monitoraggio_risorse"],
       "hard_negatives": ["progetto_alfa", "cache_bm25"]
     },
     {
       "seed": 20260820,
+      "gold_classification": "superseded_gold",
       "query": "vecchio manifesto regole obsolete",
       "relevant": ["vecchio_manifesto"],
       "hard_negatives": ["documento_riconosciuto", "progetto_alfa"]
     },
     {
       "seed": 20260821,
+      "gold_classification": "superseded_gold",
       "query": "documento riconosciuto regole operative",
       "relevant": ["documento_riconosciuto"],
       "hard_negatives": ["vecchio_manifesto", "cronologia_patch"]
     },
     {
       "seed": 20260822,
+      "gold_classification": "superseded_gold",
       "query": "ricerca vocale trascrive comandi",
       "relevant": [],
       "hard_negatives": ["ricerca_vocale", "api_rest"],
@@ -279,6 +300,7 @@
     },
     {
       "seed": 20260823,
+      "gold_classification": "superseded_gold",
       "query": "diario lavori personali",
       "relevant": [],
       "hard_negatives": ["diario_lavoro", "agenda_sprint"],
@@ -286,6 +308,7 @@
     },
     {
       "seed": 20260824,
+      "gold_classification": "superseded_gold",
       "query": "query senza riferimenti validi",
       "relevant": [],
       "hard_negatives": ["progetto_alfa", "cache_bm25"],
@@ -293,6 +316,7 @@
     },
     {
       "seed": 20260825,
+      "gold_classification": "superseded_gold",
       "query": "espressione sconosciuta assolutamente",
       "relevant": [],
       "hard_negatives": ["query_plausibile", "metrica_precisione"],

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -126,14 +126,14 @@ def test_scorecard_manifest_validates_and_is_deterministic() -> None:
     first, first_digest = benchmark._read_manifest(manifest_path)
     second, second_digest = benchmark._read_manifest(manifest_path)
 
-    assert first.schema_version == 1
+    assert first.schema_version == 2
     assert first.dataset_id == "matryca-bm25-hard-negative-it-v1"
     assert len(first.cases) >= 20
     assert first_digest == second_digest
 
     first_payload = benchmark._run_scorecard_benchmark(first, top_k=8)
     second_payload = benchmark._run_scorecard_benchmark(first, top_k=8)
-    assert first_payload["manifest_schema_version"] == 1
+    assert first_payload["manifest_schema_version"] == 2
     assert first_payload["manifest_dataset_id"] == "matryca-bm25-hard-negative-it-v1"
     assert first_payload["scorecard_fingerprint"] == second_payload["scorecard_fingerprint"]
     assert first_payload["metrics"]["recall_at_k"] >= 0.0
@@ -166,9 +166,43 @@ def test_scorecard_manifest_validates_and_is_deterministic() -> None:
         "enabled_cases": 4,
         "passed_cases": 1,
         "rate": 0.25,
+        "precision": 1.0,
+        "recall": 0.25,
+        "confusion": {
+            "true_positive": 1,
+            "true_negative": 20,
+            "false_positive": 0,
+            "false_negative": 3,
+        },
+    }
+    assert first_payload["metrics"]["update"] == {
+        "cases": 2,
+        "accuracy": 1.0,
+        "confusion": {
+            "true_positive": 2,
+            "true_negative": 0,
+            "false_positive": 0,
+            "false_negative": 0,
+        },
+        "by_class": {
+            "update_gold": {
+                "cases": 2,
+                "accuracy": 1.0,
+                "confusion": {
+                    "true_positive": 2,
+                    "true_negative": 0,
+                    "false_positive": 0,
+                    "false_negative": 0,
+                },
+            },
+            "superseded_gold": {"cases": 22},
+        },
     }
     assert first_payload["case_count"] == second_payload["case_count"] == 24
     assert first_payload["case_results"] == second_payload["case_results"]
+    assert [case["seed"] for case in first_payload["case_results"]] == sorted(
+        case.seed for case in first.cases
+    )
     assert set(first_payload["measurements"]).issuperset(
         {
             "cache",
@@ -222,10 +256,10 @@ def test_scorecard_main_writes_schema_and_environment_signature(
         == 0
     )
     payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["benchmark_schema_version"] == 2
+    assert payload["benchmark_schema_version"] == 3
     assert payload["manifest"]["digest"] == expected_digest
-    assert payload["manifest"]["schema_version"] == 1
-    assert payload["environment"]["manifest_schema_version"] == 1
+    assert payload["manifest"]["schema_version"] == 2
+    assert payload["environment"]["manifest_schema_version"] == 2
     assert payload["environment"]["source_commit"] == "b" * 40
     assert payload["metrics"]["abstention"]["enabled_cases"] == 4
     assert payload["metrics"]["abstention"]["rate"] >= 0.0
@@ -261,7 +295,7 @@ def test_scorecard_uses_manifest_top_k_unless_cli_overrides_it() -> None:
 
 def test_scorecard_metrics_detect_known_relevant_and_hard_negative_hits() -> None:
     manifest = benchmark.ManifestPayload(
-        schema_version=1,
+        schema_version=2,
         dataset_id="matryca-scorecard-unit-hits-v1",
         description="Synthetic ranking sanity check for known hits",
         top_k=2,
@@ -291,6 +325,7 @@ def test_scorecard_metrics_detect_known_relevant_and_hard_negative_hits() -> Non
                 query="alpha",
                 relevant=["doc_relevant"],
                 hard_negatives=["doc_neg"],
+                gold_classification="update_gold",
             )
         ],
     )
@@ -304,7 +339,7 @@ def test_scorecard_metrics_detect_known_relevant_and_hard_negative_hits() -> Non
 
 def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
     shared_payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "dataset_id": "matryca-scorecard-invariants-v1",
         "description": "Invariant validation fixture",
         "top_k": 8,
@@ -320,6 +355,7 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
             "query": f"alpha {index}",
             "relevant": ["doc_a"],
             "hard_negatives": ["doc_b", "doc_c"],
+            "gold_classification": "superseded_gold",
         }
         for index in range(20)
     ]
@@ -330,6 +366,7 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
         "query": "alpha duplicate",
         "relevant": ["doc_b"],
         "hard_negatives": ["doc_b", "doc_c"],
+        "gold_classification": "superseded_gold",
     }
     duplicate_seed_payload = {**shared_payload, "cases": duplicate_seed_cases}
 
@@ -353,6 +390,12 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
     unknown_nested_field_cases[0] = {**base_cases[0], "untracked": True}
     unknown_nested_field_payload = {**shared_payload, "cases": unknown_nested_field_cases}
 
+    missing_classification_cases = base_cases.copy()
+    missing_classification_cases[0] = {
+        key: value for key, value in base_cases[0].items() if key != "gold_classification"
+    }
+    missing_classification_payload = {**shared_payload, "cases": missing_classification_cases}
+
     abstain_min_cases = base_cases.copy()
     abstain_min_cases[0] = {
         **base_cases[0],
@@ -368,6 +411,7 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
     overlapping_path = tmp_path / "overlap.json"
     too_few_negatives_path = tmp_path / "few_negatives.json"
     unknown_nested_field_path = tmp_path / "unknown_nested_field.json"
+    missing_classification_path = tmp_path / "missing_classification.json"
     abstain_min_path = tmp_path / "abstain_min.json"
 
     duplicate_seed_path.write_text(json.dumps(duplicate_seed_payload), encoding="utf-8")
@@ -377,6 +421,9 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
     overlapping_path.write_text(json.dumps(overlapping_payload), encoding="utf-8")
     too_few_negatives_path.write_text(json.dumps(too_few_negatives_payload), encoding="utf-8")
     unknown_nested_field_path.write_text(json.dumps(unknown_nested_field_payload), encoding="utf-8")
+    missing_classification_path.write_text(
+        json.dumps(missing_classification_payload), encoding="utf-8"
+    )
     abstain_min_path.write_text(json.dumps(abstain_min_payload), encoding="utf-8")
 
     with pytest.raises(ValueError, match="duplicate case seed"):
@@ -391,6 +438,34 @@ def test_read_manifest_enforces_scorecard_invariants(tmp_path: Path) -> None:
         benchmark._read_manifest(abstain_min_path)
     with pytest.raises(ValueError, match="untracked"):
         benchmark._read_manifest(unknown_nested_field_path)
+    with pytest.raises(ValueError, match="gold_classification"):
+        benchmark._read_manifest(missing_classification_path)
+
+
+def test_scorecard_zero_denominators_are_explicit_zero() -> None:
+    metrics = benchmark._aggregate_rank_metrics(
+        [
+            {
+                "recall_at_k": 0.0,
+                "mrr": 0.0,
+                "ndcg": 0.0,
+                "stale_hits": 0,
+                "contradiction_hits": 0,
+                "abstained": False,
+                "update_expected": False,
+                "update_predicted": False,
+                "abstention_expected": False,
+            }
+        ],
+        top_k=8,
+        bootstrap_seed=1,
+        abstention_expected=0,
+        abstention_passed=0,
+    )
+
+    assert metrics["abstention"]["precision"] == 0.0
+    assert metrics["abstention"]["recall"] == 0.0
+    assert metrics["update"]["accuracy"] == 0.0
 
 
 def test_manifest_mode_does_not_touch_network(


### PR DESCRIPTION
## Summary
- evolve the synthetic BM25 scorecard to manifest schema v2 and output schema v3
- make update-only accuracy, abstention precision/recall/confusion, and ordered evidence fingerprints explicit
- document the reproducibility boundary and add deterministic contract coverage

## Test plan
- [x] focused benchmark and evidence-contract tests
- [x] Ruff, mypy, documentation bundle, and agent-coherence checks

Refs #448