### PR TITLE
feat(benchmark): bind public suite input provenance (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Public-suite local-input provenance (#448)** — require LoCoMo and LongMemEval callers to bind exact repository/revision/license metadata and a raw-input SHA-256 before parsing; persist that digest in immutable datasets and comparative manifests so mismatched public inputs fail closed without downloading data or executing systems.
 - **Retained synthetic retrieval scorecard evidence (#448)** — commit the first manifest-bound, retrieval-only Italian hard-negative result with its deterministic fingerprint, bootstrap intervals, signal ablation, source revision, and a regression check that separates reproducible retrieval evidence from host-dependent latency and RSS diagnostics.
 - **Governed comparative cohort receipts (#448)** — assemble deterministic, privacy-safe evidence receipts only when an exact public corpus and every required opaque result artifact have matching retained attestations across the required Matryca and open-system controls; no benchmark execution, provider call, vault access, raw-content retention, or result write.
 - **Local LongMemEval-V2 input provenance adapter (#448)** — validate caller-supplied question, trajectory, and mapping JSONL with explicit license/revision provenance and immutable input-only digests; no downloads, inference, vault access, scoring, or result writes.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -64,6 +64,16 @@ dataset license identifier and exact Hugging Face revision, returning immutable
 input/provenance evidence rather than a benchmark score. It performs no download,
 screenshot or media resolution, model or vault access, result write, or remote call.
 
+The LoCoMo and LongMemEval local loaders use the same closed public-suite input
+provenance boundary. Before parsing a local file, a caller must supply a `DatasetPin`
+(suite, repository slug, exact revision, and license identifier) plus the expected
+SHA-256 of its raw bytes. A suite mismatch or byte mismatch fails closed. The verified
+input digest is retained in the returned immutable dataset and must be copied into
+each `BenchmarkRunManifest`; comparative cohorts reject a different input digest as
+non-comparable. This proves only local-input provenance. It neither establishes an
+upstream license nor executes a suite, downloads data, invokes a model, reads a vault,
+or writes results.
+
 The comparative cohort receipt is likewise provider-free and content-free. It binds a
 validated four-system control cohort to one retained public-corpus digest and exact
 opaque-artifact attestations. It rejects missing, duplicate, mismatched, mixed-policy,

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -40,6 +40,7 @@ from .longmemeval_v2_adapter import (
     LongMemEvalV2Turn,
     load_longmemeval_v2_input,
 )
+from .public_suite_provenance import PublicSuiteInputProvenance
 from .recall import RecallBundle, recall_from_existing_retrieval
 
 __all__ = [
@@ -72,6 +73,7 @@ __all__ = [
     "memory_graph_enabled",
     "RecallBundle",
     "P0EvidencePacket",
+    "PublicSuiteInputProvenance",
     "recall_from_existing_retrieval",
     "load_locomo_retrieval_cases",
     "load_longmemeval_retrieval_cases",

--- a/src/memory/benchmark_protocol.py
+++ b/src/memory/benchmark_protocol.py
@@ -222,6 +222,7 @@ class BenchmarkRunManifest(_ClosedModel):
     schema_version: str = BENCHMARK_PROTOCOL_SCHEMA_VERSION
     cohort_id: str
     dataset: DatasetPin
+    input_provenance_digest: str
     evaluation_layer: EvaluationLayer
     system: SystemPin
     answer_model: ModelPin | None
@@ -235,6 +236,11 @@ class BenchmarkRunManifest(_ClosedModel):
         if self.schema_version != BENCHMARK_PROTOCOL_SCHEMA_VERSION:
             raise EvidenceContractError("unsupported_benchmark_protocol_schema")
         object.__setattr__(self, "cohort_id", _identifier(self.cohort_id, field="cohort_id"))
+        object.__setattr__(
+            self,
+            "input_provenance_digest",
+            _sha256(self.input_provenance_digest, field="input_provenance_digest"),
+        )
         if self.evaluation_layer == "retrieval":
             if self.answer_model is not None or self.judge_model is not None:
                 raise EvidenceContractError("retrieval_run_cannot_pin_answer_or_judge")
@@ -306,6 +312,7 @@ def validate_comparative_cohort(reports: tuple[BenchmarkRunReport, ...]) -> str:
     reference = manifests[0]
     comparison_key = (
         reference.dataset,
+        reference.input_provenance_digest,
         reference.answer_model,
         reference.judge_model,
         reference.budget,
@@ -314,6 +321,7 @@ def validate_comparative_cohort(reports: tuple[BenchmarkRunReport, ...]) -> str:
     if any(
         (
             manifest.dataset,
+            manifest.input_provenance_digest,
             manifest.answer_model,
             manifest.judge_model,
             manifest.budget,

--- a/src/memory/locomo_adapter.py
+++ b/src/memory/locomo_adapter.py
@@ -9,7 +9,6 @@ opaque artifact boundary rather than serializing this adapter's values.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import re
 from collections.abc import Mapping, Sequence
@@ -19,6 +18,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from .evidence_models import EvidenceContractError
+from .public_suite_provenance import PublicSuiteInputProvenance, verify_public_suite_input
 
 _SESSION_KEY = re.compile(r"^session_(?P<index>[1-9][0-9]*)$")
 
@@ -53,10 +53,13 @@ class LocomoDataset(_ClosedModel):
     """A deterministic, locally loaded LoCoMo retrieval-evaluation dataset."""
 
     source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provenance: PublicSuiteInputProvenance
     cases: tuple[LocomoRetrievalCase, ...] = Field(min_length=1)
 
 
-def load_locomo_retrieval_cases(path: Path) -> LocomoDataset:
+def load_locomo_retrieval_cases(
+    path: Path, *, provenance: PublicSuiteInputProvenance
+) -> LocomoDataset:
     """Load documented LoCoMo conversations and QA evidence from one local file.
 
     Unknown upstream fields, including optional image metadata, are deliberately
@@ -67,6 +70,7 @@ def load_locomo_retrieval_cases(path: Path) -> LocomoDataset:
         raw_bytes = path.read_bytes()
     except OSError as exc:
         raise EvidenceContractError("locomo_dataset_unreadable") from exc
+    source_digest = verify_public_suite_input(provenance, raw_bytes, expected_suite="locomo")
     try:
         raw: Any = json.loads(raw_bytes)
     except json.JSONDecodeError as exc:
@@ -117,7 +121,8 @@ def load_locomo_retrieval_cases(path: Path) -> LocomoDataset:
         if sample_index >= 10_000:
             raise EvidenceContractError("locomo_dataset_too_many_samples")
     return LocomoDataset(
-        source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+        source_digest=source_digest,
+        provenance=provenance,
         cases=tuple(cases),
     )
 

--- a/src/memory/longmemeval_adapter.py
+++ b/src/memory/longmemeval_adapter.py
@@ -6,7 +6,6 @@ the returned Pydantic models remain frozen and closed contracts.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from collections.abc import Mapping
 from pathlib import Path
@@ -15,6 +14,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from .evidence_models import EvidenceContractError
+from .public_suite_provenance import PublicSuiteInputProvenance, verify_public_suite_input
 
 _MAX_CASES = 10_000
 _MAX_SESSIONS = 10_000
@@ -65,15 +65,19 @@ class LongMemEvalDataset(_ClosedModel):
     """A locally loaded, digest-pinned LongMemEval dataset."""
 
     source_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    provenance: PublicSuiteInputProvenance
     cases: tuple[LongMemEvalRetrievalCase, ...] = Field(min_length=1)
 
 
-def load_longmemeval_retrieval_cases(path: Path) -> LongMemEvalDataset:
+def load_longmemeval_retrieval_cases(
+    path: Path, *, provenance: PublicSuiteInputProvenance
+) -> LongMemEvalDataset:
     """Load one acquired cleaned/oracle LongMemEval JSON file without side effects."""
     try:
         raw_bytes = path.read_bytes()
     except OSError as exc:
         raise EvidenceContractError("longmemeval_dataset_unreadable") from exc
+    source_digest = verify_public_suite_input(provenance, raw_bytes, expected_suite="longmemeval")
     try:
         raw: Any = json.loads(raw_bytes, object_pairs_hook=_no_duplicate_json_keys)
     except (_DuplicateJsonKeyError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -98,7 +102,8 @@ def load_longmemeval_retrieval_cases(path: Path) -> LongMemEvalDataset:
         cases.append(case)
     try:
         return LongMemEvalDataset(
-            source_digest=hashlib.sha256(raw_bytes).hexdigest(),
+            source_digest=source_digest,
+            provenance=provenance,
             cases=tuple(cases),
         )
     except ValidationError as exc:

--- a/src/memory/public_suite_provenance.py
+++ b/src/memory/public_suite_provenance.py
@@ -1,0 +1,43 @@
+"""Closed provenance binding for caller-supplied public benchmark inputs."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .benchmark_protocol import DatasetPin, SuiteName
+from .evidence_models import EvidenceContractError
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class PublicSuiteInputProvenance(BaseModel):
+    """Pinned public-suite identity and expected digest for one local input."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    dataset: DatasetPin
+    raw_input_digest: str = Field(pattern=_SHA256.pattern)
+    evidence_kind: Literal["local_input_provenance_only"]
+
+
+def verify_public_suite_input(
+    provenance: PublicSuiteInputProvenance,
+    raw_bytes: bytes,
+    *,
+    expected_suite: SuiteName,
+) -> str:
+    """Fail closed unless supplied bytes match the declared public-suite pin."""
+
+    if provenance.dataset.suite != expected_suite:
+        raise EvidenceContractError("public_suite_provenance_suite_mismatch")
+    digest = hashlib.sha256(raw_bytes).hexdigest()
+    if digest != provenance.raw_input_digest:
+        raise EvidenceContractError("public_suite_input_digest_mismatch")
+    return digest
+
+
+__all__ = ["PublicSuiteInputProvenance", "verify_public_suite_input"]

--- a/tests/test_benchmark_cohort.py
+++ b/tests/test_benchmark_cohort.py
@@ -65,6 +65,7 @@ def _report(role: SystemRole, system_id: str) -> BenchmarkRunReport:
         manifest=BenchmarkRunManifest(
             cohort_id="locomo-retrieval-baseline-v1",
             dataset=_dataset(),
+            input_provenance_digest=_DIGEST_C,
             evaluation_layer="retrieval",
             system=SystemPin(
                 role=role,

--- a/tests/test_benchmark_protocol.py
+++ b/tests/test_benchmark_protocol.py
@@ -65,6 +65,7 @@ def _manifest(
             dataset_revision=_C,
             license_id="CC-BY-4.0",
         ),
+        input_provenance_digest=_DIGEST_E,
         evaluation_layer=layer,
         system=SystemPin(
             role=role,
@@ -212,6 +213,21 @@ def test_comparative_cohort_rejects_context_or_layer_mismatch() -> None:
         artifacts=reports[-1].artifacts,
     )
 
+    with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
+        validate_comparative_cohort(tuple(reports))
+
+    reports[-1] = BenchmarkRunReport(
+        manifest=BenchmarkRunManifest.model_validate(
+            {
+                **reports[-1].manifest.model_dump(),
+                "budget": reports[0].manifest.budget.model_dump(),
+                "runtime": reports[0].manifest.runtime.model_dump(),
+                "input_provenance_digest": _DIGEST_D,
+            }
+        ),
+        status=reports[-1].status,
+        artifacts=reports[-1].artifacts,
+    )
     with pytest.raises(EvidenceContractError, match="comparative_cohort_context_mismatch"):
         validate_comparative_cohort(tuple(reports))
 

--- a/tests/test_locomo_adapter.py
+++ b/tests/test_locomo_adapter.py
@@ -8,8 +8,10 @@ import socket
 from pathlib import Path
 
 import pytest
+from src.memory.benchmark_protocol import DatasetPin
 from src.memory.evidence_models import EvidenceContractError
-from src.memory.locomo_adapter import load_locomo_retrieval_cases
+from src.memory.locomo_adapter import LocomoDataset, load_locomo_retrieval_cases
+from src.memory.public_suite_provenance import PublicSuiteInputProvenance
 
 
 def _dataset() -> list[object]:
@@ -56,12 +58,30 @@ def _write_dataset(tmp_path: Path, payload: object | None = None) -> Path:
     return path
 
 
+def _provenance(path: Path) -> PublicSuiteInputProvenance:
+    return PublicSuiteInputProvenance(
+        dataset=DatasetPin(
+            suite="locomo",
+            dataset_id="locomo-v1",
+            repository_slug="snap-research/locomo",
+            dataset_revision="a" * 40,
+            license_id="CC-BY-4.0",
+        ),
+        raw_input_digest=hashlib.sha256(path.read_bytes()).hexdigest(),
+        evidence_kind="local_input_provenance_only",
+    )
+
+
+def _load(path: Path) -> LocomoDataset:
+    return load_locomo_retrieval_cases(path, provenance=_provenance(path))
+
+
 def test_adapter_normalizes_sessions_evidence_and_abstention_deterministically(
     tmp_path: Path,
 ) -> None:
     path = _write_dataset(tmp_path)
 
-    dataset = load_locomo_retrieval_cases(path)
+    dataset = _load(path)
 
     assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
     assert [case.case_id for case in dataset.cases] == ["locomo-sample-1:1", "locomo-sample-1:2"]
@@ -87,7 +107,7 @@ def test_adapter_never_opens_network_or_follows_optional_image_metadata(
     monkeypatch.setattr(socket, "create_connection", reject_network)
     monkeypatch.setattr(socket, "gethostbyname", reject_network)
 
-    assert len(load_locomo_retrieval_cases(path).cases) == 2
+    assert len(_load(path).cases) == 2
 
 
 @pytest.mark.parametrize(
@@ -125,4 +145,21 @@ def test_adapter_fails_closed_for_malformed_required_evidence(
     error: str,
 ) -> None:
     with pytest.raises(EvidenceContractError, match=error):
-        load_locomo_retrieval_cases(_write_dataset(tmp_path, payload))
+        _load(_write_dataset(tmp_path, payload))
+
+
+def test_adapter_rejects_wrong_suite_or_digest(tmp_path: Path) -> None:
+    path = _write_dataset(tmp_path)
+    provenance = _provenance(path)
+    with pytest.raises(EvidenceContractError, match="public_suite_input_digest_mismatch"):
+        load_locomo_retrieval_cases(
+            path,
+            provenance=provenance.model_copy(update={"raw_input_digest": "b" * 64}),
+        )
+    with pytest.raises(EvidenceContractError, match="public_suite_provenance_suite_mismatch"):
+        load_locomo_retrieval_cases(
+            path,
+            provenance=provenance.model_copy(
+                update={"dataset": provenance.dataset.model_copy(update={"suite": "longmemeval"})}
+            ),
+        )

--- a/tests/test_longmemeval_adapter.py
+++ b/tests/test_longmemeval_adapter.py
@@ -8,8 +8,10 @@ import socket
 from pathlib import Path
 
 import pytest
+from src.memory.benchmark_protocol import DatasetPin
 from src.memory.evidence_models import EvidenceContractError
-from src.memory.longmemeval_adapter import load_longmemeval_retrieval_cases
+from src.memory.longmemeval_adapter import LongMemEvalDataset, load_longmemeval_retrieval_cases
+from src.memory.public_suite_provenance import PublicSuiteInputProvenance
 
 
 def _case(*, question_id: str = "q-1") -> dict[str, object]:
@@ -41,11 +43,29 @@ def _write_dataset(tmp_path: Path, payload: object) -> Path:
     return path
 
 
+def _provenance(path: Path, *, digest: str | None = None) -> PublicSuiteInputProvenance:
+    return PublicSuiteInputProvenance(
+        dataset=DatasetPin(
+            suite="longmemeval",
+            dataset_id="longmemeval-v1",
+            repository_slug="xiaowu0162/longmemeval",
+            dataset_revision="b" * 40,
+            license_id="MIT",
+        ),
+        raw_input_digest=digest or hashlib.sha256(path.read_bytes()).hexdigest(),
+        evidence_kind="local_input_provenance_only",
+    )
+
+
+def _load(path: Path) -> LongMemEvalDataset:
+    return load_longmemeval_retrieval_cases(path, provenance=_provenance(path))
+
+
 def test_normalizes_digest_evidence_and_preserves_upstream_order(tmp_path: Path) -> None:
     payload = [_case()]
     path = _write_dataset(tmp_path, payload)
 
-    dataset = load_longmemeval_retrieval_cases(path)
+    dataset = _load(path)
     case = dataset.cases[0]
 
     assert dataset.source_digest == hashlib.sha256(path.read_bytes()).hexdigest()
@@ -65,8 +85,8 @@ def test_digest_is_stable_and_abs_is_metadata_not_inferred_evidence(tmp_path: Pa
     payload = [_case(question_id="q-2_abs")]
     path = _write_dataset(tmp_path, payload)
 
-    first = load_longmemeval_retrieval_cases(path)
-    second = load_longmemeval_retrieval_cases(path)
+    first = _load(path)
+    second = _load(path)
 
     assert first == second
     assert first.cases[0].is_abstention is True
@@ -76,7 +96,7 @@ def test_digest_is_stable_and_abs_is_metadata_not_inferred_evidence(tmp_path: Pa
         tmp_path,
         [{**_case(question_id="q-3_abs"), "answer_session_ids": []}],
     )
-    abstention = load_longmemeval_retrieval_cases(abstention_path).cases[0]
+    abstention = _load(abstention_path).cases[0]
     assert abstention.is_abstention is True
     assert abstention.evidence_session_ids == ()
     assert abstention.evidence_turn_ids == ("session-a:turn-1",)
@@ -89,7 +109,7 @@ def test_preserves_multiple_evidence_and_oracle_style_nonchronological_order(
     payload["haystack_dates"] = ["2024-12-31", "2023-01-01"]
     payload["answer_session_ids"] = ["session-a", "session-z"]
 
-    case = load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload])).cases[0]
+    case = _load(_write_dataset(tmp_path, [payload])).cases[0]
 
     assert [session.session_id for session in case.sessions] == ["session-z", "session-a"]
     assert [session.date for session in case.sessions] == ["2024-12-31", "2023-01-01"]
@@ -124,45 +144,48 @@ def test_invalid_required_values_and_references_fail_closed(
     payload.update(change)
 
     with pytest.raises(EvidenceContractError, match=f"^{error}$"):
-        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+        _load(_write_dataset(tmp_path, [payload]))
 
 
 def test_duplicate_question_ids_fail_closed(tmp_path: Path) -> None:
     with pytest.raises(EvidenceContractError, match="^longmemeval_case_id_duplicate$"):
-        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case(), _case()]))
+        _load(_write_dataset(tmp_path, [_case(), _case()]))
 
 
 @pytest.mark.parametrize("payload", [[], {}, {"question_id": "q"}, ["not-a-case"]])
 def test_invalid_top_level_shape_fails_closed(tmp_path: Path, payload: object) -> None:
     with pytest.raises(EvidenceContractError):
-        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, payload))
+        _load(_write_dataset(tmp_path, payload))
 
 
 def test_invalid_json_and_unreadable_file_fail_closed(tmp_path: Path) -> None:
     invalid = tmp_path / "invalid.json"
     invalid.write_bytes(b"not-json")
     with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
-        load_longmemeval_retrieval_cases(invalid)
+        _load(invalid)
 
     with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_unreadable$"):
-        load_longmemeval_retrieval_cases(tmp_path / "missing.json")
+        load_longmemeval_retrieval_cases(
+            tmp_path / "missing.json",
+            provenance=_provenance(tmp_path / "missing.json", digest="a" * 64),
+        )
 
 
 def test_duplicate_json_key_and_oversized_model_field_fail_closed(tmp_path: Path) -> None:
     duplicate = tmp_path / "duplicate.json"
     duplicate.write_bytes(b'[{"question_id":"q-1","question_id":"q-2"}]')
     with pytest.raises(EvidenceContractError, match="^longmemeval_dataset_invalid_json$"):
-        load_longmemeval_retrieval_cases(duplicate)
+        _load(duplicate)
 
     payload = _case()
     payload["question_id"] = "q" * 513
     with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
-        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+        _load(_write_dataset(tmp_path, [payload]))
 
     payload = _case()
     payload["haystack_session_ids"] = ["s" * 513, "session-a"]
     with pytest.raises(EvidenceContractError, match="^longmemeval_case_invalid$"):
-        load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [payload]))
+        _load(_write_dataset(tmp_path, [payload]))
 
 
 def test_adapter_makes_no_network_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -171,4 +194,21 @@ def test_adapter_makes_no_network_calls(tmp_path: Path, monkeypatch: pytest.Monk
 
     monkeypatch.setattr(socket, "create_connection", fail)
     monkeypatch.setattr(socket, "socket", fail)
-    load_longmemeval_retrieval_cases(_write_dataset(tmp_path, [_case()]))
+    _load(_write_dataset(tmp_path, [_case()]))
+
+
+def test_adapter_rejects_wrong_suite_or_digest(tmp_path: Path) -> None:
+    path = _write_dataset(tmp_path, [_case()])
+    provenance = _provenance(path)
+    with pytest.raises(EvidenceContractError, match="public_suite_input_digest_mismatch"):
+        load_longmemeval_retrieval_cases(
+            path,
+            provenance=provenance.model_copy(update={"raw_input_digest": "c" * 64}),
+        )
+    with pytest.raises(EvidenceContractError, match="public_suite_provenance_suite_mismatch"):
+        load_longmemeval_retrieval_cases(
+            path,
+            provenance=provenance.model_copy(
+                update={"dataset": provenance.dataset.model_copy(update={"suite": "locomo"})}
+            ),
+        )

--- a/tests/test_public_suite_provenance.py
+++ b/tests/test_public_suite_provenance.py
@@ -1,0 +1,46 @@
+"""Tests for closed public-suite local-input provenance."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from pydantic import ValidationError
+from src.memory.benchmark_protocol import DatasetPin
+from src.memory.evidence_models import EvidenceContractError
+from src.memory.public_suite_provenance import (
+    PublicSuiteInputProvenance,
+    verify_public_suite_input,
+)
+
+
+def _provenance(raw: bytes = b"public fixture") -> PublicSuiteInputProvenance:
+    return PublicSuiteInputProvenance(
+        dataset=DatasetPin(
+            suite="locomo",
+            dataset_id="locomo-v1",
+            repository_slug="snap-research/locomo",
+            dataset_revision="a" * 40,
+            license_id="CC-BY-4.0",
+        ),
+        raw_input_digest=hashlib.sha256(raw).hexdigest(),
+        evidence_kind="local_input_provenance_only",
+    )
+
+
+def test_provenance_is_closed_immutable_and_binds_exact_bytes() -> None:
+    raw = b"public fixture"
+    provenance = _provenance(raw)
+
+    assert (
+        verify_public_suite_input(provenance, raw, expected_suite="locomo")
+        == hashlib.sha256(raw).hexdigest()
+    )
+    with pytest.raises(ValidationError):
+        provenance.raw_input_digest = "a" * 64
+    with pytest.raises(ValueError):
+        PublicSuiteInputProvenance.model_validate({**provenance.model_dump(), "path": "/unsafe"})
+    with pytest.raises(EvidenceContractError, match="public_suite_input_digest_mismatch"):
+        verify_public_suite_input(provenance, b"different", expected_suite="locomo")
+    with pytest.raises(EvidenceContractError, match="public_suite_provenance_suite_mismatch"):
+        verify_public_suite_input(provenance, raw, expected_suite="longmemeval")


### PR DESCRIPTION
## Summary

- require LoCoMo and LongMemEval local inputs to provide exact suite/repository/revision/license metadata and a raw-input SHA-256
- bind the verified input digest into immutable adapter output and the comparative benchmark manifest
- reject suite or byte mismatches before parsing, without downloads, models, vault access, or result writes

## Validation

- pytest -p no:cacheprovider --no-cov tests/test_public_suite_provenance.py tests/test_locomo_adapter.py tests/test_longmemeval_adapter.py tests/test_longmemeval_v2_adapter.py tests/test_benchmark_protocol.py tests/test_benchmark_cohort.py tests/test_evidence_coordination.py
- ruff check and format checks on changed source and tests
- mypy on changed memory modules
- python scripts/docs_knowledge_check.py check-bundle
- python scripts/check_agents_coherence.py

Refs #448