### PR TITLE
ci: cancel superseded CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
## Summary
- cancel superseded CodeQL runs for the same workflow and ref
- preserve existing push, pull-request, and scheduled analysis triggers

## Test plan
- [x] parsed `.github/workflows/codeql.yml` as YAML
- [x] verified the concurrency group and `cancel-in-progress` values