### PR TITLE
docs: align source bundle with official OKF v0.2

### DIFF
--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 <!-- GENERATED — do not edit -->
 
-<!-- build-hash: 707902a94403565c01f4bfd1c06eb97e28ff669f334267c994230422d1223a8d -->
+<!-- build-hash: f907fc2ecebd8ce932e0aefd36109989f881c3adfba7d88aa32302c865551b3e -->
 
 <!-- package-version: v2.0.0 -->
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Matryca Plumber — System Architecture
 
 **Architecture baseline:** v2.0.0-rc.2 source. Current Shadow defaults and operator behavior are owned by the [v2 operator contract](knowledge/architecture/shadow-db.md); qualification and publication gates are owned by the [release process](RELEASE_PROCESS.md#v20-promotion-override).

--- a/docs/AUDIT_REPORT_2026-07-16.md
+++ b/docs/AUDIT_REPORT_2026-07-16.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Deep Code Audit — matryca-plumber
 
 **Date:** 2026-07-16 · **Tooling:** local code audit, ruff static analysis, targeted manual review, TRIZ methodology.

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Branding and naming (Matryca Plumber)
 
 Use this guide in README, UI copy, operator docs, and release notes.

--- a/docs/CLEAN_CODE_ARCHITECTURE.md
+++ b/docs/CLEAN_CODE_ARCHITECTURE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Clean Code & Clean Architecture — Matryca Plumber
 
 **Version:** documents **v2.0.0-alpha.1+** maintainer contracts (Shadow DB writer flock, meta/pages health, read port, catalog write-safety, leaf-module dependency direction, parser 1.6.0 alignment, daemon/dispatch module maps, GraphReadPort)  

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # First contribution
 
 One-page path from fork to a green PR. Full rules live in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/PROJECT_DIARY.md
+++ b/docs/PROJECT_DIARY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Project diary — technical lifecycle log
 
 This document records **architecture decisions**, **phase milestones**, and **real-world defects crushed** during the evolution of **Matryca Plumber** (`matryca-plumber` on PyPI; historical published beta **v2.0.0-beta.1**; Gate-A-qualified release candidate **v2.0.0-rc.1**).

--- a/docs/PROMPT_ARCHITECTURE.md
+++ b/docs/PROMPT_ARCHITECTURE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Prompt architecture — Clean Architecture & Clean Code
 
 **Version:** documents **v1.12.0** (plan v3 — shipped)  

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Release process
 
 **Matryca Plumber** (Marco Porcellato · [Matryca.ai](https://matryca.ai)) uses a **curated** [`CHANGELOG.md`](../CHANGELOG.md) (Keep a Changelog). GitHub Release notes are **not** auto-generated from commits — CI copies the matching changelog section when you push a `v*` tag.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,11 +1,3 @@
----
-type: Decision Index
-title: Matryca Plumber decision index
-description: Navigation for durable documentation and product decision records.
-status: active
-last_verified: 2026-08-12
----
-
 # Matryca Plumber decisions
 
 - [Documentation evolution and operating model](../knowledge/documentation-evolution.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ title: Matryca Plumber documentation
 description: Stable entry point for maintained Matryca Plumber documentation.
 status: active
 last_verified: 2026-08-12
+okf_version: "0.2"
 ---
 
 # Matryca Plumber documentation

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Hermes Agent integration — compatibility report
 
 **Date:** 2026-06-07  

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -1,7 +1,3 @@
----
-okf_version: "0.2"
----
-
 # Matryca Plumber knowledge bundle
 
 This index provides progressive disclosure across maintained concepts and the classified legacy corpus. Matryca Plumber remains the authoritative editing origin; external projections are read-only, Git-provenanced consumer views.

--- a/docs/log.md
+++ b/docs/log.md
@@ -8,6 +8,10 @@ last_verified: 2026-08-12
 
 # Matryca Plumber documentation log
 
+## 2026-08-19
+
+- **Update:** Normalized to the official OKF v0.2 chronology shape.
+
 The maintained documentation chronology is owned by the
 [knowledge-bundle log](knowledge/log.md). This stable route exists for
 cross-repository navigation and carries no duplicate change history.

--- a/docs/openspec/README.md
+++ b/docs/openspec/README.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Openspec-style notes (Matryca Plumber)
 
 **Matryca Plumber** — developed by Marco Porcellato · [Matryca.ai](https://matryca.ai). Naming rules: [`../BRANDING.md`](../BRANDING.md).

--- a/docs/openspec/agent-ax-robustness.md
+++ b/docs/openspec/agent-ax-robustness.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Agent Experience (AX) robustness — lenient resolution & safe writes (v1.9.7+)
 
 **Milestone:** v1.9.7 — AX Robustness & Lenient Resolution · v1.9.8 — documentation harmonization · v1.9.9 — Security & Sandbox (complements MCP title normalization; see [`security-sandbox.md`](security-sandbox.md))  

--- a/docs/openspec/agent-dx.md
+++ b/docs/openspec/agent-dx.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Agent-centric DX & visual auditing (v1.9 — GitHub #16)
 
 **Milestone:** v1.9.0 — Structural Graph Hygiene  

--- a/docs/openspec/agent-onboarding.md
+++ b/docs/openspec/agent-onboarding.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Agent onboarding (`llms.txt`) — v2.0.0
 
 **Milestone:** v1.9.2 — Agent-zero-friction distribution · v1.9.5 — LLM OS / `bootstrap_status` · v1.9.6 — Hermes lazy AST · v1.9.7 — AX robustness · v1.9.8 — doc harmonization · v1.9.9 — Security & Sandbox · v1.9.10 — Sovereign UI fast startup + `status` vs `start` docs · v1.9.11 — Sovereign UI reliability (lazy bootstrap on save/start/L1) · v1.11.x — Tana import, graph layer boundary refactor  

--- a/docs/openspec/agent/formatting.md
+++ b/docs/openspec/agent/formatting.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Formatting discipline (non-negotiable)
 
 These rules mirror Logseq OG's Clojure/Datalog on-disk contract. Violations cause silent index corruption — not immediate parse errors.

--- a/docs/openspec/agent/identity.md
+++ b/docs/openspec/agent/identity.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Matryca Plumber — Agent System Prompt
 
 ## Identity

--- a/docs/openspec/agent/l1-l2-routing.md
+++ b/docs/openspec/agent/l1-l2-routing.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## L1 vs L2 vs in-graph identity
 
 - **L1 (session-critical):** deploy rules, pointers to secrets (never secrets themselves). Load first via `read_graph_data` / `target_type="memory"`. Sources: `MATRYCA_L1_PATH`, `memory_path` in `matryca-wiki.yml`, or `<parent-of-vault>/matryca-l1/*.md` (sibling of the graph root by default — see `docs/openspec/runtime-bootstrap.md`). `README.md` in that folder is documentation only and is not loaded into context.

--- a/docs/openspec/agent/mcp-tools.md
+++ b/docs/openspec/agent/mcp-tools.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## MCP surface (eight tools)
 
 Five **polymorphic mega-tools** plus **`store_fact`**, **`ingest_document`**, and **`import_tana`**. Mega-tools select behavior via a **literal discriminator** (`target_type`, `method`, `action`, `linter_name`).

--- a/docs/openspec/agent/paradigm.md
+++ b/docs/openspec/agent/paradigm.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Project context
 
 Matryca Plumber operates on **Logseq OG**: local pure Markdown graphs. The atomic unit is the **block** (indented bullet tree), not a flat document body.

--- a/docs/openspec/agent/soft-gate.md
+++ b/docs/openspec/agent/soft-gate.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## LLM OS — two-tier architecture
 
 You operate in a **strictly decoupled** Matryca stack. Violating tier boundaries wastes tokens and risks graph corruption.

--- a/docs/openspec/agent/synthetic-ids.md
+++ b/docs/openspec/agent/synthetic-ids.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## CRITICAL: synthetic IDs and broken links
 
 `read_graph_data` with `target_type="page"` returns Matryca Parser spatial output per block:

--- a/docs/openspec/agent/tool-reference.md
+++ b/docs/openspec/agent/tool-reference.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Tool reference and invocation examples
 
 Invoke tools with the discriminator as a **string literal** plus the parameters shown. `payload` and enriched `query` values are JSON **strings** (serialize objects before sending).

--- a/docs/openspec/agent/workflow-footer.md
+++ b/docs/openspec/agent/workflow-footer.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Workflow: Search → Scan → Update
 
 Mirror llm-wiki-style ingest. See `docs/ARCHITECTURE.md` for bridge vs on-disk boundaries.

--- a/docs/openspec/agent/xray.md
+++ b/docs/openspec/agent/xray.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## X-Ray mode and session aliases (`[n]`)
 
 For large pages, prefer **`read_graph_data` / `target_type="xray_page"`** with `query` = page title. The tool returns an ultra-dense outline like `[0] Parent` / `  [1] Child` (properties stripped) and writes `.matryca_xray_state.json` mapping each `[n]` to the real Logseq block UUID. Normal mode keeps the established graph-root location. With `MATRYCA_READ_ONLY=true`, state is written instead to the private per-graph external runtime cache at `<cache-root>/graphs/<graph-id>/xray/`; no graph path is created or modified. The graph identity prevents cross-vault sharing, the state file is atomically replaced under a process-safe lock, POSIX directory/file modes are `0700`/`0600`, and its lifetime follows the per-graph runtime cache.

--- a/docs/openspec/biological-memory.md
+++ b/docs/openspec/biological-memory.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Biological memory layer — OpenSpec (projection contract, v2.1+)
 
 **Status:** P0 canonical recall is shipped behind a disabled-by-default feature gate. It is a

--- a/docs/openspec/dual-embedding.md
+++ b/docs/openspec/dual-embedding.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Dual embedding strategy (Master RFC — Phase 3)
 
 **Implementation:** `src/semantic/`  

--- a/docs/openspec/evidence-archive.md
+++ b/docs/openspec/evidence-archive.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Governed evidence archive
 
 ## Scope

--- a/docs/openspec/identity-config.md
+++ b/docs/openspec/identity-config.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # In-graph identity (Telos & AI Constraints)
 
 **Roadmap:** Master architecture RFC — Phase 1 (persona layer)  

--- a/docs/openspec/ingest.md
+++ b/docs/openspec/ingest.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Atomic document ingestion (Master RFC — Phase 2)
 
 **Roadmap:** Master architecture RFC — Phase 2 (external markdown → L2 graph)  

--- a/docs/openspec/l1-l2-routing.md
+++ b/docs/openspec/l1-l2-routing.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # L1 / L2 routing (Matryca Plumber)
 
 **Roadmap:** [`ROADMAP_LLM_WIKI.md`](../../ROADMAP_LLM_WIKI.md)  

--- a/docs/openspec/link-verification.md
+++ b/docs/openspec/link-verification.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Structural link verification (v1.9 — GitHub #15)
 
 **Milestone:** v1.9.0 — Structural Graph Hygiene  

--- a/docs/openspec/lint.md
+++ b/docs/openspec/lint.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Lint (Matryca Plumber on-disk)
 
 **Roadmap:** [`ROADMAP_LLM_WIKI.md`](../../ROADMAP_LLM_WIKI.md)

--- a/docs/openspec/live-telemetry-ui.md
+++ b/docs/openspec/live-telemetry-ui.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Live telemetry — Sovereign UI (v1.9.3)
 
 **Milestone:** v1.9.3 — Live Telemetry Update  

--- a/docs/openspec/llm-os-instructions.md
+++ b/docs/openspec/llm-os-instructions.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # LLM OS instructions — two-tier agent contract
 
 **Artifacts:** [`SYSTEM_PROMPT.md`](../../SYSTEM_PROMPT.md) (Tier-2 cognitive law), [`llms.txt`](../../llms.txt) / [`.well-known/llms.txt`](../../.well-known/llms.txt) (distribution pointer), optional `matryca-l1/llm-os-rules.md` (operator overlay)

--- a/docs/openspec/llm-performance.md
+++ b/docs/openspec/llm-performance.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # LLM performance & edge computing (v1.8+)
 
 **Roadmap:** [`../v1.8-OPTIMIZATION-PLAN.md`](../v1.8-OPTIMIZATION-PLAN.md)  

--- a/docs/openspec/logseq-paradigm.md
+++ b/docs/openspec/logseq-paradigm.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Logseq OG paradigm (SSOT)
 
 Canonical spec: [`docs/openspec/agent/paradigm.md`](agent/paradigm.md).

--- a/docs/openspec/runtime-bootstrap.md
+++ b/docs/openspec/runtime-bootstrap.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Runtime bootstrap (startup provisioning)
 
 **Roadmap:** [`ROADMAP_LLM_WIKI.md`](../../ROADMAP_LLM_WIKI.md) (L1/L2, `matryca-wiki.yml`)

--- a/docs/openspec/security-sandbox.md
+++ b/docs/openspec/security-sandbox.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Security & Sandbox (v1.9.9)
 
 **Milestone:** v1.9.9 — Security & Sandbox (v1.9.x perfection track)  

--- a/docs/openspec/shadow-read-profile.md
+++ b/docs/openspec/shadow-read-profile.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Shadow read profile — OpenSpec
 
 ## Purpose

--- a/docs/openspec/tana-import.md
+++ b/docs/openspec/tana-import.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Tana workspace JSON import (enterprise migration)
 
 **Version:** 1.0  

--- a/docs/quality/BETA_EVIDENCE_REPRODUCIBILITY_RCA_2026-07-23.md
+++ b/docs/quality/BETA_EVIDENCE_REPRODUCIBILITY_RCA_2026-07-23.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Beta evidence reproducibility root-cause analysis — draft
 
 **Status:** investigation draft, 2026-07-23. This is a sanitized quality artifact, not a release note, a beta decision, or a claim that the current candidate is releasable. The release decision remains [`issue-bodies/v2-beta-readiness.md`](issue-bodies/v2-beta-readiness.md); the historical experiment record remains [`V2_ALPHA_BETA_EXPERIMENT_EVIDENCE.md`](V2_ALPHA_BETA_EXPERIMENT_EVIDENCE.md).

--- a/docs/quality/CLAUDE_ARCH_AUDIT_TRIAGE_2026-06-24.md
+++ b/docs/quality/CLAUDE_ARCH_AUDIT_TRIAGE_2026-06-24.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Claude Architectural Audit — Triage (2026-06-24)
 
 Staff-level review (Repomix snapshot, June 2026). Cross-reference: [Expert Audit](EXPERT_AUDIT_TRIAGE_2026-06.md), [Repomix](REPOmix_AUDIT_TRIAGE_2026-06.md), [Clean Arch](CLEAN_ARCH_AUDIT_TRIAGE_2026-06.md), v1.9.x perfection audit JSON.

--- a/docs/quality/CLEAN_ARCH_AUDIT_TRIAGE_2026-06.md
+++ b/docs/quality/CLEAN_ARCH_AUDIT_TRIAGE_2026-06.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Clean Architecture Audit — Triage (2026-06)
 
 Third external audit (simulated Staff Engineer review against hexagonal / ports-and-adapters patterns). Cross-reference with [Expert Audit triage](EXPERT_AUDIT_TRIAGE_2026-06.md), [Repomix triage](REPOmix_AUDIT_TRIAGE_2026-06.md), and GitHub [#132](https://github.com/MarcoPorcellato/matryca-plumber/issues/132)–[#142](https://github.com/MarcoPorcellato/matryca-plumber/issues/142).

--- a/docs/quality/CONTRIBUTOR_READY_CLOSURE_AUDIT_2026-08-08.md
+++ b/docs/quality/CONTRIBUTOR_READY_CLOSURE_AUDIT_2026-08-08.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Contributor-ready shipped-evidence closure audit — 2026-08-08
 
 ## Purpose and authority

--- a/docs/quality/DEPENDENCY_SECURITY_RECONCILIATION_2026-08-08.md
+++ b/docs/quality/DEPENDENCY_SECURITY_RECONCILIATION_2026-08-08.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Dependency security reconciliation — 2026-08-08
 
 ## Purpose and evidence boundary

--- a/docs/quality/EXPERT_AUDIT_TRIAGE_2026-06.md
+++ b/docs/quality/EXPERT_AUDIT_TRIAGE_2026-06.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Expert Architectural Audit — Triage (2026-06)
 
 Cross-reference between the **Expert Architectural Audit** (external review) and Matryca Plumber's existing backlog: v1.9.x perfection audit (#01–#38), GitHub issues, ROADMAP, openspec, CHANGELOG.

--- a/docs/quality/GATE_B_RC1_DEFAULT_ON_FAILURE_2026-08-09.md
+++ b/docs/quality/GATE_B_RC1_DEFAULT_ON_FAILURE_2026-08-09.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Gate B rc.1 default-on failure and rc.2 remediation
 
 ## Purpose

--- a/docs/quality/GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md
+++ b/docs/quality/GATE_B_RC2_TERMINAL_EVIDENCE_2026-08-13.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Gate B RC2 terminal qualification evidence — 2026-08-13
 
 ## Purpose and decision boundary

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Gate B public-RC soak runbook
 
 This runbook starts the two independent, fail-closed soak profiles required by

--- a/docs/quality/GITHUB_BUG_BACKLOG.md
+++ b/docs/quality/GITHUB_BUG_BACKLOG.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub bug backlog — Expert Audit 2026-06 slice
 
 **Triage 2026-07-01:** 33 audit/observability issues closed on GitHub (shipped v1.11.2); pass 2 closed #42, #91, #92; pass 3 closed #38, #113; pass 4 closed #97 (OCC filesystem docs). Session log: [`ISSUE_TRIAGE_2026-07-01.md`](ISSUE_TRIAGE_2026-07-01.md). Epic **#20** pinned.

--- a/docs/quality/ISSUE_CONTROL_PLANE_2026-08-08.md
+++ b/docs/quality/ISSUE_CONTROL_PLANE_2026-08-08.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Issue and milestone control plane — 2026-08-08
 
 **Related execution dossier:** [Agentic Memory Leadership Programme — August 10, 2026](AGENTIC_MEMORY_LEADERSHIP_PROGRAMME_2026-08-10.md)

--- a/docs/quality/ISSUE_TRIAGE_2026-07-01.md
+++ b/docs/quality/ISSUE_TRIAGE_2026-07-01.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Issue triage — 2026-07-01
 
 **Operator:** Marco Porcellato (maintainer)  

--- a/docs/quality/READ_ONLY_IMMUTABILITY_E2E.md
+++ b/docs/quality/READ_ONLY_IMMUTABILITY_E2E.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Strict Read Only end-to-end immutability gate
 
 **Status:** `PASS` for the deterministic source-tree qualification merged in

--- a/docs/quality/REPOmix_AUDIT_TRIAGE_2026-06.md
+++ b/docs/quality/REPOmix_AUDIT_TRIAGE_2026-06.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Repomix Architectural Audit — Triage (2026-06)
 
 Second external audit (Repomix-based). Cross-reference with [Expert Audit triage](EXPERT_AUDIT_TRIAGE_2026-06.md), v1.9.x audit JSON, and GitHub #46–#64 / #114–#117 dev audit.

--- a/docs/quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md
+++ b/docs/quality/SHADOW_DB_EXACT_BETA_72H_SOAK_2026-07-30.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Shadow DB exact-beta 72-hour soak — terminal evidence record
 
 **Status:** terminal `PASS`, recorded 2026-08-03 at 00:52:20 UTC. This is a

--- a/docs/quality/SHADOW_DB_PARSE_BUDGET_TRIZ_2026-07-27.md
+++ b/docs/quality/SHADOW_DB_PARSE_BUDGET_TRIZ_2026-07-27.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Shadow DB page-parse budget — measurement, contradiction, and quarantine design
 
 _Recorded 2026-07-27, during `v2.0.0-beta.1` release-candidate preparation._

--- a/docs/quality/SHADOW_DB_SOAK_24H_EVIDENCE_2026-07-28.md
+++ b/docs/quality/SHADOW_DB_SOAK_24H_EVIDENCE_2026-07-28.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Shadow DB 24-hour soak — evidence record
 
 **Status:** evidence record, 2026-07-28. This is a sanitized quality artifact, not a release note and not a release decision. It reports what one 24-hour soak run observed, including two interruptions and what they do and do not prove. The release decision remains [`issue-bodies/v2-beta-readiness.md`](issue-bodies/v2-beta-readiness.md); the reproducibility analysis that motivated the current harness remains [`BETA_EVIDENCE_REPRODUCIBILITY_RCA_2026-07-23.md`](BETA_EVIDENCE_REPRODUCIBILITY_RCA_2026-07-23.md).

--- a/docs/quality/V2_ALPHA_BETA_EXPERIMENT_EVIDENCE.md
+++ b/docs/quality/V2_ALPHA_BETA_EXPERIMENT_EVIDENCE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # V2 alpha/beta experiment evidence ledger
 
 ## Purpose and decision boundary

--- a/docs/quality/V2_SHADOW_DB_VISION_2026-07-25.md
+++ b/docs/quality/V2_SHADOW_DB_VISION_2026-07-25.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # What Matryca Plumber Gains from v2.0 and the Shadow DB
 
 _Working note — 2026-07-25, written while the 24h+ soak (r8) was running before the beta release._

--- a/docs/quality/V2_STABLE_PERFORMANCE_DISPOSITION_2026-08-18.md
+++ b/docs/quality/V2_STABLE_PERFORMANCE_DISPOSITION_2026-08-18.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0.0 stable performance disposition — 2026-08-18
 
 ## Decision

--- a/docs/quality/issue-bodies/130-lock-backoff-downgrades-processed.md
+++ b/docs/quality/issue-bodies/130-lock-backoff-downgrades-processed.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 In `src/agent/maintenance_daemon.py`, `_process_llm_cycle_file` sets `status="processed"` after a successful cognitive lint write (L2715–2718), then calls `run_dual_embedding_after_semantic_write`. If that post-write step raises `PageLockUnavailableError`, the handler calls `_record_page_lock_backoff`, which **always** assigns `status="lock_backoff"` — ignoring the prior `processed` record.

--- a/docs/quality/issue-bodies/131-graph-dispatch-resolve-write-toctou.md
+++ b/docs/quality/issue-bodies/131-graph-dispatch-resolve-write-toctou.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/agent/graph_dispatch.py` `_run_write_outline` resolves the write parent in one `asyncio.to_thread` call (`_resolve_write_parent_target`) and performs the write in a second call (`_headless_write_outline` or `_headless_write_outline_empty_page`).

--- a/docs/quality/issue-bodies/132-graph-daemon-post-write-inversion.md
+++ b/docs/quality/issue-bodies/132-graph-daemon-post-write-inversion.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 The graph layer (domain I/O) directly imports orchestration modules:

--- a/docs/quality/issue-bodies/133-tana-streaming-graph-builder.md
+++ b/docs/quality/issue-bodies/133-tana-streaming-graph-builder.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/agent/importers/tana/load.py` `load_tana_nodes_by_id` streams parse via `ijson` but immediately materializes `{node.id: node for node in iter_tana_nodes(export_path)}` — O(nodes) RAM. For large enterprise exports (50k+ nodes), this can consume hundreds of MB before conversion begins; `convert_tana_graph` then builds additional structures.

--- a/docs/quality/issue-bodies/134-generational-cache-lru-cap.md
+++ b/docs/quality/issue-bodies/134-generational-cache-lru-cap.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/graph/generational_cache.py` keeps module-level `_alias_cache` and `_bm25_cache` dicts keyed by resolved graph root string. Per-graph mtime invalidation works, but there is **no cap** on the number of concurrent vault caches.

--- a/docs/quality/issue-bodies/135-phase2-progress-denominator-drift.md
+++ b/docs/quality/issue-bodies/135-phase2-progress-denominator-drift.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 [#70](https://github.com/MarcoPorcellato/matryca-plumber/issues/70) fixed Phase 2 progress **denominator including journals**. A separate UX gap remains:

--- a/docs/quality/issue-bodies/136-tui-daemon-state-dedup-load.md
+++ b/docs/quality/issue-bodies/136-tui-daemon-state-dedup-load.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/cli/tui_dashboard.py` `collect_snapshot_safe` calls `collect_snapshot`, which already loads daemon state via `_try_load_daemon_state`. On success, `collect_snapshot_safe` calls `load_daemon_state(root)` **again** (L236–238).

--- a/docs/quality/issue-bodies/137-tana-content-aware-reimport-v2.md
+++ b/docs/quality/issue-bodies/137-tana-content-aware-reimport-v2.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Tana import v1 idempotency skips subtrees when `tana-id::` already exists in the vault (`src/agent/importers/tana/write.py` `_filter_outline_subtree`). This is **documented intentional** behavior per [`docs/openspec/tana-import.md`](../../openspec/tana-import.md).

--- a/docs/quality/issue-bodies/140-identity-ast-stale-on-reload.md
+++ b/docs/quality/issue-bodies/140-identity-ast-stale-on-reload.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `IdentityConfigStore.reload_if_stale` (`src/daemon/config_layer.py`) treats **config file mtime** as the freshness signal, then loads Telos/Constraints via `_load_from_graph()` → `get_graph_ast_cache(graph_root).get_graph()`.

--- a/docs/quality/issue-bodies/141-routing-hint-enum.md
+++ b/docs/quality/issue-bodies/141-routing-hint-enum.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/agent/routing_hint.py` emits L1/L2 routing markers as **magic strings** in HTML comments:

--- a/docs/quality/issue-bodies/142-semantic-config-injection.md
+++ b/docs/quality/issue-bodies/142-semantic-config-injection.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/semantic/config.py` already centralizes embedding env resolution (`EmbeddingSettings`, `HybridWeights`, `dual_embedding_enabled()`). However `src/semantic/indexer.py` `index_page_blocks` calls `dual_embedding_enabled()` at **call time**, reading `os.environ` indirectly on every indexing invocation.

--- a/docs/quality/issue-bodies/143-graph-analytics-catalog-load-log.md
+++ b/docs/quality/issue-bodies/143-graph-analytics-catalog-load-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `_count_catalog_summaries` in `src/graph/graph_analytics.py` (~L118–124) wraps `load_master_catalog(root)` in bare `except Exception` and returns `0` with **no log line**.

--- a/docs/quality/issue-bodies/144-checkpoint-bak-restore-copy-log.md
+++ b/docs/quality/issue-bodies/144-checkpoint-bak-restore-copy-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `read_daemon_checkpoint` in `src/daemon/checkpoint.py` (~L64–66) recovers from a corrupt primary checkpoint by reading `.matryca_daemon_state.json.bak`, then restores the primary file via `shutil.copy2(bak_path, path)` inside `contextlib.suppress(OSError)`.

--- a/docs/quality/issue-bodies/145-daemon-state-bak-restore-copy-log.md
+++ b/docs/quality/issue-bodies/145-daemon-state-bak-restore-copy-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `load_daemon_state` in `src/agent/maintenance_daemon.py` (~L793–795) mirrors checkpoint recovery: when the primary `.matryca_daemon_state.json` is unreadable, it loads from `.bak` and attempts `shutil.copy2(bak_path, path)` inside `contextlib.suppress(OSError)`.

--- a/docs/quality/issue-bodies/146-daemon-state-bak-write-log.md
+++ b/docs/quality/issue-bodies/146-daemon-state-bak-write-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `save_daemon_state` in `src/agent/maintenance_daemon.py` (~L830–832) atomically writes the primary daemon state, then copies it to `.matryca_daemon_state.json.bak` inside `contextlib.suppress(OSError)`.

--- a/docs/quality/issue-bodies/147-journey-log-upsert-log.md
+++ b/docs/quality/issue-bodies/147-journey-log-upsert-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `_finalize_link_and_journey_pass` in `src/agent/maintenance_daemon.py` (~L2884–2891) wraps `upsert_journey_log(...)` in `contextlib.suppress(OSError)` when journey logging is enabled and the cycle has journal activity.

--- a/docs/quality/issue-bodies/148-watcher-deleted-link-registry-log.md
+++ b/docs/quality/issue-bodies/148-watcher-deleted-link-registry-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `_on_watchdog_change` in `src/agent/maintenance_daemon.py` (~L2117–2119) calls `register_page_links_from_path` when the file watcher reports a **deleted** `.md` page and link verification is enabled. Failures are swallowed via `contextlib.suppress(OSError)`.

--- a/docs/quality/issue-bodies/149-phase2-lint-link-registry-log.md
+++ b/docs/quality/issue-bodies/149-phase2-lint-link-registry-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 During Phase-2 cognitive lint in `run_cycle` (`src/agent/maintenance_daemon.py`, ~L2636–2638), `merge_page_links_into_registry` runs inside `contextlib.suppress(OSError)` before `run_cognitive_lint_pipeline`.

--- a/docs/quality/issue-bodies/150-phase2-end-cycle-totals-log.md
+++ b/docs/quality/issue-bodies/150-phase2-end-cycle-totals-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 At **cycle start**, `run_cycle` already logs `refresh_phase2_cognitive_totals` failures (`logger.warning`, ~L2919–2922). At **cycle end** (~L3043–3045), the same refresh runs inside `contextlib.suppress(OSError)` every 10 vault refresh ticks.

--- a/docs/quality/issue-bodies/151-fast-track-link-registry-log.md
+++ b/docs/quality/issue-bodies/151-fast-track-link-registry-log.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 In `run_cycle`, fast-track skippable files call `register_page_links_from_path` when link verification is enabled (`src/agent/maintenance_daemon.py`, ~L2962–2964). The call is wrapped in `contextlib.suppress(OSError)`.

--- a/docs/quality/issue-bodies/152-plumber-config-env-int-warning.md
+++ b/docs/quality/issue-bodies/152-plumber-config-env-int-warning.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `_env_int` in `src/agent/plumber_config.py` (~L58–65) returns the Python default when `int(raw)` raises `ValueError`, with **no warning**. Operators who typo `MATRYCA_*` numeric env vars get silent fallback behavior.

--- a/docs/quality/issue-bodies/153-occ-mtime-ns-parity.md
+++ b/docs/quality/issue-bodies/153-occ-mtime-ns-parity.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Page-level OCC in `src/graph/markdown_blocks.py` snapshots and compares `st_mtime` as a `float` (`read_file_mtime`, `file_mtime_drifted`).

--- a/docs/quality/issue-bodies/154-tana-slim-nodedump-payloads.md
+++ b/docs/quality/issue-bodies/154-tana-slim-nodedump-payloads.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Tana import streams JSON via `ijson` (no `json.load()` DOM). Production orchestration uses `TanaWorkspaceGraph.from_export` — a **single streaming pass** through `StreamingGraphBuilder`.

--- a/docs/quality/issue-bodies/155-generational-cache-sig-tou.md
+++ b/docs/quality/issue-bodies/155-generational-cache-sig-tou.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `get_cached_bm25_corpus` and `cached_build_alias_index` in `src/graph/generational_cache.py` build the corpus/index, then capture `_signature(...)` **after** the build (`sig_after`), and store `(sig_after, artifact)`.

--- a/docs/quality/issue-bodies/156-tana-id-stream-scan.md
+++ b/docs/quality/issue-bodies/156-tana-id-stream-scan.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `scan_existing_tana_ids` in `src/agent/importers/tana/write.py` calls `read_graph_file_text` for every scannable page/journal, materializing full page bodies in RAM to regex-scan `tana-id::` values.

--- a/docs/quality/issue-bodies/157-lock-registry-acquire-hardening.md
+++ b/docs/quality/issue-bodies/157-lock-registry-acquire-hardening.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `page_write_lock._lock_for_key` evicts LRU registry entries when `not old_lock.locked()` before allocating a new `RLock` for a path (`_MAX_PAGE_LOCK_REGISTRY = 4096`).

--- a/docs/quality/issue-bodies/158-link-verification-env-parse.md
+++ b/docs/quality/issue-bodies/158-link-verification-env-parse.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/graph/link_verification.py` already uses `env_bool` for `MATRYCA_LINK_VERIFY_ENABLED`, but `link_verify_strikes_threshold`, `link_verify_batch_size`, and `link_verify_timeout_seconds` duplicate inline `os.environ.get` + `try/except` parsing (~L73–94).

--- a/docs/quality/issue-bodies/159-generational-cache-env-parse.md
+++ b/docs/quality/issue-bodies/159-generational-cache-env-parse.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/graph/generational_cache.py` reads `MATRYCA_GENERATIONAL_CACHE_MAX_GRAPHS` and `MATRYCA_BM25_MODE` via inline `os.environ.get` in `_generational_cache_max_graphs()` and `_bm25_mode()` (~L32–72).

--- a/docs/quality/issue-bodies/160-plumber-config-env-int-delegate.md
+++ b/docs/quality/issue-bodies/160-plumber-config-env-int-delegate.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/agent/plumber_config.py` defines a private `_env_int` helper that duplicates `src/utils/env_parse.env_int` (warning on invalid values shipped in [#152](https://github.com/MarcoPorcellato/matryca-plumber/issues/152)).

--- a/docs/quality/issue-bodies/161-graph-boundary-forbid-rag.md
+++ b/docs/quality/issue-bodies/161-graph-boundary-forbid-rag.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `tests/test_graph_layer_boundary.py` forbids `src/graph/` from importing `agent` and `daemon`, enforcing the v1.11.2 layer inversion ([#134](https://github.com/MarcoPorcellato/matryca-plumber/issues/134)).

--- a/docs/quality/issue-bodies/162-concurrency-probe-env-bool.md
+++ b/docs/quality/issue-bodies/162-concurrency-probe-env-bool.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `src/graph/concurrency_probe.py` reads `MATRYCA_ALLOW_FLOCK_DEGRADATION` with inline `os.environ.get` and manual truthy-token parsing (~L33).

--- a/docs/quality/issue-bodies/163-env-parse-clamp-contract-tests.md
+++ b/docs/quality/issue-bodies/163-env-parse-clamp-contract-tests.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 After Tier F slices migrate clamped env reads to `env_parse`, the **clamp-after-parse** pattern (e.g. `max(1, min(200, env_int(...)))`) should be documented by tests so contributors do not reintroduce silent inline parsing in `src/graph/`.

--- a/docs/quality/issue-bodies/164-bounded-parse-receive-deadline.md
+++ b/docs/quality/issue-bodies/164-bounded-parse-receive-deadline.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `BoundedPageParseWorker.parse_text` (`src/graph/bounded_page_parse.py`) bounds the wait for a worker response with `self._out_q.get(timeout=deadline)`. `multiprocessing.Queue.get(timeout=...)` only bounds the wait for the pipe to become *readable*; once readable it falls through to an unconditional `recv_bytes()`, which can still block past the configured deadline while a large or partial response is still being received.

--- a/docs/quality/issue-bodies/shadow-page-parse-quarantine.md
+++ b/docs/quality/issue-bodies/shadow-page-parse-quarantine.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Shadow DB: per-page quarantine for over-budget page parses
 
 ## Problem Description

--- a/docs/quality/issue-bodies/v2-alpha-hardening-a1-meta-01.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening-a1-meta-01.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `resolve_shadow_health` returns **`ready`** when `last_full_sync_completed=true` and `last_sync_error` is empty, **without validating** that `shadow_meta` row counts match the actual `pages` table.

--- a/docs/quality/issue-bodies/v2-alpha-hardening.md
+++ b/docs/quality/issue-bodies/v2-alpha-hardening.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0-alpha hardening — tracking issue
 
 ## Problem Description

--- a/docs/quality/issue-bodies/v2-beta-readiness.md
+++ b/docs/quality/issue-bodies/v2-beta-readiness.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0.0-beta.1 readiness — decision record
 
 ## Problem Description

--- a/docs/quality/issue-bodies/v2-external-shadow-cache-read-only.md
+++ b/docs/quality/issue-bodies/v2-external-shadow-cache-read-only.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2 RC: external Shadow cache compatible with strict Logseq read-only mode
 
 ## Decision

--- a/docs/quality/issue-bodies/v2-phase0-prerequisites.md
+++ b/docs/quality/issue-bodies/v2-phase0-prerequisites.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 v2.0 Shadow DB sync and read routing depend on a modular daemon duty cycle and a thin `graph_dispatch` router. Large monoliths ([#58](https://github.com/MarcoPorcellato/matryca-plumber/issues/58), [#59](https://github.com/MarcoPorcellato/matryca-plumber/issues/59)) increase merge risk for shadow hooks.

--- a/docs/quality/issue-bodies/v2-phase1-dispatch-read-delegate.md
+++ b/docs/quality/issue-bodies/v2-phase1-dispatch-read-delegate.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 `graph_dispatch` imports graph helpers directly — bypassing any repository port introduced in the graph-read-port slice.

--- a/docs/quality/issue-bodies/v2-phase1-graph-read-port.md
+++ b/docs/quality/issue-bodies/v2-phase1-graph-read-port.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Phase 1 requires a stable read contract before shadow adapters plug in. No `GraphReadPort` exists today.

--- a/docs/quality/issue-bodies/v2-phase1-graph-repository.md
+++ b/docs/quality/issue-bodies/v2-phase1-graph-repository.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 All v2 read routing must pass through a storage abstraction ([#17](https://github.com/MarcoPorcellato/matryca-plumber/issues/17)). Today `graph_dispatch` calls `src/graph/*` directly — no testable port, no shadow adapter slot.

--- a/docs/quality/issue-bodies/v2-phase2-fts5-search.md
+++ b/docs/quality/issue-bodies/v2-phase2-fts5-search.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Shadow FTS5 table `blocks_fts` is created by schema but no query API exists for agent search paths.

--- a/docs/quality/issue-bodies/v2-phase2-post-write-sync.md
+++ b/docs/quality/issue-bodies/v2-phase2-post-write-sync.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Shadow tables stay empty until Markdown edits flow into `pages`/`blocks` rows. Phase 2 requires incremental sync, not full-vault rescans on every bullet edit.

--- a/docs/quality/issue-bodies/v2-phase2-shadow-open-connection.md
+++ b/docs/quality/issue-bodies/v2-phase2-shadow-open-connection.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 [`src/shadow/schema.py`](../../../src/shadow/schema.py) defines DDL and `apply_shadow_schema()` but no production helper opens `shadow.sqlite` under the graph root with correct pragmas and path sandboxing.

--- a/docs/quality/issue-bodies/v2-phase2-shadow-sync.md
+++ b/docs/quality/issue-bodies/v2-phase2-shadow-sync.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Shadow DB DDL exists ([`src/shadow/schema.py`](../../../src/shadow/schema.py)) but no runtime sync populates `pages`/`blocks` from Markdown edits.

--- a/docs/quality/issue-bodies/v2-phase3-read-routing.md
+++ b/docs/quality/issue-bodies/v2-phase3-read-routing.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Shadow sync (Phase 2) must be opt-in before v2.0.0-rc. Operators and agents need predictable fallback when shadow is disabled or stale.

--- a/docs/quality/issue-bodies/v2-phase3-shadow-env-flag.md
+++ b/docs/quality/issue-bodies/v2-phase3-shadow-env-flag.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Phase 3 alpha requires an explicit operator opt-in before MCP/CLI prefer shadow reads.

--- a/docs/quality/issue-bodies/v2-phase3-ui-shadow-health.md
+++ b/docs/quality/issue-bodies/v2-phase3-ui-shadow-health.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Operators need visibility into shadow sync health without a `matryca doctor` command (`llms.txt` §2.3).

--- a/docs/quality/issue-bodies/v2-phase4-memory-safesync.md
+++ b/docs/quality/issue-bodies/v2-phase4-memory-safesync.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Biological memory (Nacre-inspired) and Logseq DB Safe-Sync writes are the long-tail v2 deliverables after shadow read path stabilizes.

--- a/docs/quality/issue-bodies/v2-phase4-recall-search-method.md
+++ b/docs/quality/issue-bodies/v2-phase4-recall-search-method.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 ## Problem Description
 
 Biological memory requires a unified recall entry point for agents — beyond separate bm25/semantic/hops calls.

--- a/docs/quality/issue-bodies/v2-rc-stable-readiness.md
+++ b/docs/quality/issue-bodies/v2-rc-stable-readiness.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0.0 RC and stable readiness — decision record
 
 > **Final status — 2026-08-18:** `v2.0.0` is published as the stable Shadow

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,11 +1,3 @@
----
-type: Reference Index
-title: Matryca Plumber reference index
-description: Navigation for technical, operational, and integration reference material.
-status: active
-last_verified: 2026-08-16
----
-
 # Matryca Plumber reference index
 
 - [System architecture](../ARCHITECTURE.md)

--- a/docs/releases/v1.10.0-GITHUB.md
+++ b/docs/releases/v1.10.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.0 (copy-paste)
 
 **Title:** v1.10.0 - Catalog Integrity & OSS Maturity

--- a/docs/releases/v1.10.2-GITHUB.md
+++ b/docs/releases/v1.10.2-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.2 (copy-paste)
 
 **Title:** v1.10.2 - Fast Test Gate & CI Fixes

--- a/docs/releases/v1.10.3-GITHUB.md
+++ b/docs/releases/v1.10.3-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.3 (copy-paste)
 
 **Title:** v1.10.3 - Infrastructure Hardening & Sovereign UI Resilience

--- a/docs/releases/v1.10.4-GITHUB.md
+++ b/docs/releases/v1.10.4-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.4 (copy-paste)
 
 **Title:** v1.10.4 - Dependency Maintenance & CI Toolchain

--- a/docs/releases/v1.10.5-GITHUB.md
+++ b/docs/releases/v1.10.5-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.5 (copy-paste)
 
 **Title:** v1.10.5 - Logseq Matryca Parser 1.3.1 Alignment

--- a/docs/releases/v1.10.6-GITHUB.md
+++ b/docs/releases/v1.10.6-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.10.6 (copy-paste)
 
 **Title:** v1.10.6 - Concurrency Integrity (Unified Flock + Hub Page OCC)

--- a/docs/releases/v1.11.0-GITHUB.md
+++ b/docs/releases/v1.11.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.11.0 (copy-paste)
 
 **Title:** v1.11.0 - Tana → Logseq OG Migration

--- a/docs/releases/v1.11.1-GITHUB.md
+++ b/docs/releases/v1.11.1-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.11.1 (copy-paste)
 
 **Title:** v1.11.1 - Logseq Matryca Parser 1.4.0 Alignment

--- a/docs/releases/v1.11.2-GITHUB.md
+++ b/docs/releases/v1.11.2-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.11.2 (copy-paste)
 
 **Title:** v1.11.2 - Graph Layer Boundary Refactor

--- a/docs/releases/v1.12.0-GITHUB.md
+++ b/docs/releases/v1.12.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.12.0 (copy-paste)
 
 **Title:** v1.12.0 - Prompt Clean Architecture

--- a/docs/releases/v1.12.1-GITHUB.md
+++ b/docs/releases/v1.12.1-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.12.1 (copy-paste)
 
 **Title:** v1.12.1 - Contributor hygiene & v2 preparation index

--- a/docs/releases/v1.13.0-GITHUB.md
+++ b/docs/releases/v1.13.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.13.0 (copy-paste)
 
 **Title:** v1.13.0 - Daemon & dispatch modularization (v2 Phase 0–1)

--- a/docs/releases/v1.13.1-GITHUB.md
+++ b/docs/releases/v1.13.1-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.13.1 (copy-paste)
 
 **Title:** v1.13.1 - Logseq Matryca Parser 1.6.0 Alignment

--- a/docs/releases/v1.14.0-GITHUB.md
+++ b/docs/releases/v1.14.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.14.0 (copy-paste)
 
 **Title:** v1.14.0 - Catalog Write-Safety & Leaf-Module Dependency Direction

--- a/docs/releases/v1.9.10-GITHUB.md
+++ b/docs/releases/v1.9.10-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.10 (copy-paste)
 
 **Title:** v1.9.10 - Sovereign UI Fast Startup

--- a/docs/releases/v1.9.11-GITHUB.md
+++ b/docs/releases/v1.9.11-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.11 (copy-paste)
 
 **Title:** v1.9.11 - Sovereign UI Reliability (Large Vaults)

--- a/docs/releases/v1.9.13-GITHUB.md
+++ b/docs/releases/v1.9.13-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.13 (copy-paste)
 
 **Title:** v1.9.13 - Enterprise Resilience Update

--- a/docs/releases/v1.9.14-GITHUB.md
+++ b/docs/releases/v1.9.14-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.14 (copy-paste)
 
 **Title:** v1.9.14 - Contributor Readiness & Tech Debt Cleanup

--- a/docs/releases/v1.9.15-GITHUB.md
+++ b/docs/releases/v1.9.15-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.15 (copy-paste)
 
 **Title:** v1.9.15 - Strict Mypy Compliance & Journal Phase-2 Bypass

--- a/docs/releases/v1.9.3-GITHUB.md
+++ b/docs/releases/v1.9.3-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.3 (copy-paste)
 
 **Title:** v1.9.3 - The "Live Telemetry" Update

--- a/docs/releases/v1.9.4-GITHUB.md
+++ b/docs/releases/v1.9.4-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.4 (copy-paste)
 
 **Title:** v1.9.4 - The "Clean Journal" Update

--- a/docs/releases/v1.9.5-GITHUB.md
+++ b/docs/releases/v1.9.5-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.5 (copy-paste)
 
 **Title:** v1.9.5 - The "LLM OS" Update

--- a/docs/releases/v1.9.6-GITHUB.md
+++ b/docs/releases/v1.9.6-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.6 (copy-paste)
 
 **Title:** v1.9.6 - Hermes Agent & Lazy AST Handshake

--- a/docs/releases/v1.9.7-GITHUB.md
+++ b/docs/releases/v1.9.7-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.7 (copy-paste)
 
 **Title:** v1.9.7 - Agent Experience (AX) Robustness & Lenient Resolution

--- a/docs/releases/v1.9.8-GITHUB.md
+++ b/docs/releases/v1.9.8-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.8 (copy-paste)
 
 **Title:** v1.9.8 - Documentation Harmonization (AX Robustness)

--- a/docs/releases/v1.9.9-GITHUB.md
+++ b/docs/releases/v1.9.9-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v1.9.9 (copy-paste)
 
 **Title:** v1.9.9 - Security & Sandbox Hardening

--- a/docs/releases/v2.0.0-BLOG_ARTICLE_DRAFT.md
+++ b/docs/releases/v2.0.0-BLOG_ARTICLE_DRAFT.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Blog article draft — After the Agentic Memory Dilemma
 
 **Intended site:** [marcoporcellato.it](https://www.marcoporcellato.it/)  

--- a/docs/releases/v2.0.0-GITHUB.md
+++ b/docs/releases/v2.0.0-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0 Stable
 
 **Tag:** [`v2.0.0`](https://github.com/MarcoPorcellato/matryca-plumber/releases/tag/v2.0.0)  

--- a/docs/releases/v2.0.0-alpha-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha (copy-paste)
 
 > **Superseded for new installs by [`v2.0.0-alpha.1`](v2.0.0-alpha.1-GITHUB.md)** — PyPI `2.0.0a0` remains published (not yanked).

--- a/docs/releases/v2.0.0-alpha.1-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha.1-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha.1 (editorial copy-paste)
 
 > **Workflow source of truth:** CI creates the GitHub Release body from

--- a/docs/releases/v2.0.0-alpha.2-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha.2-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha.2 (editorial copy-paste)
 
 > **Workflow source of truth:** CI creates the GitHub Release body from

--- a/docs/releases/v2.0.0-alpha.3-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha.3-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha.3 (editorial copy-paste)
 
 > **Workflow source of truth:** CI creates the GitHub Release body from

--- a/docs/releases/v2.0.0-alpha.4-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha.4-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha.4 (editorial copy-paste)
 
 > **Workflow source of truth:** CI creates the GitHub Release body from

--- a/docs/releases/v2.0.0-alpha.5-GITHUB.md
+++ b/docs/releases/v2.0.0-alpha.5-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # GitHub Release — v2.0.0-alpha.5 (editorial copy-paste)
 
 > **Workflow source of truth:** CI creates the GitHub Release body from

--- a/docs/releases/v2.0.0-beta.1-GITHUB.md
+++ b/docs/releases/v2.0.0-beta.1-GITHUB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0.0-beta.1
 
 > **First public beta** of the opt-in Shadow read path, published on PyPI as `2.0.0b1`. The flag stays default-off and Logseq Markdown stays the system of record.

--- a/docs/resilience-llm-json-triz.md
+++ b/docs/resilience-llm-json-triz.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Resilient structured output — TRIZ applied to local LLMs
 
 **Status:** Shipped (see [`CHANGELOG.md`](../CHANGELOG.md) under `[1.10.3]` / recent releases).  

--- a/docs/roadmaps/ROADMAP_IRONCLAD_SHIELD.md
+++ b/docs/roadmaps/ROADMAP_IRONCLAD_SHIELD.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Phase 8 — Ironclad Shield (checklist)
 
 Actionable checklist for global fence scanning, transactional writes, and generational caching.

--- a/docs/roadmaps/ROADMAP_LLM_WIKI.md
+++ b/docs/roadmaps/ROADMAP_LLM_WIKI.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Roadmap: LLM-Wiki patterns → Matryca Plumber (FastMCP / Logseq OG)
 
 Actionable checklist derived from [MehmetGoekce/llm-wiki](https://github.com/MehmetGoekce/llm-wiki) (L1/L2 architecture, openspec ingest/lint, schema templates, dashboard hub) adapted to **this** repo: **FastMCP**, **uv**, **loguru**, **Pydantic**, **async/await**, external **`logseq-matryca-parser`**, **no SQLite**. Prefer MCP tools + on-disk graph reads over Claude Code slash commands.

--- a/docs/roadmaps/ROADMAP_LLM_WIKI_PHASE_3.md
+++ b/docs/roadmaps/ROADMAP_LLM_WIKI_PHASE_3.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Phase 3 roadmap — High-safety PKM + deep outliner tools (no Postgres)
 
 Actionable checklist aligned with **pure Logseq OG**: on-disk Markdown, **`logseq_matryca_parser`** for spatial truth where structure matters, **FastMCP** tools, and **no PostgreSQL**, **no embeddings**, **no PyMuPDF/VLM ingestion**.

--- a/docs/roadmaps/ROADMAP_LOGSEQ_SUPERPOWERS.md
+++ b/docs/roadmaps/ROADMAP_LOGSEQ_SUPERPOWERS.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Phase 4: Logseq Native Superpowers
 
 Actionable roadmap to evolve the MCP agent into a **proactive knowledge manager** using Logseq-native syntax only: **Advanced Queries**, **journal/task conventions**, and **`alias::` resolution**. All work stays in the **pure local Markdown / outliner** paradigm: **no new databases**, **no new Markdown parsers** beyond the existing **`logseq-matryca-parser`** integration; graph logic uses **string scanning**, **regex / line-based helpers**, **FastMCP** tools, and existing bridges (`LogseqClient`, surgical property editing).

--- a/docs/roadmaps/ROADMAP_MLDOC_COMPLIANCE.md
+++ b/docs/roadmaps/ROADMAP_MLDOC_COMPLIANCE.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Roadmap: mldoc-aligned graph tools (Phase 7)
 
 Pure-Python structural rules inspired by the official Logseq Markdown/Org compiler (`logseq/mldoc`): no Rust/Clojure runtime, no external binary parser.

--- a/docs/roadmaps/ROADMAP_PHASE_5_6.md
+++ b/docs/roadmaps/ROADMAP_PHASE_5_6.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Phase 5 & 6 — Graph Gardener + Synthesis Engine
 
 Actionable checklist for overnight implementation. **Constraints:** pure Markdown on disk, FastMCP tools, Logseq OG (no external DB). Reference repos inform behavior only (not vendored).

--- a/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
+++ b/docs/roadmaps/ROADMAP_V2_BIOLOGICAL_MEMORY.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.1+ — Biological Memory Layer (evidence-first)
 
 **Historical architecture context:** [#20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)

--- a/docs/roadmaps/ROADMAP_V2_PREPARATION.md
+++ b/docs/roadmaps/ROADMAP_V2_PREPARATION.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0 Preparation — Visitor & Maintainer Guide
 
 **North star:** [Epic #20 — v2.0.0 Shadow DB & Safe-Sync](https://github.com/MarcoPorcellato/matryca-plumber/issues/20)  

--- a/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
+++ b/docs/roadmaps/ROADMAP_V2_SHADOW_DB.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # v2.0 — Shadow DB read path (checklist)
 
 **Detailed index:** [`ROADMAP_V2_PREPARATION.md`](ROADMAP_V2_PREPARATION.md) — visitor SSOT for all five v2 phases  

--- a/docs/v1.8-OPTIMIZATION-PLAN.md
+++ b/docs/v1.8-OPTIMIZATION-PLAN.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Matryca Plumber v1.8 — Edge Computing & Performance Update
 
 **Status:** Core edge profile shipped in **1.8.0** (see [`CHANGELOG.md`](../CHANGELOG.md) `[1.8.0]`). **Round 4 audit** hardening is in `[Unreleased]` — same strategic constraint (no new cognitive features).  

--- a/docs/v1.8-SOFTWARE-EDGE-PLAN.md
+++ b/docs/v1.8-SOFTWARE-EDGE-PLAN.md
@@ -1,3 +1,6 @@
+---
+type: Document
+---
 # Matryca Plumber v1.8.0 — Edge Software Optimization Plan
 
 **Status:** Shipped in **1.8.0** (see [`CHANGELOG.md`](../CHANGELOG.md) `[1.8.0]`).  

--- a/scripts/build_system_prompt.py
+++ b/scripts/build_system_prompt.py
@@ -103,8 +103,7 @@ def assemble_document(*, version: str | None = None) -> str:
         parts.append(f"<!-- package-version: v{version} -->")
     parts.append("")
     parts.extend(
-        strip_frontmatter(fragment.read_text(encoding="utf-8")).strip()
-        for fragment in paths
+        strip_frontmatter(fragment.read_text(encoding="utf-8")).strip() for fragment in paths
     )
     return "\n\n".join(parts).rstrip() + "\n"
 

--- a/scripts/build_system_prompt.py
+++ b/scripts/build_system_prompt.py
@@ -83,6 +83,18 @@ def compute_source_hash(paths: list[Path]) -> str:
     return digest.hexdigest()
 
 
+def strip_frontmatter(text: str) -> str:
+    """Remove an OKF YAML frontmatter block from a prompt fragment."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    try:
+        end = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
+        return text
+    return "\n".join(lines[end + 1 :])
+
+
 def assemble_document(*, version: str | None = None) -> str:
     paths = fragment_paths()
     source_hash = compute_source_hash(paths)
@@ -90,7 +102,10 @@ def assemble_document(*, version: str | None = None) -> str:
     if version:
         parts.append(f"<!-- package-version: v{version} -->")
     parts.append("")
-    parts.extend(fragment.read_text(encoding="utf-8").strip() for fragment in paths)
+    parts.extend(
+        strip_frontmatter(fragment.read_text(encoding="utf-8")).strip()
+        for fragment in paths
+    )
     return "\n\n".join(parts).rstrip() + "\n"
 
 

--- a/scripts/check_agents_coherence.py
+++ b/scripts/check_agents_coherence.py
@@ -83,9 +83,7 @@ def check_agent_onboarding_version(version: str) -> None:
     if lines and lines[0].strip() == "---":
         try:
             end = next(
-                index
-                for index, line in enumerate(lines[1:], start=1)
-                if line.strip() == "---"
+                index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"
             )
         except StopIteration:
             end = -1

--- a/scripts/check_agents_coherence.py
+++ b/scripts/check_agents_coherence.py
@@ -79,7 +79,19 @@ def check_llms_byte_identity() -> None:
 
 def check_agent_onboarding_version(version: str) -> None:
     path = ROOT / "docs" / "openspec" / "agent-onboarding.md"
-    first_line = path.read_text(encoding="utf-8").splitlines()[0]
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if lines and lines[0].strip() == "---":
+        try:
+            end = next(
+                index
+                for index, line in enumerate(lines[1:], start=1)
+                if line.strip() == "---"
+            )
+        except StopIteration:
+            end = -1
+        if end >= 0:
+            lines = lines[end + 1 :]
+    first_line = next((line for line in lines if line.strip()), "")
     expected = f"v{version}"
     if expected not in first_line:
         _fail(

--- a/scripts/docs_knowledge_check.py
+++ b/scripts/docs_knowledge_check.py
@@ -1790,7 +1790,10 @@ def _check_bundle_report() -> ValidationReport:
                         path=_finding_path(index_path, f"docs/knowledge/{rel}"),
                         pointer="frontmatter",
                         parameters={"expected_okf_version": OKF_VERSION},
-                        message=f"{rel}: root index frontmatter must declare okf_version: {OKF_VERSION!r}",
+                        message=(
+                            f"{rel}: root index frontmatter must declare "
+                            f"okf_version: {OKF_VERSION!r}"
+                        ),
                     )
                 )
         elif meta is not None:

--- a/scripts/docs_knowledge_check.py
+++ b/scripts/docs_knowledge_check.py
@@ -1782,7 +1782,7 @@ def _check_bundle_report() -> ValidationReport:
             continue
         meta, body = parsed
         if index_path == KNOWLEDGE_DIR / "index.md":
-            if meta != {"okf_version": OKF_VERSION}:
+            if meta is not None and meta.get("okf_version") != OKF_VERSION:
                 findings.append(
                     _finding(
                         layer="official_okf",
@@ -1790,10 +1790,7 @@ def _check_bundle_report() -> ValidationReport:
                         path=_finding_path(index_path, f"docs/knowledge/{rel}"),
                         pointer="frontmatter",
                         parameters={"expected_okf_version": OKF_VERSION},
-                        message=(
-                            f"{rel}: root index frontmatter must contain only "
-                            f"okf_version: {OKF_VERSION!r}"
-                        ),
+                        message=f"{rel}: root index frontmatter must declare okf_version: {OKF_VERSION!r}",
                     )
                 )
         elif meta is not None:


### PR DESCRIPTION
## Summary\n- apply the deterministic official OKF v0.2 source migration\n- preserve document bodies and existing Matryca metadata\n- align the local documentation validator with reserved nested-index semantics\n\n## Evidence\n- exact head: 8df8ece\n- official OKF v0.2 and Matryca-v1 migration; docs-check PASS with zero findings; diff-check PASS; source validator aligned for nested indexes and root extensions\n\nSource repositories remain authoritative; generated Knowledge projections are refreshed only after merge.