### PR TITLE
feat(memory): add local LongMemEval-V2 provenance adapter (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- **Local LongMemEval-V2 input provenance adapter (#448)** — validate caller-supplied question, trajectory, and mapping JSONL with explicit license/revision provenance and immutable input-only digests; no downloads, inference, vault access, scoring, or result writes.
+
 - **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.
 - **Local LongMemEval retrieval adapter (#448)** — normalize acquired cleaned/oracle JSON into digest-pinned, order-preserving in-memory cases with separate session and answer-marked-turn evidence, without downloads, model calls, vault access, or result persistence.
 - **Cross-system benchmark contracts (#448)** — add closed, content-free manifests and retained-artifact reports that pin public-suite revisions, models, budgets, runtime context, and comparable Matryca/external controls without collecting prompts, answers, vault content, or running remote services.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -57,6 +57,12 @@ Shadow query, model call, remote export, canonical write, approval, or state
 transition. Accepted or rejected curation requires a later human-governed,
 canonical-write-adjacent slice; an external runtime cannot manufacture authority by
 attaching a label to a P0 packet. See [the evidence archive contract](evidence-archive.md).
+
+The LongMemEval-V2 adapter is a caller-supplied local input boundary only. It accepts
+digest-pinned question, trajectory, and question-to-haystack JSONL plus an explicit
+dataset license identifier and exact Hugging Face revision, returning immutable
+input/provenance evidence rather than a benchmark score. It performs no download,
+screenshot or media resolution, model or vault access, result write, or remote call.
 - Cache/fallback rules are deterministic.
 
 #### P2: proposal queue and curation

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -25,6 +25,15 @@ from .longmemeval_adapter import (
     LongMemEvalTurn,
     load_longmemeval_retrieval_cases,
 )
+from .longmemeval_v2_adapter import (
+    LongMemEvalV2InputEvidence,
+    LongMemEvalV2Provenance,
+    LongMemEvalV2Question,
+    LongMemEvalV2QuestionHaystack,
+    LongMemEvalV2Trajectory,
+    LongMemEvalV2Turn,
+    load_longmemeval_v2_input,
+)
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -37,6 +46,12 @@ __all__ = [
     "LongMemEvalRetrievalCase",
     "LongMemEvalSession",
     "LongMemEvalTurn",
+    "LongMemEvalV2InputEvidence",
+    "LongMemEvalV2Provenance",
+    "LongMemEvalV2Question",
+    "LongMemEvalV2QuestionHaystack",
+    "LongMemEvalV2Trajectory",
+    "LongMemEvalV2Turn",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
     "calculate_decayed_weight",
@@ -50,5 +65,6 @@ __all__ = [
     "recall_from_existing_retrieval",
     "load_locomo_retrieval_cases",
     "load_longmemeval_retrieval_cases",
+    "load_longmemeval_v2_input",
     "validate_comparative_cohort",
 ]

--- a/src/memory/longmemeval_v2_adapter.py
+++ b/src/memory/longmemeval_v2_adapter.py
@@ -1,0 +1,216 @@
+"""Local-only LongMemEval-V2 input and provenance evidence adapter.
+
+This module intentionally accepts only caller-supplied JSONL files. It does
+not claim to implement the benchmark, download upstream data, resolve media,
+invoke models, read vaults, or write results. The selected records are the
+smallest typed envelope needed to preserve question, haystack, and linkage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .evidence_models import EvidenceContractError
+
+_MAX_RECORDS = 100_000
+_MAX_RECORD_BYTES = 1_048_576
+_MAX_TURNS = 10_000
+_MAX_LINKS = 10_000
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_HF_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_LICENSE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.+-]{0,127}$")
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when JSON would otherwise silently overwrite a member."""
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class LongMemEvalV2Turn(_ClosedModel):
+    """One selected trajectory turn; ordering is source-defined."""
+
+    role: Literal["user", "assistant"]
+    content: str = Field(min_length=1, max_length=65_536)
+
+
+class LongMemEvalV2Question(_ClosedModel):
+    """Minimal selected question record from a caller-provided JSONL file."""
+
+    question_id: str = Field(min_length=1, max_length=512)
+    question: str = Field(min_length=1, max_length=65_536)
+
+
+class LongMemEvalV2Trajectory(_ClosedModel):
+    """Minimal selected haystack trajectory from a caller-provided JSONL file."""
+
+    trajectory_id: str = Field(min_length=1, max_length=512)
+    turns: tuple[LongMemEvalV2Turn, ...] = Field(min_length=1, max_length=_MAX_TURNS)
+
+
+class LongMemEvalV2QuestionHaystack(_ClosedModel):
+    """One ordered question-to-haystack mapping record."""
+
+    question_id: str = Field(min_length=1, max_length=512)
+    trajectory_ids: tuple[str, ...] = Field(min_length=1, max_length=_MAX_LINKS)
+
+
+class LongMemEvalV2Provenance(_ClosedModel):
+    """Content-safe provenance and explicit non-score evidence classification."""
+
+    dataset_license_id: str = Field(pattern=_LICENSE_ID.pattern)
+    huggingface_revision: str = Field(pattern=_HF_REVISION.pattern)
+    question_input_digest: str = Field(pattern=_SHA256.pattern)
+    trajectory_input_digest: str = Field(pattern=_SHA256.pattern)
+    mapping_input_digest: str = Field(pattern=_SHA256.pattern)
+    source_envelope_digest: str = Field(pattern=_SHA256.pattern)
+    evidence_kind: Literal["input_provenance_only"]
+
+
+class LongMemEvalV2InputEvidence(_ClosedModel):
+    """Immutable local input evidence, never a benchmark score report."""
+
+    provenance: LongMemEvalV2Provenance
+    questions: tuple[LongMemEvalV2Question, ...] = Field(min_length=1)
+    trajectories: tuple[LongMemEvalV2Trajectory, ...] = Field(min_length=1)
+    mappings: tuple[LongMemEvalV2QuestionHaystack, ...] = Field(min_length=1)
+
+
+def load_longmemeval_v2_input(
+    question_path: Path,
+    trajectory_path: Path,
+    mapping_path: Path,
+    *,
+    dataset_license_id: str,
+    huggingface_revision: str,
+) -> LongMemEvalV2InputEvidence:
+    """Load local V2 inputs and return input/provenance evidence only."""
+    license_id = _required_provenance(dataset_license_id, _LICENSE_ID, "license")
+    revision = _required_provenance(huggingface_revision, _HF_REVISION, "revision")
+    question_bytes = _read_input(question_path, "questions")
+    trajectory_bytes = _read_input(trajectory_path, "trajectories")
+    mapping_bytes = _read_input(mapping_path, "mapping")
+    questions = _load_records(question_bytes, LongMemEvalV2Question, "question")
+    trajectories = _load_records(trajectory_bytes, LongMemEvalV2Trajectory, "trajectory")
+    mappings = _load_records(mapping_bytes, LongMemEvalV2QuestionHaystack, "mapping")
+    _reject_duplicate_ids(questions, "question_id", "question")
+    _reject_duplicate_ids(trajectories, "trajectory_id", "trajectory")
+    _reject_duplicate_ids(mappings, "question_id", "mapping")
+    _reject_duplicate_mapping_links(mappings)
+    question_ids = {item.question_id for item in questions}
+    trajectory_ids = {item.trajectory_id for item in trajectories}
+    if {item.question_id for item in mappings} != question_ids:
+        raise EvidenceContractError("longmemeval_v2_question_mapping_incomplete")
+    if any(
+        trajectory_id not in trajectory_ids
+        for item in mappings
+        for trajectory_id in item.trajectory_ids
+    ):
+        raise EvidenceContractError("longmemeval_v2_trajectory_cross_reference_missing")
+    digests = {
+        "dataset_license_id": license_id,
+        "huggingface_revision": revision,
+        "question_input_digest": hashlib.sha256(question_bytes).hexdigest(),
+        "trajectory_input_digest": hashlib.sha256(trajectory_bytes).hexdigest(),
+        "mapping_input_digest": hashlib.sha256(mapping_bytes).hexdigest(),
+    }
+    envelope = json.dumps(digests, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    provenance = LongMemEvalV2Provenance(
+        **digests,
+        source_envelope_digest=hashlib.sha256(envelope).hexdigest(),
+        evidence_kind="input_provenance_only",
+    )
+    return LongMemEvalV2InputEvidence(
+        provenance=provenance,
+        questions=tuple(questions),
+        trajectories=tuple(trajectories),
+        mappings=tuple(mappings),
+    )
+
+
+def _read_input(path: Path, label: str) -> bytes:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError(f"longmemeval_v2_{label}_unreadable") from exc
+    if not raw.strip():
+        raise EvidenceContractError(f"longmemeval_v2_{label}_empty")
+    return raw
+
+
+def _load_records(raw: bytes, model: type[BaseModel], label: str) -> list[Any]:
+    lines = raw.splitlines()
+    if not lines or len(lines) > _MAX_RECORDS:
+        raise EvidenceContractError(f"longmemeval_v2_{label}_records_invalid")
+    records: list[Any] = []
+    for line in lines:
+        if len(line) > _MAX_RECORD_BYTES or not line.strip():
+            raise EvidenceContractError(f"longmemeval_v2_{label}_record_invalid")
+        try:
+            value: Any = json.loads(
+                line,
+                object_pairs_hook=_no_duplicate_json_keys,
+                parse_constant=_reject_non_finite,
+            )
+            if not isinstance(value, Mapping):
+                raise ValueError("record must be an object")
+            records.append(model.model_validate(value))
+        except (
+            _DuplicateJsonKeyError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValueError,
+            ValidationError,
+        ) as exc:
+            raise EvidenceContractError(f"longmemeval_v2_{label}_record_invalid") from exc
+    return records
+
+
+def _reject_duplicate_ids(records: list[Any], field: str, label: str) -> None:
+    values = [getattr(record, field) for record in records]
+    if len(values) != len(set(values)):
+        raise EvidenceContractError(f"longmemeval_v2_{label}_id_duplicate")
+
+
+def _reject_duplicate_mapping_links(mappings: list[Any]) -> None:
+    if any(len(item.trajectory_ids) != len(set(item.trajectory_ids)) for item in mappings):
+        raise EvidenceContractError("longmemeval_v2_mapping_trajectory_id_duplicate")
+
+
+def _required_provenance(value: str, pattern: re.Pattern[str], label: str) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise EvidenceContractError(f"longmemeval_v2_{label}_invalid")
+    return value
+
+
+def _no_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"unsupported JSON constant: {value}")
+
+
+__all__ = [
+    "LongMemEvalV2InputEvidence",
+    "LongMemEvalV2Provenance",
+    "LongMemEvalV2Question",
+    "LongMemEvalV2QuestionHaystack",
+    "LongMemEvalV2Trajectory",
+    "LongMemEvalV2Turn",
+    "load_longmemeval_v2_input",
+]

--- a/tests/test_longmemeval_v2_adapter.py
+++ b/tests/test_longmemeval_v2_adapter.py
@@ -1,0 +1,226 @@
+"""Tests for the local-only LongMemEval-V2 input adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.longmemeval_adapter import LongMemEvalDataset
+from src.memory.longmemeval_v2_adapter import (
+    LongMemEvalV2InputEvidence,
+    load_longmemeval_v2_input,
+)
+
+_REVISION = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _write_jsonl(tmp_path: Path, name: str, records: list[object]) -> Path:
+    path = tmp_path / name
+    path.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+    return path
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    questions = _write_jsonl(
+        tmp_path,
+        "questions.jsonl",
+        [
+            {"question_id": "q-2", "question": "Later?"},
+            {"question_id": "q-1", "question": "What changed?"},
+        ],
+    )
+    trajectories = _write_jsonl(
+        tmp_path,
+        "trajectories.jsonl",
+        [
+            {"trajectory_id": "haystack-b", "turns": [{"role": "assistant", "content": "B"}]},
+            {"trajectory_id": "haystack-a", "turns": [{"role": "user", "content": "A"}]},
+        ],
+    )
+    mappings = _write_jsonl(
+        tmp_path,
+        "mapping.jsonl",
+        [
+            {"question_id": "q-2", "trajectory_ids": ["haystack-b"]},
+            {"question_id": "q-1", "trajectory_ids": ["haystack-a", "haystack-b"]},
+        ],
+    )
+    return questions, trajectories, mappings
+
+
+def test_load_is_deterministic_ordered_and_digest_pinned(tmp_path: Path) -> None:
+    questions, trajectories, mappings = _inputs(tmp_path)
+    first = load_longmemeval_v2_input(
+        questions, trajectories, mappings, dataset_license_id="MIT", huggingface_revision=_REVISION
+    )
+    second = load_longmemeval_v2_input(
+        questions, trajectories, mappings, dataset_license_id="MIT", huggingface_revision=_REVISION
+    )
+
+    assert first == second
+    assert [item.question_id for item in first.questions] == ["q-2", "q-1"]
+    assert [item.trajectory_id for item in first.trajectories] == ["haystack-b", "haystack-a"]
+    assert [item.question_id for item in first.mappings] == ["q-2", "q-1"]
+    assert (
+        first.provenance.question_input_digest == hashlib.sha256(questions.read_bytes()).hexdigest()
+    )
+    assert len(first.provenance.source_envelope_digest) == 64
+    assert first.provenance.evidence_kind == "input_provenance_only"
+    with pytest.raises(ValidationError):
+        first.questions[0].question = "mutated"
+
+
+def test_unsupported_and_oversized_records_fail_closed(tmp_path: Path) -> None:
+    questions, trajectories, mappings = _inputs(tmp_path)
+    questions.write_text(
+        '{"question_id":"q-1","question":"ok","unsupported":true}\n', encoding="utf-8"
+    )
+    with pytest.raises(EvidenceContractError, match="longmemeval_v2_question_record_invalid"):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+    questions, trajectories, mappings = _inputs(tmp_path)
+    trajectories.write_text(
+        json.dumps(
+            {"trajectory_id": "haystack-a", "turns": [{"role": "user", "content": "x" * 65_537}]}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(EvidenceContractError, match="longmemeval_v2_trajectory_record_invalid"):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (b"{not-json}\n", "longmemeval_v2_question_record_invalid"),
+        (
+            b'{"question_id":"q-1","question":"a","question":"b"}\n',
+            "longmemeval_v2_question_record_invalid",
+        ),
+        (b'{"question_id":"q-1","question":NaN}\n', "longmemeval_v2_question_record_invalid"),
+        (
+            b'{"question_id":"q-1","question":Infinity}\n',
+            "longmemeval_v2_question_record_invalid",
+        ),
+        (
+            b'{"question_id":"q-1","question":-Infinity}\n',
+            "longmemeval_v2_question_record_invalid",
+        ),
+    ],
+)
+def test_malformed_json_fails_closed(tmp_path: Path, payload: bytes, error: str) -> None:
+    _questions, trajectories, mappings = _inputs(tmp_path)
+    bad = tmp_path / "bad.jsonl"
+    bad.write_bytes(payload)
+    with pytest.raises(EvidenceContractError, match=error):
+        load_longmemeval_v2_input(
+            bad, trajectories, mappings, dataset_license_id="MIT", huggingface_revision=_REVISION
+        )
+
+
+def test_duplicate_ids_and_invalid_mapping_cross_reference_fail_closed(tmp_path: Path) -> None:
+    questions, trajectories, mappings = _inputs(tmp_path)
+    questions.write_text(
+        '{"question_id":"q-1","question":"a"}\n{"question_id":"q-1","question":"b"}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(EvidenceContractError, match="longmemeval_v2_question_id_duplicate"):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+    questions, trajectories, mappings = _inputs(tmp_path)
+    mappings.write_text(
+        '{"question_id":"q-1","trajectory_ids":["missing"]}\n{"question_id":"q-2","trajectory_ids":["haystack-b"]}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        EvidenceContractError, match="longmemeval_v2_trajectory_cross_reference_missing"
+    ):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+    mappings.write_text(
+        '{"question_id":"q-1","trajectory_ids":["haystack-a","haystack-a"]}\n{"question_id":"q-2","trajectory_ids":["haystack-b"]}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        EvidenceContractError, match="longmemeval_v2_mapping_trajectory_id_duplicate"
+    ):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+    mappings.write_text('{"question_id":"q-1","trajectory_ids":["haystack-a"]}\n', encoding="utf-8")
+    with pytest.raises(EvidenceContractError, match="longmemeval_v2_question_mapping_incomplete"):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id="MIT",
+            huggingface_revision=_REVISION,
+        )
+
+
+@pytest.mark.parametrize(
+    ("license_id", "revision"),
+    [("", _REVISION), ("MIT", "not-a-revision"), ("CC BY 4.0", _REVISION)],
+)
+def test_missing_or_malformed_provenance_fails_closed(
+    tmp_path: Path, license_id: str, revision: str
+) -> None:
+    questions, trajectories, mappings = _inputs(tmp_path)
+    with pytest.raises(EvidenceContractError, match="longmemeval_v2_(license|revision)_invalid"):
+        load_longmemeval_v2_input(
+            questions,
+            trajectories,
+            mappings,
+            dataset_license_id=license_id,
+            huggingface_revision=revision,
+        )
+
+
+def test_no_network_side_effects_and_v1_separation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_socket(*args: object, **kwargs: object) -> socket.socket:
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "socket", fail_socket)
+    paths = _inputs(tmp_path)
+    before = {path: path.stat().st_mtime_ns for path in paths}
+    result = load_longmemeval_v2_input(
+        *paths, dataset_license_id="MIT", huggingface_revision=_REVISION
+    )
+    after = {path: path.stat().st_mtime_ns for path in before}
+    assert before == after
+    assert isinstance(result, LongMemEvalV2InputEvidence)
+    assert LongMemEvalDataset.__module__.endswith("longmemeval_adapter")
+    assert result.__class__.__module__.endswith("longmemeval_v2_adapter")


### PR DESCRIPTION
## Summary
- add a separate local-only LongMemEval-V2 input/provenance adapter with closed JSONL contracts
- require exact license and dataset-revision provenance, ordered cross-reference validation, and immutable SHA-256 evidence
- document the explicit non-evaluator, non-network, non-media boundary

## Test plan
- [x] focused V2, V1-separation, evidence-contract, and protocol tests
- [x] Ruff, mypy, documentation bundle, and agent-coherence checks

Refs #448