### PR TITLE
ci: avoid duplicate documentation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
           npm run test
           npm run build
 
-      - name: Docs knowledge check
-        run: make docs-check
-
       - name: Legacy documentation audit (informational)
         continue-on-error: true
         run: make docs-audit


### PR DESCRIPTION
## Summary
- remove the standalone documentation knowledge check from CI
- retain the same blocking gate through `make ci`

## Test plan
- [x] `python3 scripts/docs_knowledge_check.py check-bundle`
- [x] verified `make ci` invokes the documentation gate exactly once