### PR TITLE
feat(graph): add OG identity session slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Changed
 
+- **Internal OG graph identity slice** — add a Plumber-owned, in-process
+  identity-only session port and service, composed through one internal
+  `logseq-matryca-parser` 1.7.1 adapter. It returns opaque graph and source
+  bindings only; it adds no content payload, UI, endpoint, CLI/MCP surface,
+  Shadow/DB routing, fallback, mutation, event, or consumer-compatibility
+  claim. Closes #566.
 - **Canonical graph-read contract artifact** — add the static, content-free
   `plumber.graph.read/v1` schema, producer/consumer fixtures, and deterministic
   fixture-attestation TCK. It enables no runtime adapter, Logseq DB capability,

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -11,13 +11,15 @@ owner: core-runtime
 # Plumber public contract catalogue
 
 This catalogue reserves the public contract namespace owned by Matryca Plumber.
-It introduces no runtime adapter, endpoint, compatibility claim, or Logseq DB
-support. `plumber.graph.read/v1` additionally has a static, transport-neutral
-schema and synthetic fixture artifact; it remains feature-off.
+It introduces no endpoint, compatibility claim, or Logseq DB support.
+`plumber.graph.read/v1` additionally has a static, transport-neutral schema
+and synthetic fixture artifact. Its page and subtree capabilities remain
+feature-off; an internal OG identity-only session slice is not a transport or
+consumer-compatibility surface.
 
 | Contract family | Intended responsibility | Status |
 | --- | --- | --- |
-| [`plumber.graph.read/v1`](plumber-graph-read-v1.md) | Session-bound page and complete ordered subtree reads. | Static artifact; feature-off. |
+| [`plumber.graph.read/v1`](plumber-graph-read-v1.md) | Session-bound identity, page, and complete ordered subtree reads. | Static artifact; identity-only internal OG slice. |
 | `plumber.graph.topology/v1` | Derived graph topology for consumers. | Reserved; feature-off. |
 | `plumber.control/v1` | Bounded operator configuration and gardening commands. | Reserved; feature-off. |
 | `plumber.host.navigate/v1` | Explicit host navigation request, never implicit UI control. | Reserved; feature-off. |
@@ -26,9 +28,10 @@ schema and synthetic fixture artifact; it remains feature-off.
 `plumber.graph.read/v1` source of truth is its Plumber-owned,
 transport-neutral artifact containing a schema, synthetic content-free fixtures,
 producer and consumer profiles, and a deterministic compatibility test kit. Its
-fixture attestation does not make the contract usable. A runtime contract becomes
-usable only after its exact artifact, producer profile, and consumer profile pass
-the recorded admission gate.
+fixture attestation does not make the contract usable. The internal OG identity
+slice reuses only contract vocabulary and does not qualify consumer transport.
+A runtime contract becomes usable only after its exact artifact, producer
+profile, and consumer profile pass the recorded admission gate.
 
 Consumers include Matryca Trama and Matryca Brain. They do not import Parser or
 access Logseq directly. Parser remains an internal implementation selected by

--- a/docs/contracts/plumber-graph-read-v1.md
+++ b/docs/contracts/plumber-graph-read-v1.md
@@ -12,9 +12,16 @@ owner: core-runtime
 
 ## Status
 
-`plumber.graph.read/v1` is a **proposed, feature-off** public contract. This
-artifact defines static interoperability inputs only. It creates no runtime
-adapter, endpoint, CLI command, MCP tool, graph session, or Logseq DB support.
+`plumber.graph.read/v1` remains a **proposed, feature-off** public contract for
+page and complete-subtree delivery. This artifact defines static
+interoperability inputs only. It creates no endpoint, CLI command, MCP tool,
+or Logseq DB support.
+
+Issue #566 adds one internal, in-process OG `graph.identify` vertical slice:
+an explicit source is parsed through Plumber's private Parser adapter and then
+served through a Plumber-owned session port. It returns opaque graph and source
+revision bindings only. It serves no page or subtree payload and creates no
+external consumer compatibility claim.
 
 The canonical artifact is repository-owned and transport-neutral:
 
@@ -77,12 +84,14 @@ emit events.
 
 ## Admission boundary
 
-The artifact is a prerequisite for a future Plumber-owned
-`GraphSessionReadPort`, not that port's implementation. Existing `GraphReadPort`
-remains the filesystem/Shadow repository port. A future producer and consumer
-must separately qualify the exact source profile, graph binding, session
-lifecycle, bounded reads, source revision, failure behavior, and consumer
-compatibility before any runtime wiring is introduced.
+The artifact remains the prerequisite for page and subtree implementations of
+Plumber-owned `GraphSessionReadPort`. Issue #566 uses only its identity
+vocabulary in an internal OG service; its runtime DTO is not a serialized
+fixture-schema envelope. Existing `GraphReadPort` remains the
+filesystem/Shadow repository port. A future producer and consumer must
+separately qualify the exact source profile, graph binding, session lifecycle,
+bounded reads, source revision, failure behavior, and consumer compatibility
+before any page/subtree runtime wiring is introduced.
 
 For Logseq OG, Plumber may select Parser behind its internal boundary. Parser
 types never become public contract types. For Logseq DB, only a separately

--- a/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
+++ b/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
@@ -42,7 +42,7 @@ UI owner, while Plumber retains its bounded Operator Console. No LENS source or 
 | OG Markdown parsing | Parser, selected by Plumber | Parser owns parsing; legacy/experimental LENS remains compatible only during its deprecation window. |
 | OG and Shadow repository reads | Plumber `GraphReadPort` | `GraphReadPort remains filesystem/Shadow-only`; it is not a session or DB port. |
 | Logseq DB host access | Plumber | A future adapter may use only a qualified **Logseq DB official host surface**. |
-| Consumer graph reads | Plumber `GraphSessionReadPort` | Public application boundary; no runtime interface is introduced by this decision. |
+| Consumer graph reads | Plumber `GraphSessionReadPort` | Internal OG identity-only runtime exists; page/subtree and external transport remain feature-off. |
 | Graph and control contracts | Plumber | `plumber.graph.read/v1`, `plumber.graph.topology/v1`, `plumber.control/v1`, and `plumber.host.navigate/v1`. |
 | Product intelligence and graph UI | Trama | Consumer implementation over published Plumber contracts. |
 | Optional analysis consumer | Brain | Consumer implementation over published Plumber contracts. |
@@ -63,9 +63,10 @@ UI owner, while Plumber retains its bounded Operator Console. No LENS source or 
 This decision defines ownership, not a shipped runtime capability. The public
 contract artifact must be transport-neutral and contain versioned schemas,
 synthetic fixtures, and a compatibility test kit before a consumer is wired.
-`GraphSessionReadPort` is feature-off until the artifact and the selected
-source profile qualify graph identity, session lifecycle, bounded page and
-complete ordered subtree reads, source revision, failure semantics, and
+The internal OG identity-only `GraphSessionReadPort` uses only an explicit
+Parser source, opaque identity, session binding, and source revision. Page and
+complete ordered subtree reads remain feature-off until the artifact and the
+selected source profile qualify bounded payloads, failure semantics, and
 consumer compatibility.
 
 For OG, Plumber may call Parser behind its internal boundary. For DB, Plumber

--- a/docs/knowledge/inventory.json
+++ b/docs/knowledge/inventory.json
@@ -400,7 +400,8 @@
       "destination": null,
       "action": "keep",
       "supersedes": [],
-      "notes": ""
+      "notes": "",
+      "missing": false
     },
     {
       "path": "docs/decisions/2026-08-30-github-actions-qualification-authority.md",

--- a/src/agent/og_parser_identity_adapter.py
+++ b/src/agent/og_parser_identity_adapter.py
@@ -1,0 +1,55 @@
+"""Internal OG Parser adapter for content-free Plumber graph identity."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path, PurePosixPath
+
+from logseq_matryca_parser import LogosParser
+
+from ..graph.markdown_io import read_graph_page_text
+from ..graph.path_sandbox import resolved_graph_root
+from ..graph.ports.session_read import OgGraphIdentityPort
+from ..graph.session_read_models import GraphSessionReadError, GraphSourceIdentity
+from ..rag.matryca_hooks import resolve_logseq_page_md
+
+
+def _validated_page_title(page_title: str) -> str:
+    normalized = page_title.strip().replace("\\", "/")
+    parts = PurePosixPath(normalized).parts
+    if not normalized or normalized.startswith("/") or ".." in parts:
+        raise GraphSessionReadError("invalid OG page reference")
+    return normalized
+
+
+def _opaque_digest(value: str | bytes) -> str:
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(raw).hexdigest()[:32]
+
+
+class ParserOgIdentityAdapter(OgGraphIdentityPort):
+    """Use the locked public Parser API without exposing its objects past this edge."""
+
+    def identify_og_graph(self, graph_root: Path, page_title: str) -> GraphSourceIdentity:
+        title = _validated_page_title(page_title)
+        root = resolved_graph_root(graph_root)
+        if not root.is_dir():
+            raise GraphSessionReadError("OG graph root unavailable")
+        try:
+            page_path = resolve_logseq_page_md(root, title)
+            source_text = read_graph_page_text(page_path, root)
+        except (OSError, ValueError) as exc:
+            raise GraphSessionReadError("OG page resolution rejected") from exc
+        try:
+            parsed_page = LogosParser().parse_page_file(str(page_path))
+        except Exception as exc:
+            raise GraphSessionReadError("OG Parser identity read failed") from exc
+        if parsed_page is None:
+            raise GraphSessionReadError("OG Parser returned no page")
+        return GraphSourceIdentity(
+            graph_id=_opaque_digest(str(root)),
+            source_revision=_opaque_digest(source_text),
+        )
+
+
+__all__ = ["ParserOgIdentityAdapter"]

--- a/src/agent/og_session_read_composition.py
+++ b/src/agent/og_session_read_composition.py
@@ -1,0 +1,36 @@
+"""Composition root for the internal OG identity-only graph session reader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from ..graph.ports.session_read import GraphSessionReadPort, OgGraphIdentityPort
+from ..graph.session_read_models import GraphSession
+from ..graph.session_read_service import GraphSessionReadService
+from .og_parser_identity_adapter import ParserOgIdentityAdapter
+
+
+@dataclass(frozen=True, slots=True)
+class OgGraphSessionReader:
+    """One consumer-ready reader plus its explicit active session descriptor."""
+
+    session: GraphSession
+    reader: GraphSessionReadPort
+
+
+def create_og_graph_session_reader(
+    graph_root: Path,
+    page_title: str,
+    *,
+    identity_source: OgGraphIdentityPort | None = None,
+) -> OgGraphSessionReader:
+    """Bind one explicit OG source to an identity-only Plumber session."""
+    source = identity_source or ParserOgIdentityAdapter()
+    identity = source.identify_og_graph(graph_root, page_title)
+    session = GraphSession.from_source(session_id=uuid4().hex, source=identity)
+    return OgGraphSessionReader(session=session, reader=GraphSessionReadService(session))
+
+
+__all__ = ["OgGraphSessionReader", "create_og_graph_session_reader"]

--- a/src/graph/ports/__init__.py
+++ b/src/graph/ports/__init__.py
@@ -1,5 +1,6 @@
 """Graph layer ports (protocols) for v2 read/write adapters."""
 
 from .read import GraphReadPort
+from .session_read import GraphSessionReadPort, OgGraphIdentityPort
 
-__all__ = ["GraphReadPort"]
+__all__ = ["GraphReadPort", "GraphSessionReadPort", "OgGraphIdentityPort"]

--- a/src/graph/ports/session_read.py
+++ b/src/graph/ports/session_read.py
@@ -1,0 +1,27 @@
+"""Narrow ports for Plumber-owned, session-bound graph identity reads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from ..session_read_models import GraphIdentityResponse, GraphSourceIdentity
+
+
+class OgGraphIdentityPort(Protocol):
+    """Internal source boundary implemented by the OG Parser adapter."""
+
+    def identify_og_graph(self, graph_root: Path, page_title: str) -> GraphSourceIdentity:
+        """Return normalized, content-free identity for one explicitly selected OG page."""
+        ...
+
+
+class GraphSessionReadPort(Protocol):
+    """Consumer boundary for the current identity-only Plumber session slice."""
+
+    def identify(self, *, session_id: str, graph_id: str) -> GraphIdentityResponse:
+        """Return identity only when the caller presents the active graph binding."""
+        ...
+
+
+__all__ = ["GraphSessionReadPort", "OgGraphIdentityPort"]

--- a/src/graph/session_read_models.py
+++ b/src/graph/session_read_models.py
@@ -1,0 +1,106 @@
+"""Plumber-owned values for the identity-only graph session read slice."""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+CONTRACT_ID: Final[Literal["plumber.graph.read/v1"]] = "plumber.graph.read/v1"
+SCHEMA_VERSION: Final[Literal[1]] = 1
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+class GraphSessionReadError(ValueError):
+    """Raised when an identity-only graph session request fails closed."""
+
+
+class GraphReadCapability(StrEnum):
+    """Capabilities implemented by this narrow runtime slice."""
+
+    GRAPH_IDENTIFY = "graph.identify"
+
+
+class GraphSessionState(StrEnum):
+    """Lifecycle states that may be exposed by an identity-only session."""
+
+    ACTIVE = "active"
+    CLOSED = "closed"
+
+
+class _OpaqueIdentityModel(BaseModel):
+    """Validate content-free identifiers shared by session-facing values."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    @field_validator("*")
+    @classmethod
+    def _validate_opaque_ids(cls, value: object) -> object:
+        if isinstance(value, str) and (len(value) > 128 or not _OPAQUE_ID.fullmatch(value)):
+            raise ValueError("must be a bounded opaque identifier")
+        return value
+
+
+class GraphSourceIdentity(_OpaqueIdentityModel):
+    """Adapter-normalized identity; never carries a Parser model or graph content."""
+
+    graph_id: str
+    source_revision: str
+
+
+class GraphSession(_OpaqueIdentityModel):
+    """One Plumber-owned OG session bound to a graph identity and source revision."""
+
+    contract_id: Literal["plumber.graph.read/v1"] = CONTRACT_ID
+    schema_version: Literal[1] = SCHEMA_VERSION
+    id: str
+    graph_id: str
+    source_revision: str
+    mode: Literal["og"] = "og"
+    capabilities: frozenset[GraphReadCapability]
+    state: GraphSessionState = GraphSessionState.ACTIVE
+
+    @classmethod
+    def from_source(cls, *, session_id: str, source: GraphSourceIdentity) -> GraphSession:
+        """Create the only session shape admitted by the OG identity slice."""
+        return cls(
+            id=session_id,
+            graph_id=source.graph_id,
+            source_revision=source.source_revision,
+            capabilities=frozenset({GraphReadCapability.GRAPH_IDENTIFY}),
+        )
+
+
+class GraphIdentityResult(_OpaqueIdentityModel):
+    """Content-free result for ``graph.identify``."""
+
+    graph_id: str
+
+
+class GraphIdentityResponse(_OpaqueIdentityModel):
+    """Plumber-owned response vocabulary for the internal identity-only reader."""
+
+    contract_id: Literal["plumber.graph.read/v1"] = CONTRACT_ID
+    schema_version: Literal[1] = SCHEMA_VERSION
+    session_id: str
+    graph_id: str
+    source_revision: str
+    operation: Literal["graph.identify"] = "graph.identify"
+    outcome: Literal["pass"] = "pass"
+    reason: Literal["og-parser-identity"] = "og-parser-identity"
+    result: GraphIdentityResult
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "SCHEMA_VERSION",
+    "GraphIdentityResponse",
+    "GraphIdentityResult",
+    "GraphReadCapability",
+    "GraphSession",
+    "GraphSessionReadError",
+    "GraphSessionState",
+    "GraphSourceIdentity",
+]

--- a/src/graph/session_read_service.py
+++ b/src/graph/session_read_service.py
@@ -1,0 +1,40 @@
+"""Application service for the identity-only ``plumber.graph.read/v1`` slice."""
+
+from __future__ import annotations
+
+from .ports.session_read import GraphSessionReadPort
+from .session_read_models import (
+    GraphIdentityResponse,
+    GraphIdentityResult,
+    GraphReadCapability,
+    GraphSession,
+    GraphSessionReadError,
+    GraphSessionState,
+)
+
+
+class GraphSessionReadService(GraphSessionReadPort):
+    """Serve one active, bound graph identity without selecting a source or transport."""
+
+    def __init__(self, session: GraphSession) -> None:
+        self._session = session
+
+    def identify(self, *, session_id: str, graph_id: str) -> GraphIdentityResponse:
+        """Return a content-free identity response or reject an invalid session binding."""
+        if session_id != self._session.id:
+            raise GraphSessionReadError("session binding rejected")
+        if self._session.state is not GraphSessionState.ACTIVE:
+            raise GraphSessionReadError("session is not active")
+        if graph_id != self._session.graph_id:
+            raise GraphSessionReadError("foreign graph binding rejected")
+        if GraphReadCapability.GRAPH_IDENTIFY not in self._session.capabilities:
+            raise GraphSessionReadError("graph.identify capability unavailable")
+        return GraphIdentityResponse(
+            session_id=self._session.id,
+            graph_id=self._session.graph_id,
+            source_revision=self._session.source_revision,
+            result=GraphIdentityResult(graph_id=self._session.graph_id),
+        )
+
+
+__all__ = ["GraphSessionReadService"]

--- a/tests/test_og_identity_boundary.py
+++ b/tests/test_og_identity_boundary.py
@@ -1,0 +1,45 @@
+"""Architecture guards for Parser isolation in the OG identity slice."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SLICE_MODULES = (
+    ROOT / "src" / "graph" / "session_read_models.py",
+    ROOT / "src" / "graph" / "session_read_service.py",
+    ROOT / "src" / "graph" / "ports" / "session_read.py",
+    ROOT / "src" / "agent" / "og_session_read_composition.py",
+    ROOT / "src" / "agent" / "og_parser_identity_adapter.py",
+)
+
+
+def _parser_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(
+                alias.name for alias in node.names if alias.name.startswith("logseq_matryca_parser")
+            )
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.startswith("logseq_matryca_parser")
+        ):
+            imports.add(node.module)
+    return imports
+
+
+def test_parser_import_is_confined_to_internal_adapter() -> None:
+    """Breaks if a DTO, port, service, or composition root imports Parser directly."""
+    observed = {path.name: _parser_imports(path) for path in SLICE_MODULES}
+
+    assert observed == {
+        "session_read_models.py": set(),
+        "session_read_service.py": set(),
+        "session_read.py": set(),
+        "og_session_read_composition.py": set(),
+        "og_parser_identity_adapter.py": {"logseq_matryca_parser"},
+    }

--- a/tests/test_og_identity_session_read.py
+++ b/tests/test_og_identity_session_read.py
@@ -1,0 +1,95 @@
+"""Behavior specification for the internal OG identity-only session slice."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from src.agent.og_session_read_composition import create_og_graph_session_reader
+from src.graph.ports.session_read import GraphSessionReadPort, OgGraphIdentityPort
+from src.graph.session_read_models import (
+    GraphReadCapability,
+    GraphSession,
+    GraphSessionReadError,
+    GraphSessionState,
+    GraphSourceIdentity,
+)
+from src.graph.session_read_service import GraphSessionReadService
+
+
+class _FixedOgIdentitySource(OgGraphIdentityPort):
+    def identify_og_graph(self, graph_root: Path, page_title: str) -> GraphSourceIdentity:
+        assert graph_root == Path("selected-og-root")
+        assert page_title == "Selected page"
+        return GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha")
+
+
+def test_consumer_receives_only_plumber_owned_identity_response() -> None:
+    """Breaks if Parser data crosses GraphSessionReadPort's public boundary."""
+    session = GraphSession.from_source(
+        session_id="session-alpha",
+        source=_FixedOgIdentitySource().identify_og_graph(
+            Path("selected-og-root"), "Selected page"
+        ),
+    )
+    reader: GraphSessionReadPort = GraphSessionReadService(session)
+
+    response = reader.identify(session_id="session-alpha", graph_id="graph-alpha")
+
+    assert response.contract_id == "plumber.graph.read/v1"
+    assert response.operation == "graph.identify"
+    assert response.result.graph_id == "graph-alpha"
+    assert response.source_revision == "revision-alpha"
+    assert response.model_dump() == {
+        "contract_id": "plumber.graph.read/v1",
+        "schema_version": 1,
+        "session_id": "session-alpha",
+        "graph_id": "graph-alpha",
+        "source_revision": "revision-alpha",
+        "operation": "graph.identify",
+        "outcome": "pass",
+        "reason": "og-parser-identity",
+        "result": {"graph_id": "graph-alpha"},
+    }
+
+
+def test_composition_binds_consumer_reader_to_parser_normalized_identity() -> None:
+    """Breaks if composition skips the injected source or exposes a different graph binding."""
+    binding = create_og_graph_session_reader(
+        Path("selected-og-root"),
+        "Selected page",
+        identity_source=_FixedOgIdentitySource(),
+    )
+    reader: GraphSessionReadPort = binding.reader
+
+    response = reader.identify(session_id=binding.session.id, graph_id="graph-alpha")
+
+    assert binding.session.graph_id == "graph-alpha"
+    assert response.result.graph_id == "graph-alpha"
+
+
+def test_identity_rejects_foreign_graph_binding() -> None:
+    """Breaks if a session can serve an identity for another graph."""
+    session = GraphSession.from_source(
+        session_id="session-alpha",
+        source=GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha"),
+    )
+
+    with pytest.raises(GraphSessionReadError, match="foreign graph binding"):
+        GraphSessionReadService(session).identify(session_id="session-alpha", graph_id="graph-beta")
+
+
+def test_identity_rejects_closed_session() -> None:
+    """Breaks if a closed session continues to serve a graph identity."""
+    session = GraphSession(
+        id="session-alpha",
+        graph_id="graph-alpha",
+        source_revision="revision-alpha",
+        capabilities=frozenset({GraphReadCapability.GRAPH_IDENTIFY}),
+        state=GraphSessionState.CLOSED,
+    )
+
+    with pytest.raises(GraphSessionReadError, match="session is not active"):
+        GraphSessionReadService(session).identify(
+            session_id="session-alpha", graph_id="graph-alpha"
+        )

--- a/tests/test_og_parser_identity_adapter.py
+++ b/tests/test_og_parser_identity_adapter.py
@@ -1,0 +1,61 @@
+"""Parser adapter behavior for the OG identity-only session slice."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from src.agent.og_parser_identity_adapter import ParserOgIdentityAdapter
+from src.graph.session_read_models import GraphSessionReadError
+
+
+def test_parser_adapter_returns_opaque_plumber_identity_for_one_safe_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if adapter leaks Parser objects or derives identity outside selected OG source."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    page = pages / "Selected.md"
+    page.write_text("- root\n", encoding="utf-8")
+
+    class _ParsedPage:
+        title = "Selected"
+
+    class _Parser:
+        def parse_page_file(self, path: str) -> _ParsedPage:
+            assert path == str(page)
+            return _ParsedPage()
+
+    monkeypatch.setattr("src.agent.og_parser_identity_adapter.LogosParser", _Parser)
+
+    identity = ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+    assert identity.graph_id == hashlib.sha256(str(tmp_path.resolve()).encode()).hexdigest()[:32]
+    assert identity.source_revision == hashlib.sha256(b"- root\n").hexdigest()[:32]
+
+
+def test_parser_adapter_rejects_path_traversal_before_parsing(tmp_path: Path) -> None:
+    """Breaks if an unsafe page reference reaches Parser file access."""
+    with pytest.raises(GraphSessionReadError, match="invalid OG page reference"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "../outside")
+
+
+def test_parser_adapter_normalizes_parser_failures_to_a_closed_boundary_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if a Parser implementation exception escapes the Plumber boundary."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / "Selected.md").write_text("- root\n", encoding="utf-8")
+
+    class _FailingParser:
+        def parse_page_file(self, path: str) -> None:
+            raise RuntimeError("parser internals")
+
+    monkeypatch.setattr("src.agent.og_parser_identity_adapter.LogosParser", _FailingParser)
+
+    with pytest.raises(GraphSessionReadError, match="OG Parser identity read failed"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")


### PR DESCRIPTION
## Summary

- add Plumber-owned identity/session DTOs, port, and application service
- add one internal OG Parser adapter and explicit composition root
- prove Parser → Plumber → consumer dependency direction with fail-closed tests
- keep graph content, DB, Shadow, UI, CLI/MCP, mutation, and events outside this slice

## Verification

- focused suite: 20 passed
- `make docs-audit`
- `make ci`
- independent Luna review: GREEN
- remote commit tree matches the locally reviewed tree

## Qualification boundary

This is an internal in-process `graph.identify` slice. It does not qualify page/subtree delivery, external consumer compatibility, transport, Logseq DB, or production runtime support.

Closes #566