### PR TITLE
fix(quality): bind Gate B to exact candidate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Version-bound Gate B qualification** — require each durable soak campaign to
+  declare and verify its exact installed candidate version instead of retaining a
+  runner-local version from an earlier release candidate.
+
 ## [2.0.1-rc.3] - 2026-08-31
 
 `v2.0.1-rc.3` is the fresh publication candidate after the signed

--- a/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
+++ b/docs/quality/GATE_B_RC_SOAK_RUNBOOK.md
@@ -4,8 +4,8 @@ type: Document
 # Gate B public-RC soak runbook
 
 This runbook starts the two independent, fail-closed soak profiles required by
-the `v2.0.0` Gate B decision. Each campaign runs against one exact installed
-public candidate wheel, never a source checkout.
+a Gate B release decision. Each campaign runs against one exact installed public
+candidate wheel, never a source checkout.
 
 ## RC2 terminal result
 
@@ -23,8 +23,9 @@ stable artifact or complete the other v2.0.0 promotion gates.
 ## Post-RC read-path requalification boundary
 
 Each public-RC campaign records evidence only for its exact installed wheel. The
-historical rc.1 results below apply only to `2.0.0rc1`; the current campaign must
-start from zero and bind both profiles to the exact public `2.0.0rc2` wheel. Issue
+historical rc.1 and rc.2 results apply only to their respective `2.0.0` candidate
+wheels; every later campaign must start from zero and bind both profiles to its own
+exact public wheel. Issue
 [#389](https://github.com/MarcoPorcellato/matryca-plumber/issues/389) changes the FTS
 and subtree paths exercised by both profiles by adding requested-row freshness checks
 and explicit Markdown/BM25 fallback reasons. Do not rewrite or transfer the RC result
@@ -139,9 +140,10 @@ SQLite state manually; preserve the failed attempt and correct the harness.
    exact wheel.
 3. Freeze the committed qualification runner outside the repository, vault,
    working copies, cache roots, and evidence roots; record its commit and digest.
-4. Pass the verified wheel path and published SHA-256 to each profile. The
-   collector verifies the installed package RECORD, records the exact wheel
-   binding, and refuses to start the soak if either identity differs.
+4. Pass the exact PEP 440 distribution version, verified wheel path, and published
+   SHA-256 to each profile. The collector verifies the installed package RECORD,
+   records the exact package and wheel binding, and refuses to start the soak if any
+   identity differs.
 5. Copy the private source vault once per profile. Never point either collector
    at the live vault.
 
@@ -153,6 +155,7 @@ Use the profile-specific paths in this template:
 <candidate-python> <frozen-runner>/scripts/qualify_gate_b_soak.py \
   --profile <default-on|read-only-external> \
   --output <evidence-root> \
+  --candidate-package <distribution-version> \
   --candidate-python <candidate-python> \
   --candidate-wheel <verified-public-wheel> \
   --expected-wheel-sha256 <published-wheel-sha256> \

--- a/scripts/qualify_gate_b_soak.py
+++ b/scripts/qualify_gate_b_soak.py
@@ -24,6 +24,7 @@ from beta_evidence.core import (
     _canonical_hash,
     _is_within,
     _record_gate,
+    _require_matching_gate_input,
 )
 from beta_evidence.soak import collect_soak
 from beta_evidence.wheel import _copy_vault_without_cache, _verify_candidate_python
@@ -33,7 +34,6 @@ Profile = Literal["default-on", "read-only-external"]
 _PROFILE_FILE = "gate-b-profile.json"
 _PROFILE_SCHEMA_VERSION = 1
 _PROFILES: tuple[Profile, ...] = ("default-on", "read-only-external")
-_RC_PACKAGE = "2.0.0rc2"
 _SHA256 = re.compile(r"[0-9a-f]{64}")
 
 _DEFAULT_ON_PROBE = r"""
@@ -380,6 +380,7 @@ def _bind_manifest(output: Path, profile: Profile, cache_root: Path, working: Pa
 def _bind_public_rc_wheel(
     output: Path,
     *,
+    candidate_package: str,
     candidate_python: Path,
     candidate_wheel: Path,
     expected_wheel_sha256: str,
@@ -398,9 +399,12 @@ def _bind_public_rc_wheel(
     wheel_sha256 = _sha256(wheel.read_bytes())
     if wheel_sha256 != expected_wheel_sha256:
         raise EvidenceError("wheel_sha256_mismatch")
-    provenance = _verify_candidate_python(python, _RC_PACKAGE)
+    provenance = _verify_candidate_python(python, candidate_package)
     binding = _candidate_wheel_binding_digest(wheel_sha256, provenance)
-    input_hash = _canonical_hash({"candidate_package": _RC_PACKAGE, "wheel_sha256": wheel_sha256})
+    input_hash = _canonical_hash(
+        {"candidate_package": candidate_package, "wheel_sha256": wheel_sha256}
+    )
+    _require_matching_gate_input(output, gate_id="wheel", input_hash=input_hash)
     _record_gate(
         output,
         GateRecord(
@@ -408,14 +412,14 @@ def _bind_public_rc_wheel(
             input_hash,
             "PASS",
             {
-                "candidate_package": _RC_PACKAGE,
+                "candidate_package": candidate_package,
                 "wheel_sha256": wheel_sha256,
                 "candidate_provenance_digest": provenance,
                 "candidate_wheel_binding_digest": binding,
                 "installed_record_verified": True,
             },
         ),
-        metadata={"candidate_package": _RC_PACKAGE},
+        metadata={"candidate_package": candidate_package},
     )
     return provenance
 
@@ -502,6 +506,7 @@ def run_gate_b_soak(
     *,
     profile: Profile,
     output: Path,
+    candidate_package: str,
     candidate_python: Path,
     candidate_wheel: Path,
     expected_wheel_sha256: str,
@@ -533,6 +538,7 @@ def run_gate_b_soak(
         raise EvidenceError("candidate_artifact_unsafe")
     candidate_provenance = _bind_public_rc_wheel(
         resolved_output,
+        candidate_package=candidate_package,
         candidate_python=candidate_python,
         candidate_wheel=resolved_wheel,
         expected_wheel_sha256=expected_wheel_sha256,
@@ -540,7 +546,7 @@ def run_gate_b_soak(
     _load_or_create_profile(resolved_output, profile, cache)
 
     def candidate_verifier(python: Path) -> str:
-        observed = _verify_candidate_python(python, _RC_PACKAGE)
+        observed = _verify_candidate_python(python, candidate_package)
         if observed != candidate_provenance:
             raise EvidenceError("soak_candidate_provenance_mismatch")
         return observed
@@ -581,6 +587,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--profile", choices=_PROFILES, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--candidate-package", required=True)
     parser.add_argument("--candidate-python", type=Path, required=True)
     parser.add_argument("--candidate-wheel", type=Path, required=True)
     parser.add_argument("--expected-wheel-sha256", required=True)
@@ -601,6 +608,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         run_gate_b_soak(
             profile=cast(Profile, args.profile),
             output=args.output,
+            candidate_package=args.candidate_package,
             candidate_python=args.candidate_python,
             candidate_wheel=args.candidate_wheel,
             expected_wheel_sha256=args.expected_wheel_sha256,

--- a/tests/test_gate_b_soak.py
+++ b/tests/test_gate_b_soak.py
@@ -5,8 +5,10 @@ import importlib.util
 import json
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
+from typing import cast
 
 import pytest
 
@@ -243,7 +245,7 @@ def test_public_rc_wheel_binding_records_exact_installed_identity(
 ) -> None:
     module = _module()
     output = tmp_path / "evidence"
-    wheel = tmp_path / "matryca_plumber-2.0.0rc2-py3-none-any.whl"
+    wheel = tmp_path / "matryca_plumber-2.0.1rc3-py3-none-any.whl"
     wheel.write_bytes(b"public rc wheel")
     expected_sha256 = module._sha256(wheel.read_bytes())
     provenance = "b" * 64
@@ -257,15 +259,17 @@ def test_public_rc_wheel_binding_records_exact_installed_identity(
     assert (
         module._bind_public_rc_wheel(
             output,
+            candidate_package="2.0.1rc3",
             candidate_python=Path(sys.executable),
             candidate_wheel=wheel,
             expected_wheel_sha256=expected_sha256,
         )
         == provenance
     )
-    assert observed == [(Path(sys.executable).absolute(), "2.0.0rc2")]
+    assert observed == [(Path(sys.executable).absolute(), "2.0.1rc3")]
     checkpoint = json.loads((output / "checkpoint.json").read_text(encoding="utf-8"))
     details = checkpoint["gates"]["wheel"]["details"]
+    assert details["candidate_package"] == "2.0.1rc3"
     assert details["wheel_sha256"] == expected_sha256
     assert details["candidate_provenance_digest"] == provenance
     assert details["installed_record_verified"] is True
@@ -278,10 +282,98 @@ def test_public_rc_wheel_binding_rejects_digest_mismatch(tmp_path: Path) -> None
     with pytest.raises(module.EvidenceError, match="wheel_sha256_mismatch"):
         module._bind_public_rc_wheel(
             tmp_path / "evidence",
+            candidate_package="2.0.1rc3",
             candidate_python=Path(sys.executable),
             candidate_wheel=wheel,
             expected_wheel_sha256="a" * 64,
         )
+
+
+def test_public_rc_wheel_binding_rejects_candidate_version_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    output = tmp_path / "evidence"
+    wheel = tmp_path / "matryca_plumber-2.0.1rc3-py3-none-any.whl"
+    wheel.write_bytes(b"public rc wheel")
+    expected_sha256 = module._sha256(wheel.read_bytes())
+    monkeypatch.setattr(module, "_verify_candidate_python", lambda *_args: "b" * 64)
+
+    module._bind_public_rc_wheel(
+        output,
+        candidate_package="2.0.1rc3",
+        candidate_python=Path(sys.executable),
+        candidate_wheel=wheel,
+        expected_wheel_sha256=expected_sha256,
+    )
+
+    with pytest.raises(module.EvidenceError, match="gate_resume_mismatch"):
+        module._bind_public_rc_wheel(
+            output,
+            candidate_package="2.0.1rc4",
+            candidate_python=Path(sys.executable),
+            candidate_wheel=wheel,
+            expected_wheel_sha256=expected_sha256,
+        )
+
+
+def test_cli_candidate_package_reaches_initial_and_resume_verifiers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    source = _graph(tmp_path)
+    source_realpath = tmp_path / "source-realpath.txt"
+    source_realpath.write_text(f"{source.resolve()}\n", encoding="utf-8")
+    wheel = tmp_path / "matryca_plumber-2.0.1rc3-py3-none-any.whl"
+    wheel.write_bytes(b"public rc wheel")
+    observed: list[tuple[str, str]] = []
+    provenance = "b" * 64
+
+    def bind(_output: Path, *, candidate_package: str, **_kwargs: object) -> str:
+        observed.append(("initial", candidate_package))
+        return provenance
+
+    def verify(_python: Path, candidate_package: str) -> str:
+        observed.append(("resume", candidate_package))
+        return provenance
+
+    def collect(_output: Path, **kwargs: object) -> object:
+        candidate_verifier = cast(Callable[[Path], str], kwargs["candidate_verifier"])
+        assert candidate_verifier(Path(sys.executable)) == provenance
+        return object()
+
+    monkeypatch.setattr(module, "_bind_public_rc_wheel", bind)
+    monkeypatch.setattr(module, "_verify_candidate_python", verify)
+    monkeypatch.setattr(module, "collect_soak", collect)
+
+    assert (
+        module.main(
+            [
+                "--profile",
+                "default-on",
+                "--output",
+                str(tmp_path / "evidence"),
+                "--candidate-package",
+                "2.0.1rc3",
+                "--candidate-python",
+                sys.executable,
+                "--candidate-wheel",
+                str(wheel),
+                "--expected-wheel-sha256",
+                module._sha256(wheel.read_bytes()),
+                "--source-vault",
+                str(source),
+                "--expected-source-realpath-file",
+                str(source_realpath),
+                "--working-root",
+                str(tmp_path / "working"),
+                "--cache-root",
+                str(tmp_path / "cache"),
+            ]
+        )
+        == 0
+    )
+    assert observed == [("initial", "2.0.1rc3"), ("resume", "2.0.1rc3")]
 
 
 def test_main_reports_privacy_safe_failure(
@@ -294,6 +386,8 @@ def test_main_reports_privacy_safe_failure(
             "default-on",
             "--output",
             str(tmp_path / "evidence"),
+            "--candidate-package",
+            "2.0.1rc3",
             "--candidate-python",
             str(tmp_path / "missing-python"),
             "--candidate-wheel",


### PR DESCRIPTION
## Summary

- Require the exact candidate package version for every durable Gate B run.
- Bind the package version and public wheel digest into persisted gate input.
- Reject resume attempts when the candidate version or wheel identity drifts.
- Generalize the RC soak runbook beyond the former RC2 constant.

## Acceptance criteria

- Initial and resumed verification use the same explicit candidate package.
- Existing persisted wheel input fails closed on version or digest mismatch.
- Full repository CI and focused Gate B tests pass.

## Scope and non-goals

- Scope: Gate B runner, runner tests, soak runbook, and Unreleased changelog.
- Non-goals: release artifacts, tags, stable promotion, or existing RC1/RC2 evidence.

## Security, privacy, and compatibility

- Security/privacy impact: strengthens provenance and resume integrity; no new data collection.
- Compatibility impact: operators must pass --candidate-package explicitly.

## Test plan

- [x] make ci passes locally: 2,094 passed, 5 skipped, 84.50% coverage.
- [x] Focused Gate B suite passes: 75 passed with coverage disabled for the narrow run.
- [x] User-visible operator contract documented in CHANGELOG.md under Unreleased.
- [x] No CLI/MCP/environment prompt surface changed.

## Documentation and changelog

- Documentation impact: runbook now documents the required candidate package binding.
- Changelog decision: Fixed entry records the fail-closed version binding.

## Rollback or rejection conditions

- Stop on any hosted CI failure, base/head drift, unexpected scope, or review request.

## Issue linking

No issue is auto-closed; this is release-qualification hardening.