### PR TITLE
feat(benchmark): add governed cohort receipts (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Governed comparative cohort receipts (#448)** — assemble deterministic, privacy-safe evidence receipts only when an exact public corpus and every required opaque result artifact have matching retained attestations across the required Matryca and open-system controls; no benchmark execution, provider call, vault access, raw-content retention, or result write.
 - **Local LongMemEval-V2 input provenance adapter (#448)** — validate caller-supplied question, trajectory, and mapping JSONL with explicit license/revision provenance and immutable input-only digests; no downloads, inference, vault access, scoring, or result writes.
 
 - **Local LoCoMo retrieval adapter (#448)** — normalize an already acquired public LoCoMo dataset into deterministic session-turn and QA-evidence cases without downloads, image fetching, model calls, vault access, or result persistence.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -63,6 +63,16 @@ digest-pinned question, trajectory, and question-to-haystack JSONL plus an expli
 dataset license identifier and exact Hugging Face revision, returning immutable
 input/provenance evidence rather than a benchmark score. It performs no download,
 screenshot or media resolution, model or vault access, result write, or remote call.
+
+The comparative cohort receipt is likewise provider-free and content-free. It binds a
+validated four-system control cohort to one retained public-corpus digest and exact
+opaque-artifact attestations. It rejects missing, duplicate, mismatched, mixed-policy,
+non-reproduced, or non-comparable evidence, and accepts exactly four baseline runs.
+The receipt records no retention path, corpus text,
+prompt, answer, credential, or vault identifier; it neither runs systems nor writes
+artifacts. Raw public-suite material remains outside the receipt under the declared
+retention policy, and a receipt is evidence of comparability and retention only—not a
+quality score or a superiority claim.
 - Cache/fallback rules are deterministic.
 
 #### P2: proposal queue and curation

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,5 +1,11 @@
 """Biological memory graph layer (Nacre-inspired, Epic #99)."""
 
+from .benchmark_cohort import (
+    ComparativeCohortReceipt,
+    CorpusRetentionAttestation,
+    RetainedArtifactAttestation,
+    assemble_comparative_cohort_receipt,
+)
 from .benchmark_protocol import (
     BenchmarkRunManifest,
     BenchmarkRunReport,
@@ -54,6 +60,10 @@ __all__ = [
     "LongMemEvalV2Turn",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
+    "ComparativeCohortReceipt",
+    "CorpusRetentionAttestation",
+    "RetainedArtifactAttestation",
+    "assemble_comparative_cohort_receipt",
     "calculate_decayed_weight",
     "calculate_stability",
     "compute_decayed_weight_from_dates",

--- a/src/memory/benchmark_cohort.py
+++ b/src/memory/benchmark_cohort.py
@@ -1,0 +1,218 @@
+"""Provider-free assembly of privacy-safe comparative benchmark receipts.
+
+This module never executes a benchmark.  It turns already completed, closed
+``BenchmarkRunReport`` values into a deterministic receipt only after checking
+that every opaque artifact has a matching, content-free retention attestation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from .benchmark_protocol import (
+    ArtifactKind,
+    BenchmarkRunReport,
+    DatasetPin,
+    validate_comparative_cohort,
+)
+from .evidence_models import EvidenceContractError
+
+COHORT_RECEIPT_SCHEMA_VERSION = "benchmark-cohort-receipt.v1"
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+RetentionClass = Literal["public_benchmark_only"]
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+def _identifier(value: str, *, field: str) -> str:
+    normalized = value.strip()
+    if not _IDENTIFIER.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+def _sha256(value: str, *, field: str) -> str:
+    normalized = value.strip().lower()
+    if not _SHA256.fullmatch(normalized):
+        raise EvidenceContractError(f"invalid_{field}")
+    return normalized
+
+
+class CorpusRetentionAttestation(_ClosedModel):
+    """Content-free proof that an exact public corpus revision remains retained."""
+
+    dataset: DatasetPin
+    corpus_digest: str
+    record_count: int = Field(ge=1)
+    retention_policy_id: str
+    retention_class: RetentionClass = "public_benchmark_only"
+
+    @model_validator(mode="after")
+    def _validate_attestation(self) -> CorpusRetentionAttestation:
+        object.__setattr__(
+            self,
+            "corpus_digest",
+            _sha256(self.corpus_digest, field="corpus_digest"),
+        )
+        object.__setattr__(
+            self,
+            "retention_policy_id",
+            _identifier(self.retention_policy_id, field="retention_policy_id"),
+        )
+        return self
+
+
+class RetainedArtifactAttestation(_ClosedModel):
+    """Content-free proof that one required run artifact remains retained."""
+
+    report_id: str
+    kind: ArtifactKind
+    digest: str
+    record_count: int = Field(ge=0)
+    retention_policy_id: str
+    retention_class: RetentionClass = "public_benchmark_only"
+
+    @model_validator(mode="after")
+    def _validate_attestation(self) -> RetainedArtifactAttestation:
+        object.__setattr__(self, "report_id", _sha256(self.report_id, field="report_id"))
+        object.__setattr__(self, "digest", _sha256(self.digest, field=f"{self.kind}_digest"))
+        object.__setattr__(
+            self,
+            "retention_policy_id",
+            _identifier(self.retention_policy_id, field="retention_policy_id"),
+        )
+        return self
+
+
+class ComparativeCohortReceipt(_ClosedModel):
+    """Public, deterministic receipt for a retained like-for-like cohort."""
+
+    schema_version: str = COHORT_RECEIPT_SCHEMA_VERSION
+    cohort_id: str
+    cohort_fingerprint: str
+    corpus: CorpusRetentionAttestation
+    retention_policy_id: str
+    report_ids: tuple[str, ...]
+    artifact_retention_digest: str
+
+    @model_validator(mode="after")
+    def _validate_receipt(self) -> ComparativeCohortReceipt:
+        if self.schema_version != COHORT_RECEIPT_SCHEMA_VERSION:
+            raise EvidenceContractError("unsupported_cohort_receipt_schema")
+        object.__setattr__(self, "cohort_id", _identifier(self.cohort_id, field="cohort_id"))
+        object.__setattr__(
+            self,
+            "cohort_fingerprint",
+            _sha256(self.cohort_fingerprint, field="cohort_fingerprint"),
+        )
+        object.__setattr__(
+            self,
+            "retention_policy_id",
+            _identifier(self.retention_policy_id, field="retention_policy_id"),
+        )
+        report_ids = tuple(_sha256(value, field="report_id") for value in self.report_ids)
+        if len(report_ids) != 4 or len(set(report_ids)) != len(report_ids):
+            raise EvidenceContractError("invalid_cohort_report_ids")
+        object.__setattr__(self, "report_ids", tuple(sorted(report_ids)))
+        object.__setattr__(
+            self,
+            "artifact_retention_digest",
+            _sha256(self.artifact_retention_digest, field="artifact_retention_digest"),
+        )
+        if self.corpus.retention_policy_id != self.retention_policy_id:
+            raise EvidenceContractError("cohort_retention_policy_mismatch")
+        return self
+
+    @property
+    def receipt_id(self) -> str:
+        return hashlib.sha256(canonical_cohort_receipt_bytes(self)).hexdigest()
+
+
+def canonical_cohort_receipt_bytes(receipt: ComparativeCohortReceipt) -> bytes:
+    """Return the stable content-addressed representation of a public receipt."""
+
+    return json.dumps(
+        receipt.model_dump(mode="json"),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def assemble_comparative_cohort_receipt(
+    reports: tuple[BenchmarkRunReport, ...],
+    corpus: CorpusRetentionAttestation,
+    artifacts: tuple[RetainedArtifactAttestation, ...],
+) -> ComparativeCohortReceipt:
+    """Assemble a receipt after closed control, source, and retention checks.
+
+    No artifact bytes, paths, prompts, answers, credentials, or system calls are
+    accepted.  The caller retains raw public benchmark material elsewhere and
+    supplies only exact content-free attestations here.
+    """
+
+    cohort_fingerprint = validate_comparative_cohort(reports)
+    manifests = tuple(report.manifest for report in reports)
+    cohort_id = manifests[0].cohort_id
+    if corpus.dataset != manifests[0].dataset:
+        raise EvidenceContractError("cohort_corpus_dataset_mismatch")
+
+    expected = {
+        (report.report_id, artifact.kind): (artifact.digest, artifact.record_count)
+        for report in reports
+        for artifact in report.artifacts
+    }
+    if len(expected) != sum(len(report.artifacts) for report in reports):
+        raise EvidenceContractError("cohort_report_id_duplicate")
+    supplied = {(item.report_id, item.kind): (item.digest, item.record_count) for item in artifacts}
+    if len(supplied) != len(artifacts) or set(supplied) != set(expected):
+        raise EvidenceContractError("incomplete_or_duplicate_retention_attestations")
+    if supplied != expected:
+        raise EvidenceContractError("retained_artifact_mismatch")
+
+    policy_ids = {corpus.retention_policy_id, *(item.retention_policy_id for item in artifacts)}
+    if len(policy_ids) != 1:
+        raise EvidenceContractError("cohort_retention_policy_mismatch")
+    retention_payload = [
+        {
+            "digest": item.digest,
+            "kind": item.kind,
+            "record_count": item.record_count,
+            "report_id": item.report_id,
+        }
+        for item in sorted(artifacts, key=lambda item: (item.report_id, item.kind))
+    ]
+    retention_digest = hashlib.sha256(
+        json.dumps(
+            retention_payload,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return ComparativeCohortReceipt(
+        cohort_id=cohort_id,
+        cohort_fingerprint=cohort_fingerprint,
+        corpus=corpus,
+        retention_policy_id=corpus.retention_policy_id,
+        report_ids=tuple(report.report_id for report in reports),
+        artifact_retention_digest=retention_digest,
+    )
+
+
+__all__ = [
+    "COHORT_RECEIPT_SCHEMA_VERSION",
+    "ComparativeCohortReceipt",
+    "CorpusRetentionAttestation",
+    "RetainedArtifactAttestation",
+    "assemble_comparative_cohort_receipt",
+    "canonical_cohort_receipt_bytes",
+]

--- a/src/memory/benchmark_protocol.py
+++ b/src/memory/benchmark_protocol.py
@@ -292,9 +292,11 @@ def validate_comparative_cohort(reports: tuple[BenchmarkRunReport, ...]) -> str:
     The validator does not score systems.  It proves only that a resulting
     comparison has the required controls and compatible measurement context.
     """
-    if len(reports) < 4:
-        raise EvidenceContractError("comparative_cohort_requires_four_runs")
+    if len(reports) != 4:
+        raise EvidenceContractError("comparative_cohort_requires_exactly_four_runs")
     manifests = tuple(report.manifest for report in reports)
+    if any(manifest.evidence_class != "independently_reproduced" for manifest in manifests):
+        raise EvidenceContractError("comparative_cohort_requires_reproduced_evidence")
     if any(report.status != "completed" for report in reports):
         raise EvidenceContractError("comparative_cohort_requires_completed_runs")
     if len({manifest.cohort_id for manifest in manifests}) != 1:

--- a/tests/test_benchmark_cohort.py
+++ b/tests/test_benchmark_cohort.py
@@ -1,0 +1,245 @@
+"""Tests for provider-free comparative cohort receipt assembly."""
+
+from __future__ import annotations
+
+import pytest
+from src.memory.benchmark_cohort import (
+    ComparativeCohortReceipt,
+    CorpusRetentionAttestation,
+    RetainedArtifactAttestation,
+    assemble_comparative_cohort_receipt,
+    canonical_cohort_receipt_bytes,
+)
+from src.memory.benchmark_protocol import (
+    BenchmarkRunManifest,
+    BenchmarkRunReport,
+    DatasetPin,
+    EvaluationBudget,
+    OpaqueArtifact,
+    RuntimePin,
+    SystemPin,
+    SystemRole,
+)
+from src.memory.evidence_models import EvidenceContractError
+
+_A = "a" * 40
+_B = "b" * 40
+_C = "c" * 40
+_D = "d" * 40
+_E = "e" * 40
+_F = "f" * 40
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+_DIGEST_C = "c" * 64
+_DIGEST_D = "d" * 64
+_CORPUS_DIGEST = "f" * 64
+
+
+def _dataset() -> DatasetPin:
+    return DatasetPin(
+        suite="locomo",
+        dataset_id="locomo-v1",
+        repository_slug="snap-research/locomo",
+        dataset_revision=_C,
+        license_id="CC-BY-4.0",
+    )
+
+
+def _runtime() -> RuntimePin:
+    return RuntimePin(
+        harness_revision=_A,
+        matryca_revision=_B,
+        dependency_lock_digest=_DIGEST_A,
+        hardware_class="apple-m4-max-64gb",
+        os_family="macos-15",
+        runtime_version="python-3.12",
+        concurrency=1,
+        cache_state="cold",
+        failure_policy_id="retain-all-terminal-outcomes",
+        retry_policy_id="no-retry",
+    )
+
+
+def _report(role: SystemRole, system_id: str) -> BenchmarkRunReport:
+    return BenchmarkRunReport(
+        manifest=BenchmarkRunManifest(
+            cohort_id="locomo-retrieval-baseline-v1",
+            dataset=_dataset(),
+            evaluation_layer="retrieval",
+            system=SystemPin(
+                role=role,
+                system_id=system_id,
+                implementation_revision=_D if system_id == "matryca-plumber" else _E,
+                configuration_digest=_DIGEST_B,
+                open_source=True,
+            ),
+            answer_model=None,
+            judge_model=None,
+            budget=EvaluationBudget(
+                context_token_budget=8_192,
+                retrieval_call_budget=4,
+                top_k=8,
+                timeout_seconds=60,
+            ),
+            runtime=_runtime(),
+            evidence_class="independently_reproduced",
+        ),
+        status="completed",
+        artifacts=(
+            OpaqueArtifact(kind="item_results", digest=_DIGEST_A, record_count=24),
+            OpaqueArtifact(kind="run_metadata", digest=_DIGEST_B, record_count=1),
+            OpaqueArtifact(kind="exclusions", digest=_DIGEST_C, record_count=0),
+            OpaqueArtifact(kind="failed_runs", digest=_DIGEST_D, record_count=0),
+        ),
+    )
+
+
+def _reports() -> tuple[BenchmarkRunReport, ...]:
+    return (
+        _report("matryca_without_semantic_memory", "matryca-plumber"),
+        _report("matryca_candidate_feature", "matryca-plumber"),
+        _report("external_open_system", "mem0"),
+        _report("external_open_system", "graphiti"),
+    )
+
+
+def _corpus() -> CorpusRetentionAttestation:
+    return CorpusRetentionAttestation(
+        dataset=_dataset(),
+        corpus_digest=_CORPUS_DIGEST,
+        record_count=250,
+        retention_policy_id="public-benchmark-retention-v1",
+    )
+
+
+def _artifacts(reports: tuple[BenchmarkRunReport, ...]) -> tuple[RetainedArtifactAttestation, ...]:
+    return tuple(
+        RetainedArtifactAttestation(
+            report_id=report.report_id,
+            kind=artifact.kind,
+            digest=artifact.digest,
+            record_count=artifact.record_count,
+            retention_policy_id="public-benchmark-retention-v1",
+        )
+        for report in reports
+        for artifact in report.artifacts
+    )
+
+
+def test_receipt_is_deterministic_closed_and_content_free() -> None:
+    reports = _reports()
+    receipt = assemble_comparative_cohort_receipt(reports, _corpus(), _artifacts(reports))
+    reordered = assemble_comparative_cohort_receipt(
+        tuple(reversed(reports)), _corpus(), tuple(reversed(_artifacts(reports)))
+    )
+
+    assert receipt == reordered
+    assert receipt.receipt_id == reordered.receipt_id
+    assert canonical_cohort_receipt_bytes(receipt) == canonical_cohort_receipt_bytes(reordered)
+    assert receipt.report_ids == tuple(sorted(report.report_id for report in reports))
+    assert "path" not in canonical_cohort_receipt_bytes(receipt).decode("ascii")
+    with pytest.raises(ValueError):
+        ComparativeCohortReceipt.model_validate({**receipt.model_dump(), "raw_prompt": "unsafe"})
+    with pytest.raises(ValueError, match="invalid_cohort_report_ids"):
+        ComparativeCohortReceipt.model_validate(
+            {**receipt.model_dump(), "report_ids": [*receipt.report_ids, _DIGEST_D]}
+        )
+
+
+def test_receipt_rejects_missing_duplicate_and_mismatched_attestations() -> None:
+    reports = _reports()
+    artifacts = _artifacts(reports)
+
+    with pytest.raises(
+        EvidenceContractError, match="incomplete_or_duplicate_retention_attestations"
+    ):
+        assemble_comparative_cohort_receipt(reports, _corpus(), artifacts[:-1])
+    with pytest.raises(
+        EvidenceContractError, match="incomplete_or_duplicate_retention_attestations"
+    ):
+        assemble_comparative_cohort_receipt(reports, _corpus(), (*artifacts, artifacts[0]))
+
+    mismatched = RetainedArtifactAttestation(
+        report_id=artifacts[0].report_id,
+        kind=artifacts[0].kind,
+        digest=_CORPUS_DIGEST,
+        record_count=artifacts[0].record_count,
+        retention_policy_id=artifacts[0].retention_policy_id,
+    )
+    with pytest.raises(EvidenceContractError, match="retained_artifact_mismatch"):
+        assemble_comparative_cohort_receipt(reports, _corpus(), (mismatched, *artifacts[1:]))
+
+
+def test_receipt_rejects_dataset_and_retention_policy_mismatches() -> None:
+    reports = _reports()
+    wrong_corpus = CorpusRetentionAttestation(
+        dataset=DatasetPin(
+            suite="longmemeval",
+            dataset_id="longmemeval-v1",
+            repository_slug="x/y",
+            dataset_revision=_F,
+            license_id="MIT",
+        ),
+        corpus_digest=_CORPUS_DIGEST,
+        record_count=250,
+        retention_policy_id="public-benchmark-retention-v1",
+    )
+    with pytest.raises(EvidenceContractError, match="cohort_corpus_dataset_mismatch"):
+        assemble_comparative_cohort_receipt(reports, wrong_corpus, _artifacts(reports))
+
+    changed = list(_artifacts(reports))
+    changed[-1] = RetainedArtifactAttestation(
+        report_id=changed[-1].report_id,
+        kind=changed[-1].kind,
+        digest=changed[-1].digest,
+        record_count=changed[-1].record_count,
+        retention_policy_id="another-policy",
+    )
+    with pytest.raises(EvidenceContractError, match="cohort_retention_policy_mismatch"):
+        assemble_comparative_cohort_receipt(reports, _corpus(), tuple(changed))
+
+
+def test_receipt_preserves_comparative_and_completed_run_gates() -> None:
+    reports = _reports()
+    incomplete = reports[:-1]
+
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_exactly_four_runs"
+    ):
+        assemble_comparative_cohort_receipt(incomplete, _corpus(), _artifacts(incomplete))
+
+    expanded = (*reports, _report("external_open_system", "zep"))
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_exactly_four_runs"
+    ):
+        assemble_comparative_cohort_receipt(expanded, _corpus(), _artifacts(expanded))
+
+    failed = BenchmarkRunReport(
+        manifest=reports[-1].manifest,
+        status="failed",
+        artifacts=reports[-1].artifacts,
+    )
+    modified = (*reports[:-1], failed)
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_requires_completed_runs"):
+        assemble_comparative_cohort_receipt(modified, _corpus(), _artifacts(modified))
+
+
+def test_receipt_rejects_non_reproduced_evidence() -> None:
+    reports = list(_reports())
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {**reports[-1].manifest.model_dump(), "evidence_class": "upstream_reported_not_rerun"}
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
+    non_reproduced = tuple(reports)
+
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_reproduced_evidence"
+    ):
+        assemble_comparative_cohort_receipt(
+            non_reproduced,
+            _corpus(),
+            _artifacts(non_reproduced),
+        )

--- a/tests/test_benchmark_protocol.py
+++ b/tests/test_benchmark_protocol.py
@@ -170,6 +170,27 @@ def test_comparative_cohort_requires_matryca_controls_and_two_open_systems() -> 
     ):
         validate_comparative_cohort(duplicated_external)
 
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_exactly_four_runs"
+    ):
+        validate_comparative_cohort(reports[:-1])
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_exactly_four_runs"
+    ):
+        validate_comparative_cohort((*reports, _report("external_open_system", "zep")))
+
+    non_reproduced = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {**reports[-1].manifest.model_dump(), "evidence_class": "upstream_reported_not_rerun"}
+        ),
+        status="completed",
+        artifacts=reports[-1].artifacts,
+    )
+    with pytest.raises(
+        EvidenceContractError, match="comparative_cohort_requires_reproduced_evidence"
+    ):
+        validate_comparative_cohort((*reports[:-1], non_reproduced))
+
 
 def test_comparative_cohort_rejects_context_or_layer_mismatch() -> None:
     reports = list(


### PR DESCRIPTION
## Summary
- add a provider-free, content-free receipt for reproducible four-system comparative cohorts
- require independently reproduced evidence, a matched public corpus attestation, and complete exact retained-artifact attestations
- reject privacy boundary violations, missing or duplicate evidence, mismatched digests/counts, mixed retention policies, and non-comparable cohorts

## Validation
- [x] 29 focused benchmark/evidence tests
- [x] Ruff and mypy
- [x] documentation bundle and agent-coherence checks
- [x] independent review of the exact head

Refs #448