### PR TITLE
fix(config): fsync directory after dotenv replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   until the reviewed CCP source supports matrix-aware diagnosis and mount
   rendering.
 
+### Fixed
+
+- **Operator configuration durability** — fsync the parent directory after
+  atomically replacing `.env`, preserving existing optimistic-concurrency and
+  cleanup behavior.
+
 ## [2.0.1-rc.1] - 2026-08-23
 
 ### Added

--- a/src/cli/ui_server.py
+++ b/src/cli/ui_server.py
@@ -607,6 +607,14 @@ def _atomic_write_text(
             raise _DotenvConflictError("dotenv changed before atomic replacement")
         os.replace(tmp_path, path)
         committed = True
+        try:
+            directory_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
     finally:
         if not committed:
             tmp_path.unlink(missing_ok=True)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -645,6 +645,65 @@ def test_dotenv_atomic_replace_failure_preserves_source_and_cleans_temp(
     assert not list(tmp_path.glob("..env.*.tmp"))
 
 
+def test_dotenv_atomic_replace_fsyncs_parent_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.cli import ui_server
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("SETTING=original\n", encoding="utf-8")
+    events: list[str] = []
+    directory_fd = 987_654
+    real_open = os.open
+    real_close = os.close
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def track_open(
+        path: str | os.PathLike[str],
+        flags: int,
+        mode: int = 0o777,
+    ) -> int:
+        if Path(path) == tmp_path:
+            events.append("directory-open")
+            return directory_fd
+        return real_open(path, flags, mode)
+
+    def track_fsync(fd: int) -> None:
+        if fd == directory_fd:
+            events.append("directory-fsync")
+            return
+        events.append("file-fsync")
+        real_fsync(fd)
+
+    def track_replace(source: Path, target: Path) -> None:
+        events.append("replace")
+        real_replace(source, target)
+
+    def track_close(fd: int) -> None:
+        if fd == directory_fd:
+            events.append("directory-close")
+            return
+        real_close(fd)
+
+    monkeypatch.setattr("src.cli.ui_server.os.open", track_open)
+    monkeypatch.setattr("src.cli.ui_server.os.fsync", track_fsync)
+    monkeypatch.setattr("src.cli.ui_server.os.replace", track_replace)
+    monkeypatch.setattr("src.cli.ui_server.os.close", track_close)
+
+    ui_server._apply_dotenv_updates({"SETTING": "updated"}, env_path=env_path)
+
+    assert env_path.read_text(encoding="utf-8") == "SETTING=updated\n"
+    assert events == [
+        "file-fsync",
+        "replace",
+        "directory-open",
+        "directory-fsync",
+        "directory-close",
+    ]
+
+
 @pytest.mark.parametrize("endpoint", ["/api/config", "/api/config/graph-path"])
 def test_config_updates_return_typed_dotenv_conflict(
     endpoint: str,

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -663,7 +663,7 @@ def test_dotenv_atomic_replace_fsyncs_parent_directory(
     def track_open(
         path: str | os.PathLike[str],
         flags: int,
-        mode: int = 0o777,
+        mode: int = 0o600,
     ) -> int:
         if Path(path) == tmp_path:
             events.append("directory-open")


### PR DESCRIPTION
## Summary
- fsync the dotenv parent directory after atomic replacement
- add a regression test covering file fsync, replacement, directory fsync, and close ordering

## Test plan
- [x] focused dotenv tests
- [x] Ruff
- [x] mypy
- [x] make ci