### PR TITLE
fix(git): isolate robot commit paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - **Operator configuration durability** — fsync the parent directory after
   atomically replacing `.env`, preserving existing optimistic-concurrency and
   cleanup behavior.
+- **Surgical robot commits** — commit only the requested Markdown paths while
+  preserving unrelated user-staged Git changes exactly.
 
 ## [2.0.1-rc.1] - 2026-08-23
 

--- a/src/daemon/git_audit.py
+++ b/src/daemon/git_audit.py
@@ -104,13 +104,13 @@ def robot_git_commit(
 
     try:
         repo.index.add(rel_paths)
-        if not repo.index.diff("HEAD"):
+        if not repo.index.diff("HEAD", paths=tuple(rel_paths)):
             return {
                 "committed": False,
                 "skipped": True,
                 "reason": "no changes to commit for staged paths",
             }
-        repo.index.commit(message)
+        repo.git.commit("--only", "-m", message, "--", *rel_paths)
     except Exception as exc:  # noqa: BLE001 - never crash writers
         logger.error("Robot git commit failed under {}: {}", root, exc)
         return {

--- a/tests/test_git_audit.py
+++ b/tests/test_git_audit.py
@@ -42,19 +42,28 @@ def test_robot_git_commit_stages_only_target_file(
 
     target.write_text("- hello world\n", encoding="utf-8")
     other.write_text("- other changed\n", encoding="utf-8")
+    _git(["add", "pages/b.md"], tmp_path)
 
     result = robot_git_commit(tmp_path, [target], "updated page a")
     assert result.get("committed") is True
 
-    status = subprocess.run(
-        ["git", "status", "--porcelain"],
+    committed_paths = subprocess.run(
+        ["git", "show", "--format=", "--name-only", "HEAD"],
         cwd=str(tmp_path),
         capture_output=True,
         text=True,
         check=True,
     )
-    assert "pages/a.md" not in status.stdout or status.stdout.strip() == ""
-    assert "pages/b.md" in status.stdout
+    assert committed_paths.stdout.splitlines() == ["pages/a.md"]
+
+    staged_paths = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert staged_paths.stdout.splitlines() == ["pages/b.md"]
 
 
 def test_path_is_sensitive_for_git() -> None:


### PR DESCRIPTION
## Summary

- Commit only the Markdown paths requested by the robot writer.
- Preserve unrelated pre-staged user changes exactly.
- Add regression coverage for selective commit behavior.

## Verification

- `make ci`
- Focused Git audit regression tests
- Ruff and mypy
- Signed commit verification