### PR TITLE
docs: remove trailing whitespace from Tine roadmap

### DIFF
--- a/docs/roadmaps/TINE_LOGSEQ_ECOSYSTEM_INTEGRATION_STRATEGY_2026-08-12.md
+++ b/docs/roadmaps/TINE_LOGSEQ_ECOSYSTEM_INTEGRATION_STRATEGY_2026-08-12.md
@@ -18,8 +18,8 @@ source_commit: 4f82e12e737335f54fabfb7979b1b83026148663
 
 # Tine and Logseq ecosystem integration strategy
 
-**Date:** 2026-08-12  
-**Decision status:** proposed, evidence-backed roadmap; no compatibility or release claim  
+**Date:** 2026-08-12
+**Decision status:** proposed, evidence-backed roadmap; no compatibility or release claim
 **Scope:** Tine collaboration, Logseq OG companion, Logseq DB integration, and the smallest Matryca Plumber changes with the highest expected impact
 
 ## Executive decision


### PR DESCRIPTION
## Summary

- remove two trailing-space line breaks from the Tine/Logseq strategy document;
- keep the source document compatible with downstream projection `git diff --check`.

## Test plan

- [x] `make docs-check`
- [x] `git diff --check`

This is formatting-only and does not change the roadmap decision or runtime behavior.
