### PR TITLE
docs(quality): reconcile RC2 readiness evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,13 +6,14 @@ Matryca Plumber is local data infrastructure for headless AI agents working with
 
 Architecture debate and RFC: [Discussion #19 — Core Architecture Evolution](https://github.com/MarcoPorcellato/matryca-plumber/discussions/19).
 
-*Status as of **2026-08-09** — `v2.0.0rc1` is the historical first public RC.
-Its Read Only external-cache Gate B profile reached terminal `PASS`; its
+*Status as of **2026-08-14** — `v2.0.0rc1` is the historical first public RC:
+its Read Only external-cache Gate B profile reached terminal `PASS`, while its
 default-on profile was frozen non-terminal after exposing a qualifier cleanup
-defect. `v2.0.0rc2` is the next exact candidate, carrying parser 1.7.1 and the
-corrected qualifier. Stable promotion remains blocked until fresh rc.2 Gate B
-evidence reaches terminal `PASS`; implementation progress does not imply release
-qualification. Issue numbers link to GitHub.*
+defect. The exact public `v2.0.0rc2` candidate has since completed its fresh
+dual-profile Gate B soaks and upgrade matrix. The canonical
+[`v2.0.0 stable-readiness decision`](docs/quality/issue-bodies/v2-rc-stable-readiness.md)
+owns the remaining blockers; stable promotion is not complete before
+`2026-08-16T16:45:18Z`. Issue numbers link to GitHub.*
 
 ---
 
@@ -49,8 +50,9 @@ restart-resilient 72-hour soak. The sanitized
 [`terminal evidence record`](docs/quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md)
 records 415 completed cycles, 259,225.349 observed seconds, source Markdown
 unchanged during the source-to-working-copy check, and a terminal `PASS`; this closes only
-Gate A's exact-beta real-vault row. The currently active `2.0.0rc1` Gate B run
-remains `RUNNING` and is tracked as an independent stable-preparation checkpoint.
+Gate A's exact-beta real-vault row. The historical RC1 split outcome is preserved
+in the [stable-readiness decision](docs/quality/issue-bodies/v2-rc-stable-readiness.md)
+and must not be read as the current RC2 Gate B state.
 
 The published `2.0.0rc1` candidate line has merged Strict Read Only enforcement,
 external per-user Shadow cache routing, default-on Shadow with explicit opt-out,
@@ -61,14 +63,11 @@ graph-local, while the next candidate is default-on and external.
 
 Promotion therefore remains deliberately sequential:
 
-1. complete every remaining Gate A row on the exact candidate, including
-   upgrade/rollback, defect disposition, default-on/read-only installed-wheel
-   proof, operator-contract synchronization, and release build/platform checks;
-2. publish `v2.0.0-rc.1` so prerelease users can exercise the complete external
-   Shadow path;
-3. complete Gate B on that published RC, including at least seven days of
-   observation and the default-on/read-only soaks;
-4. publish stable `v2.0.0` only after every Gate B row passes.
+1. preserve the frozen RC2 artifact as the stable-promotion source;
+2. complete every remaining canonical Gate B row, including the RC observation
+   window, supported-platform evidence, performance disposition, stable
+   documentation, and exact-stable-artifact proof;
+3. publish stable `v2.0.0` only after every Gate B row passes.
 
 ---
 

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -1,5 +1,9 @@
 # Documentation update log
 
+## 2026-08-14
+
+- **Stable-readiness state:** Reconciled RC2 terminal soak and persistent upgrade/rollback evidence, corrected the roadmap's historical RC1 framing, and recorded the RC observation cutoff while retaining the remaining stable-promotion blockers.
+
 ## 2026-08-13
 
 - **RC2 qualification evidence:** Recorded the terminal dual-profile Gate B result for the exact public `2.0.0rc2` wheel, including frozen artifact and runner bindings, 72-hour valid-time proof, attempt-chain integrity, Read Only external-cache isolation, and explicit remaining stable-release gates.

--- a/docs/quality/GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md
+++ b/docs/quality/GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md
@@ -59,10 +59,14 @@ This closes the **Default-on soak** and **Read Only external-cache soak** rows
 for the exact RC2 artifact in the v2 stable-readiness decision. RC1's split
 outcome remains preserved as historical evidence and is not rewritten.
 
-Stable `v2.0.0` remains a separate maintainer decision. The following gates
-are intentionally still open: the minimum RC observation window, exact-artifact
-upgrade matrix, supported-platform evidence, performance disposition, stable
-operator wording, and full release proof on the exact stable commit.
+Stable `v2.0.0` remains a separate maintainer decision. The persistent
+exact-public-`2.0.0rc2` upgrade/rollback receipt has since reached terminal
+`PASS` across `1.14.5`, `2.0.0a5`, `2.0.0b1`, and `2.0.0rc1`; it binds the wheel
+SHA-256 recorded above and preserves working Markdown after each rollback. It
+closes the RC2 upgrade-matrix row only, not final stable-artifact verification.
+The following gates are intentionally still open: the minimum RC observation
+window, supported-platform evidence, performance disposition, stable operator
+wording, and full release proof on the exact stable commit.
 
 The published RC2 wheel is therefore a qualified public prerelease for users
 who want to test the v2 Shadow DB contract now. It must not be represented as

--- a/docs/quality/issue-bodies/v2-rc-stable-readiness.md
+++ b/docs/quality/issue-bodies/v2-rc-stable-readiness.md
@@ -146,14 +146,14 @@ child-process diagnostic is retained in the committed record.
 
 | Requirement | Evidence required | Status |
 |-------------|-------------------|--------|
-| RC observation | At least 7 days of RC availability and maintainer operation, with no unresolved P0/P1 regression | [ ] — under observation, not yet complete |
+| RC observation | At least 7 days of RC availability and maintainer operation, with no unresolved P0/P1 regression | [ ] — under observation; not complete before `2026-08-16T16:45:18Z` |
 | Default-on soak | At least 72 hours and preferably 7 days with the flag unset, plus an explicit opt-out control run | [x] — exact public `2.0.0rc2` wheel terminal `PASS` on 2026-08-13 after 417 cycles, 834 passing attempts, and 259,548.995 valid seconds; source/working Markdown fingerprints matched and the artifact, installed RECORD, runner, and attempt chain were verified. See [`GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md`](../GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md). |
 | Read Only external-cache soak | Default-on Shadow reaches and retains `READY` with `MATRYCA_READ_ONLY=true`; all writes remain outside the graph and Markdown fingerprints remain unchanged | [x] — exact public `2.0.0rc2` wheel terminal `PASS` on 2026-08-13 after 417 cycles, 834 passing attempts, and 259,421.167 valid seconds; source/working Markdown fingerprints matched and the artifact, installed RECORD, runner, and attempt chain were verified. See [`GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md`](../GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md). |
-| Upgrade matrix | Stable `1.14.5`, alpha `2.0.0a5`, beta `2.0.0b1`, and RC upgrade paths pass from published artifacts | [ ] |
+| Upgrade matrix | Stable `1.14.5`, alpha `2.0.0a5`, beta `2.0.0b1`, and RC upgrade paths pass from published artifacts | [x] — the persistent exact-public-`2.0.0rc2` receipt reached terminal `PASS`: all four published baselines installed, upgraded to candidate, completed every candidate check, rolled back, and preserved working Markdown. The receipt binds candidate wheel SHA-256 `0b0c8a94377b9c1805b7304a10fe728c6d5c1f4ba120519b6e25c374c0a42318`; it is maintainer-held qualification evidence and does not replace final exact-stable-artifact verification. |
 | Cross-platform gate | Linux, macOS, and Windows CI or installed-runtime evidence passes for the supported Shadow read contract | [ ] |
 | Performance disposition | FTS and subtree measurements have explicit pass thresholds or a documented non-blocking disposition; fallback remains usable | [ ] |
 | Stable documentation | In-memory BM25 is deprecated as the default discovery path but remains a supported fallback; no beta/RC wording survives on stable surfaces | [ ] |
-| Final release proof | Full CI, code audit, clean build, release-note extraction, installed-wheel smoke, and artifact digest verification pass on the exact stable commit | [ ] |
+| Final release proof | Full CI, code audit, clean build, release-note extraction, installed-wheel smoke, and artifact digest verification pass on the exact stable commit | [ ] — explicitly pending on the frozen-RC2-derived exact stable candidate |
 
 `v2.0.0` may be published only when every Gate B row is complete.
 


### PR DESCRIPTION
## Summary
- Record the terminal RC2 upgrade/rollback qualification for all four published baselines.
- Make the RC observation cutoff explicit and retain the exact stable-artifact proof as a blocking gate.
- Align the roadmap with the current RC2 qualification state while preserving RC1 as historical evidence.

## Test plan
- [x] `make docs-check`
- [x] `make docs-audit`
- [x] `git diff --check`

Refs #343