### PR TITLE
feat(mcp): add content-free shadow status read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- **Content-free Shadow status read target** — add `read_graph_data(target_type="shadow_status")` as a versioned, query-only status surface with no cache initialization, schema migration, mutation, or content read.
+
 - **Versioned Shadow read profile** — expose an additive, content-free `shadow_db.read_profile` with a closed profile version, installed producer version, hashed graph binding, committed generation, readiness, schema compatibility, and bounded capabilities so external read-side consumers can fail closed without filesystem or metadata-table access.
 
 - **Provider-free graph-outcome contracts (#483)** — add frozen, closed, byte-stable task, environment, episode, event, rubric, veto, report, and content-free receipt schemas for resettable Logseq outcome evaluation; malformed provenance, duplicate identifiers, impossible event chains, unbounded budgets, incompatible write policies, and incomplete evidence fail closed without filesystem, vault, Shadow, model, provider, or network side effects.

--- a/src/agent/dispatch_read_handlers.py
+++ b/src/agent/dispatch_read_handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Awaitable, Callable
 
 from loguru import logger
@@ -12,6 +13,7 @@ from ..graph.bootstrap_status import format_bootstrap_status_markdown
 from ..graph.dashboard import build_dashboard_markdown
 from ..graph.link_tag_hop import format_hop_report_markdown
 from ..rag.matryca_hooks import get_page_spatial_context
+from ..shadow.state_api import resolve_shadow_db_state_for_api
 from .graph_tool_helpers import (
     ReadGraphTarget,
     bounded_int_from_options,
@@ -193,6 +195,17 @@ async def handle_read_bootstrap_status(
     return cap_llm_payload_chars(status_md)
 
 
+async def handle_read_shadow_status(
+    _wiki_config: MatrycaWikiConfig,
+    graph_path: str,
+    _query: str,
+) -> str:
+    """Return the versioned, content-free Shadow read profile without cache initialization."""
+    snapshot = await asyncio.to_thread(resolve_shadow_db_state_for_api, graph_path)
+    logger.bind(state=snapshot.state).info("read_graph_data(shadow_status) completed")
+    return json.dumps(snapshot.model_dump(mode="json"), separators=(",", ":"), sort_keys=True)
+
+
 async def handle_read_dashboard(
     wiki_config: MatrycaWikiConfig,
     graph_path: str,
@@ -215,6 +228,7 @@ _READ_HANDLERS: dict[ReadGraphTarget, ReadHandler] = {
     "subtree": handle_read_subtree,
     "structural_hops": handle_read_structural_hops,
     "bootstrap_status": handle_read_bootstrap_status,
+    "shadow_status": handle_read_shadow_status,
     "dashboard": handle_read_dashboard,
 }
 
@@ -244,6 +258,7 @@ __all__ = [
     "handle_read_dashboard",
     "handle_read_memory",
     "handle_read_page",
+    "handle_read_shadow_status",
     "handle_read_structural_hops",
     "handle_read_subtree",
     "handle_read_xray_page",

--- a/src/agent/graph_tool_helpers.py
+++ b/src/agent/graph_tool_helpers.py
@@ -31,6 +31,7 @@ ReadGraphTarget = Literal[
     "dashboard",
     "xray_page",
     "bootstrap_status",
+    "shadow_status",
 ]
 SearchGraphMethod = Literal[
     "bm25",

--- a/src/agent/mcp_server.py
+++ b/src/agent/mcp_server.py
@@ -136,6 +136,10 @@ def register_mcp_tools(mcp: FastMCP) -> None:
         (``bootstrap_complete``, progress, ``soft_gate_active``). Call before the Master Index
         Soft Gate.
 
+        **``target_type=shadow_status``** — ``query`` ignored. Content-free, versioned
+        read-cache status and compatibility profile. This performs no initialization, mutation,
+        schema migration, or content read.
+
         **``target_type=dashboard``** — ``query`` ignored. Matryca dashboard Markdown:
         page counts, ``id::`` tally, block-ref health under ``pages/``.
 

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -58,6 +58,7 @@ READ_TARGETS: tuple[ReadGraphTarget, ...] = (
     "dashboard",
     "xray_page",
     "bootstrap_status",
+    "shadow_status",
 )
 SEARCH_METHODS: tuple[SearchGraphMethod, ...] = (
     "bm25",

--- a/tests/test_graph_dispatch_read.py
+++ b/tests/test_graph_dispatch_read.py
@@ -12,6 +12,7 @@ from src.agent.dispatch_read_handlers import (
 )
 from src.agent.graph_dispatch import dispatch_read
 from src.config import MatrycaWikiConfig
+from src.shadow.connection import shadow_db_path
 
 
 @pytest.mark.asyncio
@@ -46,3 +47,22 @@ async def test_dispatch_read_subtree_via_port(
 async def test_handle_read_subtree_empty_query_message() -> None:
     body = await handle_read_subtree(MatrycaWikiConfig(), "/tmp/graph", "  ")
     assert "target_type=subtree" in body
+
+
+@pytest.mark.asyncio
+async def test_dispatch_read_shadow_status_is_content_free_and_does_not_create_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "pages").mkdir()
+    monkeypatch.setenv("LOGSEQ_GRAPH_PATH", str(tmp_path))
+    monkeypatch.setenv("MATRYCA_SHADOW_DB_ENABLED", "false")
+
+    body = await dispatch_read_target(MatrycaWikiConfig(), "shadow_status", "ignored")
+
+    payload = json.loads(body)
+    assert payload["state"] == "disabled"
+    assert payload["read_profile"]["profile"] == "shadow-read-profile"
+    assert payload["read_profile"]["graph_id"] is None
+    assert str(tmp_path) not in body
+    assert not shadow_db_path(tmp_path).exists()


### PR DESCRIPTION
## Summary

- add `read_graph_data(target_type="shadow_status")` to the existing read-only MCP surface
- return the existing versioned, content-free cache-status profile as deterministic JSON
- verify the call neither exposes graph paths nor creates a cache when disabled

## Safety

The target is routed through the existing read dispatcher. It performs no initialization, mutation, schema migration, or content read.

## Validation

- `uv run pytest tests/test_graph_dispatch_read.py tests/test_shadow_state_api.py tests/test_mcp_server.py tests/test_read_only_immutability_e2e.py -q --no-cov` (34 passed)
- Ruff and mypy on changed Python files
- `make agents-check docs-check`