### PR TITLE
test(benchmark): retain synthetic scorecard evidence (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Retained synthetic retrieval scorecard evidence (#448)** — commit the first manifest-bound, retrieval-only Italian hard-negative result with its deterministic fingerprint, bootstrap intervals, signal ablation, source revision, and a regression check that separates reproducible retrieval evidence from host-dependent latency and RSS diagnostics.
 - **Governed comparative cohort receipts (#448)** — assemble deterministic, privacy-safe evidence receipts only when an exact public corpus and every required opaque result artifact have matching retained attestations across the required Matryca and open-system controls; no benchmark execution, provider call, vault access, raw-content retention, or result write.
 - **Local LongMemEval-V2 input provenance adapter (#448)** — validate caller-supplied question, trajectory, and mapping JSONL with explicit license/revision provenance and immutable input-only digests; no downloads, inference, vault access, scoring, or result writes.
 

--- a/benchmarks/results/bm25_query_cache_scorecard_macos_arm64_2026-08-10.json
+++ b/benchmarks/results/bm25_query_cache_scorecard_macos_arm64_2026-08-10.json
@@ -1,0 +1,696 @@
+{
+  "benchmark_schema_version": 3,
+  "case_count": 24,
+  "case_results": [
+    {
+      "gold_classification": "update_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 0.5,
+        "ndcg": 0.6309,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": true,
+        "update_predicted": true
+      },
+      "query": "cache bm25 invalidazione limit row",
+      "retrieved_relations": [
+        "pages/progetto_alfa.md",
+        "pages/cache_bm25.md"
+      ],
+      "seed": 20260802
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "banca dati grafi relazioni pagine",
+      "retrieved_relations": [
+        "pages/banca_dati_grafi.md",
+        "pages/backup_offline.md"
+      ],
+      "seed": 20260803
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "pipeline riassunto entit\u00e0 titolo sommario",
+      "retrieved_relations": [
+        "pages/pipeline_riassunto.md"
+      ],
+      "seed": 20260804
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "onboarding team checklist",
+      "retrieved_relations": [
+        "pages/onboarding_team.md"
+      ],
+      "seed": 20260805
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "backup locale snapshot ripristino",
+      "retrieved_relations": [
+        "pages/backup_locale.md",
+        "pages/backup_offline.md",
+        "pages/progetto_alfa.md",
+        "pages/orchestrazione_k8s.md"
+      ],
+      "seed": 20260806
+    },
+    {
+      "gold_classification": "update_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": true,
+        "update_predicted": true
+      },
+      "query": "sicurezza oauth token privilegio autorizzazione",
+      "retrieved_relations": [
+        "pages/sicurezza_oauth.md"
+      ],
+      "seed": 20260807
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "api rest payload codice errore",
+      "retrieved_relations": [
+        "pages/api_rest.md"
+      ],
+      "seed": 20260808
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "indice semantico vettori tag struttura",
+      "retrieved_relations": [
+        "pages/indice_semantico.md",
+        "pages/diario_lavoro.md"
+      ],
+      "seed": 20260809
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 0.5,
+        "ndcg": 0.6934,
+        "recall_at_k": 1.0,
+        "stale_hits": 2,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "query plausibile precisione recall",
+      "retrieved_relations": [
+        "pages/query_plausibile.md",
+        "pages/metrica_precisione.md",
+        "pages/metriche_mrc.md"
+      ],
+      "seed": 20260810
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "contratti energia tariffa",
+      "retrieved_relations": [
+        "pages/contratti_energia.md"
+      ],
+      "seed": 20260811
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "agenda sprint revisione criteri",
+      "retrieved_relations": [
+        "pages/agenda_sprint.md",
+        "pages/documento_riconosciuto.md"
+      ],
+      "seed": 20260812
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 0.5,
+        "ndcg": 0.6309,
+        "recall_at_k": 1.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "metrica mrr ndcg top-k",
+      "retrieved_relations": [
+        "pages/metrica_precisione.md",
+        "pages/metriche_mrc.md"
+      ],
+      "seed": 20260813
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "cronologia patch hash firma",
+      "retrieved_relations": [
+        "pages/cronologia_patch.md"
+      ],
+      "seed": 20260814
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "utente privilegiato verifica multifattore",
+      "retrieved_relations": [
+        "pages/utente_privilegiato.md",
+        "pages/backup_offline.md",
+        "pages/sicurezza_oauth.md"
+      ],
+      "seed": 20260815
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "orchestrazione k8s risorse workload",
+      "retrieved_relations": [
+        "pages/orchestrazione_k8s.md",
+        "pages/monitoraggio_risorse.md"
+      ],
+      "seed": 20260816
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "modello llm sintesi controllo",
+      "retrieved_relations": [
+        "pages/modello_llm.md",
+        "pages/cronologia_patch.md"
+      ],
+      "seed": 20260817
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "backup offline checksum rete",
+      "retrieved_relations": [
+        "pages/backup_offline.md",
+        "pages/backup_locale.md"
+      ],
+      "seed": 20260818
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 0,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "monitoraggio risorse memoria rss latenza",
+      "retrieved_relations": [
+        "pages/monitoraggio_risorse.md",
+        "pages/contratti_energia.md",
+        "pages/orchestrazione_k8s.md"
+      ],
+      "seed": 20260819
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "vecchio manifesto regole obsolete",
+      "retrieved_relations": [
+        "pages/vecchio_manifesto.md",
+        "pages/documento_riconosciuto.md"
+      ],
+      "seed": 20260820
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": false,
+        "contradiction_hits": 1,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "recall_at_k": 1.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": true
+      },
+      "query": "documento riconosciuto regole operative",
+      "retrieved_relations": [
+        "pages/documento_riconosciuto.md",
+        "pages/vecchio_manifesto.md"
+      ],
+      "seed": 20260821
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": true,
+        "contradiction_hits": 1,
+        "mrr": 0.0,
+        "ndcg": 0.0,
+        "recall_at_k": 0.0,
+        "stale_hits": 1,
+        "update_expected": false,
+        "update_predicted": false
+      },
+      "query": "ricerca vocale trascrive comandi",
+      "retrieved_relations": [
+        "pages/ricerca_vocale.md"
+      ],
+      "seed": 20260822
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": true,
+        "contradiction_hits": 1,
+        "mrr": 0.0,
+        "ndcg": 0.0,
+        "recall_at_k": 0.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": false
+      },
+      "query": "diario lavori personali",
+      "retrieved_relations": [
+        "pages/diario_lavoro.md"
+      ],
+      "seed": 20260823
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": false,
+        "abstention_expected": true,
+        "contradiction_hits": 0,
+        "mrr": 0.0,
+        "ndcg": 0.0,
+        "recall_at_k": 0.0,
+        "stale_hits": 2,
+        "update_expected": false,
+        "update_predicted": false
+      },
+      "query": "query senza riferimenti validi",
+      "retrieved_relations": [
+        "pages/vecchio_manifesto.md",
+        "pages/backup_locale.md",
+        "pages/query_plausibile.md"
+      ],
+      "seed": 20260824
+    },
+    {
+      "gold_classification": "superseded_gold",
+      "metrics": {
+        "abstained": true,
+        "abstention_expected": true,
+        "contradiction_hits": 0,
+        "mrr": 0.0,
+        "ndcg": 0.0,
+        "recall_at_k": 0.0,
+        "stale_hits": 0,
+        "update_expected": false,
+        "update_predicted": false
+      },
+      "query": "espressione sconosciuta assolutamente",
+      "retrieved_relations": [],
+      "seed": 20260825
+    }
+  ],
+  "config": {
+    "capacities": [
+      512,
+      2048,
+      8192,
+      16384
+    ],
+    "documents": 128,
+    "multi_corpora": 4,
+    "repetitions": 3,
+    "requests": 20000,
+    "seed": 20260802,
+    "warmup": 512
+  },
+  "environment": {
+    "corpus_digest": "c1b7eef66bd60aa0caaea5a04bdfb3095d1ecd435a17db377b3e54d99e6cc1d7",
+    "machine": "arm64",
+    "manifest_schema_version": 2,
+    "os": "macOS-15.7.3-arm64-arm-64bit",
+    "python": "3.12.13",
+    "source_commit": "dcf45eb3764aa6857ce4310a7ec4b418ff4a5deb"
+  },
+  "evaluation_scope": {
+    "end_to_end_answer_evaluated": false,
+    "retrieval_only": true
+  },
+  "manifest": {
+    "digest": "c1b7eef66bd60aa0caaea5a04bdfb3095d1ecd435a17db377b3e54d99e6cc1d7",
+    "path": "tests/fixtures/bm25_hard_negative_manifest_v1.json",
+    "schema_version": 2
+  },
+  "manifest_dataset_id": "matryca-bm25-hard-negative-it-v1",
+  "manifest_schema_version": 2,
+  "measurements": {
+    "cache": {
+      "capacity": 8192,
+      "entries": 24,
+      "evictions": 0,
+      "hits": 0,
+      "invalidations": 0,
+      "misses": 24,
+      "result_row_capacity": 65536,
+      "result_rows": 44,
+      "uncached_scoring_max_ns": 16917,
+      "uncached_scoring_samples": 24,
+      "uncached_scoring_total_ns": 175874
+    },
+    "cache_hit_ratio": 0.0,
+    "context_estimate_tokens": 3072,
+    "context_token_estimator": "ceil(payload_estimate_bytes / 4)",
+    "estimated_model_cost_usd": 0.0,
+    "external_model_calls": 0,
+    "latency_us": {
+      "median": 10.167,
+      "p50": 10.167,
+      "p95": 19.109,
+      "p99": 26.764
+    },
+    "model_cost_applicability": "not_applicable",
+    "payload_estimate_bytes": 12288,
+    "peak_rss_bytes": 38780928,
+    "query_cache_row_budget": 65536,
+    "requests": 24,
+    "rss_end_bytes": 38780928,
+    "top_k": 8
+  },
+  "metrics": {
+    "abstention": {
+      "confusion": {
+        "false_negative": 3,
+        "false_positive": 0,
+        "true_negative": 20,
+        "true_positive": 1
+      },
+      "enabled_cases": 4,
+      "passed_cases": 1,
+      "precision": 1.0,
+      "rate": 0.25,
+      "recall": 0.25
+    },
+    "confidence_intervals": {
+      "mrr": {
+        "confidence_level": 0.95,
+        "high": 0.9167,
+        "low": 0.6042,
+        "samples": 1000
+      },
+      "ndcg": {
+        "confidence_level": 0.95,
+        "high": 0.9302,
+        "low": 0.6359,
+        "samples": 1000
+      },
+      "recall_at_k": {
+        "confidence_level": 0.95,
+        "high": 0.9583,
+        "low": 0.6667,
+        "samples": 1000
+      }
+    },
+    "contradiction": {
+      "hits": 9,
+      "query_rate": 0.375,
+      "rate_per_query_position": 0.046875
+    },
+    "mrr": 0.7708,
+    "ndcg": 0.7898,
+    "recall_at_k": 0.8333,
+    "stale": {
+      "hits": 10,
+      "query_rate": 0.333333,
+      "rate_per_query_position": 0.052083
+    },
+    "update": {
+      "accuracy": 1.0,
+      "by_class": {
+        "superseded_gold": {
+          "cases": 22
+        },
+        "update_gold": {
+          "accuracy": 1.0,
+          "cases": 2,
+          "confusion": {
+            "false_negative": 0,
+            "false_positive": 0,
+            "true_negative": 0,
+            "true_positive": 2
+          }
+        }
+      },
+      "cases": 2,
+      "confusion": {
+        "false_negative": 0,
+        "false_positive": 0,
+        "true_negative": 0,
+        "true_positive": 2
+      }
+    }
+  },
+  "scorecard_fingerprint": "072d0f912f3aa47e3dbd53f4a46b023e16ea56030d4de29111caefa080683502",
+  "signal_ablations": {
+    "no_retrieval": {
+      "abstention": {
+        "confusion": {
+          "false_negative": 0,
+          "false_positive": 0,
+          "true_negative": 20,
+          "true_positive": 4
+        },
+        "enabled_cases": 4,
+        "passed_cases": 4,
+        "precision": 1.0,
+        "rate": 1.0,
+        "recall": 1.0
+      },
+      "confidence_intervals": {
+        "mrr": {
+          "confidence_level": 0.95,
+          "high": 0.0,
+          "low": 0.0,
+          "samples": 1000
+        },
+        "ndcg": {
+          "confidence_level": 0.95,
+          "high": 0.0,
+          "low": 0.0,
+          "samples": 1000
+        },
+        "recall_at_k": {
+          "confidence_level": 0.95,
+          "high": 0.0,
+          "low": 0.0,
+          "samples": 1000
+        }
+      },
+      "contradiction": {
+        "hits": 0,
+        "query_rate": 0.0,
+        "rate_per_query_position": 0.0
+      },
+      "mrr": 0.0,
+      "ndcg": 0.0,
+      "recall_at_k": 0.0,
+      "stale": {
+        "hits": 0,
+        "query_rate": 0.0,
+        "rate_per_query_position": 0.0
+      },
+      "update": {
+        "accuracy": 0.0,
+        "by_class": {
+          "superseded_gold": {
+            "cases": 22
+          },
+          "update_gold": {
+            "accuracy": 0.0,
+            "cases": 2,
+            "confusion": {
+              "false_negative": 2,
+              "false_positive": 0,
+              "true_negative": 0,
+              "true_positive": 0
+            }
+          }
+        },
+        "cases": 2,
+        "confusion": {
+          "false_negative": 2,
+          "false_positive": 0,
+          "true_negative": 0,
+          "true_positive": 0
+        }
+      }
+    }
+  }
+}

--- a/docs/knowledge/architecture/bm25-query-cache-capacity.md
+++ b/docs/knowledge/architecture/bm25-query-cache-capacity.md
@@ -111,6 +111,24 @@ It intentionally does not report end-to-end answer quality: that belongs to the
 separate adapter layer, where answer model, judge, prompt, token budget, and
 failure policy can be pinned rather than conflated with retrieval quality.
 
+### Retained baseline result
+
+[`bm25_query_cache_scorecard_macos_arm64_2026-08-10.json`](../../../benchmarks/results/bm25_query_cache_scorecard_macos_arm64_2026-08-10.json)
+is the first retained execution of this profile. It binds the 24-case synthetic
+manifest digest `c1b7eef66bd60aa0caaea5a04bdfb3095d1ecd435a17db377b3e54d99e6cc1d7`
+to source commit `dcf45eb3764aa6857ce4310a7ec4b418ff4a5deb` on macOS arm64,
+Python 3.12.13. Its deterministic retrieval fingerprint is
+`072d0f912f3aa47e3dbd53f4a46b023e16ea56030d4de29111caefa080683502`.
+
+The run reports Recall@8 `0.8333`, MRR `0.7708`, and nDCG `0.7898`; each has a
+deterministic 1,000-sample percentile-bootstrap interval in the retained JSON.
+Its no-retrieval ablation scores zero on those ranking metrics. Latency and RSS
+are diagnostic measurements from this one process and machine, not portable
+performance claims. The committed regression test re-executes only the
+deterministic scoring path and requires matching case results, metrics,
+ablation, manifest digest, and fingerprint. It deliberately does not compare
+host-dependent timing or RSS.
+
 ## Cross-system evidence contract
 
 `src.memory.benchmark_protocol` provides a closed, provider-free contract for

--- a/tests/test_bm25_query_cache_benchmark.py
+++ b/tests/test_bm25_query_cache_benchmark.py
@@ -231,6 +231,34 @@ def test_scorecard_manifest_validates_and_is_deterministic() -> None:
     assert first_digest == second_digest
 
 
+def test_committed_scorecard_result_retains_reproducible_retrieval_evidence() -> None:
+    manifest_path = Path("tests/fixtures/bm25_hard_negative_manifest_v1.json")
+    result_path = Path("benchmarks/results/bm25_query_cache_scorecard_macos_arm64_2026-08-10.json")
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    manifest, manifest_digest = benchmark._read_manifest(manifest_path)
+    rerun = benchmark._run_scorecard_benchmark(manifest, top_k=8)
+
+    assert payload["benchmark_schema_version"] == 3
+    assert payload["case_count"] == 24
+    assert payload["manifest_dataset_id"] == "matryca-bm25-hard-negative-it-v1"
+    assert payload["manifest"] == {
+        "digest": manifest_digest,
+        "path": "tests/fixtures/bm25_hard_negative_manifest_v1.json",
+        "schema_version": 2,
+    }
+    assert payload["environment"]["corpus_digest"] == manifest_digest
+    assert payload["environment"]["source_commit"] == "dcf45eb3764aa6857ce4310a7ec4b418ff4a5deb"
+    assert payload["evaluation_scope"] == {
+        "end_to_end_answer_evaluated": False,
+        "retrieval_only": True,
+    }
+    assert payload["scorecard_fingerprint"] == rerun["scorecard_fingerprint"]
+    assert payload["case_results"] == rerun["case_results"]
+    assert payload["metrics"] == rerun["metrics"]
+    assert payload["signal_ablations"] == rerun["signal_ablations"]
+    assert "/Users/" not in result_path.read_text(encoding="utf-8")
+
+
 def test_scorecard_main_writes_schema_and_environment_signature(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- retain the first manifest-bound synthetic Italian hard-negative retrieval scorecard result
- verify its deterministic evidence separately from host-dependent latency and RSS diagnostics
- document provenance, scope, and reproducibility limits

## Validation

- pytest -p no:cacheprovider --no-cov tests/test_bm25_query_cache_benchmark.py tests/test_evidence_coordination.py tests/test_benchmark_protocol.py tests/test_benchmark_cohort.py
- ruff check --no-cache tests/test_bm25_query_cache_benchmark.py
- ruff format --check tests/test_bm25_query_cache_benchmark.py
- python scripts/docs_knowledge_check.py check-bundle
- python scripts/check_agents_coherence.py

Refs #448