### PR TITLE
test: freeze Shadow read-profile fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- **Frozen Shadow read-profile fixtures** — publish a content-free v1 admission
+  corpus with healthy, malformed, future-version, unhealthy, and foreign-binding
+  packets for deterministic compatibility checks; no cache operation or new read
+  capability is introduced.
+
 - **Content-free Shadow status read target** — add `read_graph_data(target_type="shadow_status")` as a versioned, query-only status surface with no cache initialization, schema migration, mutation, or content read.
 
 - **Versioned Shadow read profile** — expose an additive, content-free `shadow_db.read_profile` with a closed profile version, installed producer version, hashed graph binding, committed generation, readiness, schema compatibility, and bounded capabilities so external read-side consumers can fail closed without filesystem or metadata-table access.

--- a/docs/openspec/shadow-read-profile.md
+++ b/docs/openspec/shadow-read-profile.md
@@ -38,3 +38,11 @@ content-free `shadow_db` reason and may omit binding/generation information.
 
 The profile is diagnostic and admission data only. It does not replace established
 health routing or Markdown/BM25 fallback.
+
+## Frozen fixture corpus
+
+`tests/fixtures/shadow_read_profile/` contains the content-free v1 packet corpus.
+`healthy_v1.json` is a valid profile snapshot. The malformed, future-version,
+unhealthy, and foreign-binding packets are explicit negative admission cases for
+compatibility verification; they do not describe normal producer states. The corpus
+contains no filesystem path, graph content, identifiers, query, SQL, or secret.

--- a/tests/fixtures/shadow_read_profile/foreign_binding.json
+++ b/tests/fixtures/shadow_read_profile/foreign_binding.json
@@ -1,0 +1,1 @@
+{"state":"ready","read_profile":{"profile":"shadow-read-profile","version":1,"producer_version":"2.0.0rc2","graph_id":"v1-foreign","generation":4,"state":"ready","ready":true,"schema_compatible":true,"capabilities":["state"]}}

--- a/tests/fixtures/shadow_read_profile/healthy_v1.json
+++ b/tests/fixtures/shadow_read_profile/healthy_v1.json
@@ -1,0 +1,1 @@
+{"state":"ready","read_profile":{"profile":"shadow-read-profile","version":1,"producer_version":"2.0.0rc2","graph_id":"v1-expected","generation":4,"state":"ready","ready":true,"schema_compatible":true,"capabilities":["state"]}}

--- a/tests/fixtures/shadow_read_profile/malformed_payload.json
+++ b/tests/fixtures/shadow_read_profile/malformed_payload.json
@@ -1,0 +1,1 @@
+{"state":"ready","read_profile":"not-an-object"}

--- a/tests/fixtures/shadow_read_profile/unhealthy_not_ready.json
+++ b/tests/fixtures/shadow_read_profile/unhealthy_not_ready.json
@@ -1,0 +1,1 @@
+{"state":"stale","read_profile":{"profile":"shadow-read-profile","version":1,"producer_version":"2.0.0rc2","graph_id":"v1-expected","generation":4,"state":"stale","ready":false,"schema_compatible":true,"capabilities":["state"]}}

--- a/tests/fixtures/shadow_read_profile/unsupported_future_profile.json
+++ b/tests/fixtures/shadow_read_profile/unsupported_future_profile.json
@@ -1,0 +1,1 @@
+{"state":"ready","read_profile":{"profile":"shadow-read-profile","version":2,"producer_version":"2.0.0rc2","graph_id":"v1-expected","generation":4,"state":"ready","ready":true,"schema_compatible":true,"capabilities":["state"]}}

--- a/tests/test_shadow_read_profile_fixtures.py
+++ b/tests/test_shadow_read_profile_fixtures.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 from pydantic import ValidationError
@@ -21,7 +22,10 @@ FORBIDDEN_KEYS = {"path", "content", "rows", "query", "sql", "secret"}
 
 
 def _load(name: str) -> dict[str, object]:
-    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+    payload = json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"fixture {name} must be a JSON object")
+    return cast(dict[str, object], payload)
 
 
 def test_fixture_corpus_is_complete_and_content_free() -> None:

--- a/tests/test_shadow_read_profile_fixtures.py
+++ b/tests/test_shadow_read_profile_fixtures.py
@@ -1,0 +1,64 @@
+"""Frozen, content-free v1 Shadow read-profile fixture corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from src.shadow.state_api import ShadowDbStateResponse
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "shadow_read_profile"
+FIXTURE_NAMES = {
+    "healthy_v1.json",
+    "malformed_payload.json",
+    "unsupported_future_profile.json",
+    "unhealthy_not_ready.json",
+    "foreign_binding.json",
+}
+FORBIDDEN_KEYS = {"path", "content", "rows", "query", "sql", "secret"}
+
+
+def _load(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_fixture_corpus_is_complete_and_content_free() -> None:
+    assert {path.name for path in FIXTURE_DIR.glob("*.json")} == FIXTURE_NAMES
+    for name in FIXTURE_NAMES:
+        payload = _load(name)
+        assert not (set(payload) & FORBIDDEN_KEYS)
+        profile = payload.get("read_profile")
+        if isinstance(profile, dict):
+            assert not (set(profile) & FORBIDDEN_KEYS)
+
+
+def test_healthy_fixture_matches_closed_v1_contract() -> None:
+    snapshot = ShadowDbStateResponse.model_validate(_load("healthy_v1.json"))
+
+    assert snapshot.read_profile is not None
+    assert snapshot.read_profile.profile == "shadow-read-profile"
+    assert snapshot.read_profile.version == 1
+    assert snapshot.read_profile.ready is True
+    assert snapshot.read_profile.schema_compatible is True
+    assert snapshot.read_profile.capabilities == ("state",)
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ["malformed_payload.json", "unsupported_future_profile.json"],
+)
+def test_invalid_contract_fixtures_do_not_validate(fixture_name: str) -> None:
+    with pytest.raises(ValidationError):
+        ShadowDbStateResponse.model_validate(_load(fixture_name))
+
+
+def test_unhealthy_and_foreign_fixtures_remain_explicit_admission_cases() -> None:
+    unhealthy = ShadowDbStateResponse.model_validate(_load("unhealthy_not_ready.json"))
+    foreign = ShadowDbStateResponse.model_validate(_load("foreign_binding.json"))
+
+    assert unhealthy.read_profile is not None
+    assert unhealthy.read_profile.ready is False
+    assert foreign.read_profile is not None
+    assert foreign.read_profile.graph_id != "v1-expected"


### PR DESCRIPTION
## Summary\n- publish the content-free v1 status-profile fixture corpus\n- document healthy and negative admission packets\n- add deterministic contract/integrity coverage without runtime changes\n\n## Validation\n- 1 file already formatted\n- All checks passed!\n- pyproject.toml: note: unused section(s): module = ['edn_format', 'edn_format.*', 'fastapi.*', 'httpx.*', 'ijson', 'instructor', 'openai', 'psutil', 'starlette.*', 'uvicorn.*', 'yaml']
Success: no issues found in 1 source file\n- .....................                                                    [100%]
21 passed in 0.36s (21 passed)\n- uv run python scripts/check_agents_coherence.py
agents coherence OK
uv run python scripts/docs_knowledge_check.py check-bundle
inventory sync OK (no drift)
inventory.md OK
OKF v0.2 format compatibility: PASS (0 findings)
Matryca quality profile v1.0: PASS (0 findings)
Validator v1; finding schema v1
docs knowledge check OK\n- fixture corpus byte-identical to the paired consumer PR\n\nNo cache operation, schema change, endpoint, or read capability is introduced.