### PR TITLE
feat(benchmark): add local BEAM input adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- **Local BEAM input provenance adapter (#448)** — normalize caller-supplied BEAM chat and probing-question JSON into immutable, digest-bound input evidence with an exact public dataset pin; no downloads, inference, vault access, scoring, or result writes.
 - **Public-suite local-input provenance (#448)** — require LoCoMo and LongMemEval callers to bind exact repository/revision/license metadata and a raw-input SHA-256 before parsing; persist that digest in immutable datasets and comparative manifests so mismatched public inputs fail closed without downloading data or executing systems.
 - **Retained synthetic retrieval scorecard evidence (#448)** — commit the first manifest-bound, retrieval-only Italian hard-negative result with its deterministic fingerprint, bootstrap intervals, signal ablation, source revision, and a regression check that separates reproducible retrieval evidence from host-dependent latency and RSS diagnostics.
 - **Governed comparative cohort receipts (#448)** — assemble deterministic, privacy-safe evidence receipts only when an exact public corpus and every required opaque result artifact have matching retained attestations across the required Matryca and open-system controls; no benchmark execution, provider call, vault access, raw-content retention, or result write.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -74,6 +74,12 @@ non-comparable. This proves only local-input provenance. It neither establishes 
 upstream license nor executes a suite, downloads data, invokes a model, reads a vault,
 or writes results.
 
+The BEAM adapter applies the same local-only policy to one caller-supplied `chat.json`
+and its colocated `probing_questions.json`. The caller binds the official repository,
+exact revision, CC-BY-SA-4.0 data license, chat identifier, and both raw-byte digests.
+It emits immutable input/provenance evidence only; it does not download data, resolve
+an answer, invoke a model, access a vault, score a run, or write results.
+
 The comparative cohort receipt is likewise provider-free and content-free. It binds a
 validated four-system control cohort to one retained public-corpus digest and exact
 opaque-artifact attestations. It rejects missing, duplicate, mismatched, mixed-policy,
@@ -129,7 +135,7 @@ When publicly exposed, document in `.env.example` under **Advanced / high impact
   do not download, call models, access the vault, or persist results. LongMemEval's
   session-level answer references and optional answer-marked turns remain separate, and
   `_abs` IDs are metadata rather than inferred retrieval outcomes. Unknown upstream input
-  fields are deliberately ignored for forward compatibility; emitted evaluation contracts
+fields are deliberately ignored for forward compatibility; emitted evaluation contracts
   remain closed and frozen.
 
 ## P0 canonical recall

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,5 +1,13 @@
 """Biological memory graph layer (Nacre-inspired, Epic #99)."""
 
+from .beam_adapter import (
+    BeamConversation,
+    BeamInputEvidence,
+    BeamProvenance,
+    BeamQuestion,
+    BeamTurn,
+    load_beam_input,
+)
 from .benchmark_cohort import (
     ComparativeCohortReceipt,
     CorpusRetentionAttestation,
@@ -61,6 +69,11 @@ __all__ = [
     "LongMemEvalV2Turn",
     "BenchmarkRunManifest",
     "BenchmarkRunReport",
+    "BeamConversation",
+    "BeamInputEvidence",
+    "BeamProvenance",
+    "BeamQuestion",
+    "BeamTurn",
     "ComparativeCohortReceipt",
     "CorpusRetentionAttestation",
     "RetainedArtifactAttestation",
@@ -76,6 +89,7 @@ __all__ = [
     "PublicSuiteInputProvenance",
     "recall_from_existing_retrieval",
     "load_locomo_retrieval_cases",
+    "load_beam_input",
     "load_longmemeval_retrieval_cases",
     "load_longmemeval_v2_input",
     "validate_comparative_cohort",

--- a/src/memory/beam_adapter.py
+++ b/src/memory/beam_adapter.py
@@ -1,0 +1,238 @@
+"""Local-only BEAM input and provenance adapter.
+
+This boundary accepts one already acquired ``chat.json`` and its colocated
+``probing_questions.json``.  It never downloads BEAM, invokes a model, reads a
+vault, scores answers, or persists results.  The caller supplies the stable
+chat identifier because BEAM encodes it in the directory layout, not the JSON.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .benchmark_protocol import DatasetPin
+from .evidence_models import EvidenceContractError
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_MAX_BATCHES = 10_000
+_MAX_TURNS = 100_000
+_MAX_QUESTIONS = 100_000
+_MAX_BYTES = 64 * 1024 * 1024
+
+
+class _DuplicateJsonKeyError(ValueError):
+    """Raised when JSON would otherwise silently overwrite a member."""
+
+
+class _ClosedModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class BeamTurn(_ClosedModel):
+    """One source-ordered BEAM conversation turn."""
+
+    role: Literal["user", "assistant"]
+    turn_id: str = Field(min_length=1, max_length=512)
+    content: str = Field(min_length=1, max_length=65_536)
+
+
+class BeamConversation(_ClosedModel):
+    """One caller-named BEAM chat, retaining source order only."""
+
+    chat_id: str = Field(min_length=1, max_length=512)
+    turns: tuple[BeamTurn, ...] = Field(min_length=1, max_length=_MAX_TURNS)
+
+
+class BeamQuestion(_ClosedModel):
+    """One retrieval question linked to its colocated chat by ``chat_id``."""
+
+    question_id: str = Field(min_length=1, max_length=1_024)
+    chat_id: str = Field(min_length=1, max_length=512)
+    category: str = Field(min_length=1, max_length=512)
+    question: str = Field(min_length=1, max_length=65_536)
+
+
+class BeamProvenance(_ClosedModel):
+    """Exact public-source and raw-byte binding for one BEAM local bundle."""
+
+    dataset: DatasetPin
+    chat_input_digest: str = Field(pattern=_SHA256.pattern)
+    questions_input_digest: str = Field(pattern=_SHA256.pattern)
+    source_envelope_digest: str = Field(pattern=_SHA256.pattern)
+    evidence_kind: Literal["local_input_provenance_only"]
+
+
+class BeamInputEvidence(_ClosedModel):
+    """Immutable local BEAM input evidence, never a benchmark result."""
+
+    provenance: BeamProvenance
+    conversation: BeamConversation
+    questions: tuple[BeamQuestion, ...] = Field(min_length=1, max_length=_MAX_QUESTIONS)
+
+
+def load_beam_input(
+    chat_path: Path,
+    questions_path: Path,
+    *,
+    chat_id: str,
+    dataset: DatasetPin,
+) -> BeamInputEvidence:
+    """Load one local BEAM chat/question bundle with fail-closed provenance."""
+    if dataset.suite != "beam":
+        raise EvidenceContractError("beam_dataset_suite_mismatch")
+    chat_id = _required_text(chat_id, "beam_chat_id_invalid")
+    chat_bytes = _read_input(chat_path, "chat")
+    questions_bytes = _read_input(questions_path, "questions")
+    batches = _load_json(chat_bytes, "chat")
+    questions_by_category = _load_json(questions_bytes, "questions")
+    turns = _parse_turns(batches)
+    questions = _parse_questions(questions_by_category, chat_id)
+    envelope = json.dumps(
+        {
+            "chat_id": chat_id,
+            "dataset": dataset.model_dump(mode="json"),
+            "chat_input_digest": hashlib.sha256(chat_bytes).hexdigest(),
+            "questions_input_digest": hashlib.sha256(questions_bytes).hexdigest(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    provenance = BeamProvenance(
+        dataset=dataset,
+        chat_input_digest=hashlib.sha256(chat_bytes).hexdigest(),
+        questions_input_digest=hashlib.sha256(questions_bytes).hexdigest(),
+        source_envelope_digest=hashlib.sha256(envelope).hexdigest(),
+        evidence_kind="local_input_provenance_only",
+    )
+    return BeamInputEvidence(
+        provenance=provenance,
+        conversation=BeamConversation(chat_id=chat_id, turns=tuple(turns)),
+        questions=tuple(questions),
+    )
+
+
+def _read_input(path: Path, label: str) -> bytes:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceContractError(f"beam_{label}_unreadable") from exc
+    if not raw.strip() or len(raw) > _MAX_BYTES:
+        raise EvidenceContractError(f"beam_{label}_invalid")
+    return raw
+
+
+def _load_json(raw: bytes, label: str) -> Any:
+    try:
+        return json.loads(
+            raw,
+            object_pairs_hook=_no_duplicate_json_keys,
+            parse_constant=_reject_non_finite,
+        )
+    except (
+        _DuplicateJsonKeyError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as exc:
+        raise EvidenceContractError(f"beam_{label}_invalid") from exc
+
+
+def _parse_turns(value: Any) -> list[BeamTurn]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise EvidenceContractError("beam_chat_invalid")
+    if len(value) > _MAX_BATCHES:
+        raise EvidenceContractError("beam_chat_invalid")
+    turns: list[BeamTurn] = []
+    turn_ids: set[str] = set()
+    for batch in value:
+        if not isinstance(batch, Mapping) or set(batch) != {"batch_number", "turns"}:
+            raise EvidenceContractError("beam_chat_invalid")
+        source_turns = batch["turns"]
+        if not isinstance(source_turns, Sequence) or isinstance(source_turns, (str, bytes)):
+            raise EvidenceContractError("beam_chat_invalid")
+        for source_turn in source_turns:
+            if not isinstance(source_turn, Mapping):
+                raise EvidenceContractError("beam_chat_invalid")
+            try:
+                turn = BeamTurn(
+                    role=source_turn["role"],
+                    turn_id=_required_text(source_turn["id"], "beam_turn_id_invalid"),
+                    content=_required_text(source_turn["content"], "beam_turn_content_invalid"),
+                )
+            except (KeyError, ValidationError, EvidenceContractError) as exc:
+                raise EvidenceContractError("beam_chat_invalid") from exc
+            if turn.turn_id in turn_ids:
+                raise EvidenceContractError("beam_turn_id_duplicate")
+            turn_ids.add(turn.turn_id)
+            turns.append(turn)
+            if len(turns) > _MAX_TURNS:
+                raise EvidenceContractError("beam_chat_invalid")
+    if not turns:
+        raise EvidenceContractError("beam_chat_invalid")
+    return turns
+
+
+def _parse_questions(value: Any, chat_id: str) -> list[BeamQuestion]:
+    if not isinstance(value, Mapping) or not value:
+        raise EvidenceContractError("beam_questions_invalid")
+    questions: list[BeamQuestion] = []
+    for category, entries in value.items():
+        category = _required_text(category, "beam_question_category_invalid")
+        if not isinstance(entries, Sequence) or isinstance(entries, (str, bytes)) or not entries:
+            raise EvidenceContractError("beam_questions_invalid")
+        for index, entry in enumerate(entries, start=1):
+            if not isinstance(entry, Mapping):
+                raise EvidenceContractError("beam_questions_invalid")
+            try:
+                question = _required_text(entry["question"], "beam_question_invalid")
+            except (KeyError, EvidenceContractError) as exc:
+                raise EvidenceContractError("beam_questions_invalid") from exc
+            questions.append(
+                BeamQuestion(
+                    question_id=f"{chat_id}:{category}:{index}",
+                    chat_id=chat_id,
+                    category=category,
+                    question=question,
+                )
+            )
+            if len(questions) > _MAX_QUESTIONS:
+                raise EvidenceContractError("beam_questions_invalid")
+    if not questions:
+        raise EvidenceContractError("beam_questions_invalid")
+    return questions
+
+
+def _required_text(value: Any, error: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceContractError(error)
+    return value
+
+
+def _no_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"unsupported JSON constant: {value}")
+
+
+__all__ = [
+    "BeamConversation",
+    "BeamInputEvidence",
+    "BeamProvenance",
+    "BeamQuestion",
+    "BeamTurn",
+    "load_beam_input",
+]

--- a/tests/test_beam_adapter.py
+++ b/tests/test_beam_adapter.py
@@ -1,0 +1,142 @@
+"""Tests for the local-only BEAM input adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from src.memory.beam_adapter import BeamInputEvidence, load_beam_input
+from src.memory.benchmark_protocol import DatasetPin
+from src.memory.evidence_models import EvidenceContractError
+
+_REVISION = "3e12035532eb85768f1a7cd779832b650c4b2ef9"
+
+
+def _dataset() -> DatasetPin:
+    return DatasetPin(
+        suite="beam",
+        dataset_id="beam-100k",
+        repository_slug="mohammadtavakoli78/BEAM",
+        dataset_revision=_REVISION,
+        license_id="CC-BY-SA-4.0",
+    )
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path]:
+    chat = tmp_path / "chat.json"
+    chat.write_text(
+        json.dumps(
+            [
+                {
+                    "batch_number": 1,
+                    "turns": [
+                        {"role": "user", "id": "1,1", "content": "First topic"},
+                        {"role": "assistant", "id": "1,2", "content": "Acknowledged"},
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    questions = tmp_path / "probing_questions.json"
+    questions.write_text(
+        json.dumps(
+            {
+                "information_extraction": [
+                    {"question": "What was the topic?", "ideal_answer": "First"}
+                ],
+                "event_ordering": [{"question": "What happened first?"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return chat, questions
+
+
+def _load(tmp_path: Path) -> BeamInputEvidence:
+    chat, questions = _inputs(tmp_path)
+    return load_beam_input(chat, questions, chat_id="100K/1", dataset=_dataset())
+
+
+def test_load_is_deterministic_ordered_and_digest_bound(tmp_path: Path) -> None:
+    first = _load(tmp_path)
+    second = _load(tmp_path)
+
+    assert first == second
+    assert [turn.turn_id for turn in first.conversation.turns] == ["1,1", "1,2"]
+    assert [question.question_id for question in first.questions] == [
+        "100K/1:information_extraction:1",
+        "100K/1:event_ordering:1",
+    ]
+    assert (
+        first.provenance.chat_input_digest
+        == hashlib.sha256((tmp_path / "chat.json").read_bytes()).hexdigest()
+    )
+    assert first.provenance.evidence_kind == "local_input_provenance_only"
+
+
+@pytest.mark.parametrize(
+    ("chat_payload", "question_payload", "error"),
+    [
+        (b'[{"batch_number":1,"turns":[]} ]', None, "beam_chat_invalid"),
+        (
+            b'[{"batch_number":1,"turns":[{"role":"user","id":"x","id":"y","content":"a"}]}]',
+            None,
+            "beam_chat_invalid",
+        ),
+        (None, b'{"category":[{"question":"a","question":"b"}]}', "beam_questions_invalid"),
+        (None, b'{"category":[{}]}', "beam_questions_invalid"),
+    ],
+)
+def test_invalid_or_duplicate_source_fields_fail_closed(
+    tmp_path: Path, chat_payload: bytes | None, question_payload: bytes | None, error: str
+) -> None:
+    chat, questions = _inputs(tmp_path)
+    if chat_payload is not None:
+        chat.write_bytes(chat_payload)
+    if question_payload is not None:
+        questions.write_bytes(question_payload)
+    with pytest.raises(EvidenceContractError, match=error):
+        load_beam_input(chat, questions, chat_id="100K/1", dataset=_dataset())
+
+
+def test_suite_mismatch_and_duplicate_turn_ids_fail_closed(tmp_path: Path) -> None:
+    chat, questions = _inputs(tmp_path)
+    with pytest.raises(EvidenceContractError, match="beam_dataset_suite_mismatch"):
+        load_beam_input(
+            chat,
+            questions,
+            chat_id="100K/1",
+            dataset=_dataset().model_copy(update={"suite": "locomo"}),
+        )
+    chat.write_text(
+        json.dumps(
+            [
+                {
+                    "batch_number": 1,
+                    "turns": [
+                        {"role": "user", "id": "x", "content": "a"},
+                        {"role": "assistant", "id": "x", "content": "b"},
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(EvidenceContractError, match="beam_turn_id_duplicate"):
+        load_beam_input(chat, questions, chat_id="100K/1", dataset=_dataset())
+
+
+def test_no_network_or_write_side_effects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_socket(*args: object, **kwargs: object) -> socket.socket:
+        raise AssertionError("network access is forbidden")
+
+    monkeypatch.setattr(socket, "socket", fail_socket)
+    paths = _inputs(tmp_path)
+    before = {path: path.stat().st_mtime_ns for path in paths}
+    result = load_beam_input(*paths, chat_id="100K/1", dataset=_dataset())
+    assert before == {path: path.stat().st_mtime_ns for path in paths}
+    assert isinstance(result, BeamInputEvidence)


### PR DESCRIPTION
## Summary
- add a fail-closed local-only adapter for one BEAM chat and its colocated probing questions
- bind the exact public dataset revision, license, chat identity, and raw input digests
- document the input-only boundary and add deterministic, no-network proof coverage

## Validation
- 25 focused tests passed
- Ruff passed
- mypy passed
- documentation and agent coherence checks passed

Closes #448