### PR TITLE
fix(graph): harden OG session snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 - **Internal OG graph identity slice** — add a Plumber-owned, in-process
   identity-only session port and service, composed through one internal
-  `logseq-matryca-parser` 1.7.1 adapter. It returns opaque graph and source
-  bindings only; it adds no content payload, UI, endpoint, CLI/MCP surface,
-  Shadow/DB routing, fallback, mutation, event, or consumer-compatibility
-  claim. Closes #566.
+  `logseq-matryca-parser` 1.7.1 adapter. It hashes and parses one identical,
+  UTF-8, 1 MiB-bounded descriptor-bound regular-file snapshot; symlink and
+  replacement races, session close, and monotonic expiry fail closed. It returns
+  opaque graph and source bindings only; it adds no content payload, UI,
+  endpoint, CLI/MCP surface, Shadow/DB routing, fallback, mutation, event, or
+  consumer-compatibility claim. Closes #566, #568.
 - **Canonical graph-read contract artifact** — add the static, content-free
   `plumber.graph.read/v1` schema, producer/consumer fixtures, and deterministic
   fixture-attestation TCK. It enables no runtime adapter, Logseq DB capability,

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -16,6 +16,8 @@ It introduces no endpoint, compatibility claim, or Logseq DB support.
 and synthetic fixture artifact. Its page and subtree capabilities remain
 feature-off; an internal OG identity-only session slice is not a transport or
 consumer-compatibility surface.
+That internal slice admits one explicit UTF-8 snapshot up to 1 MiB, then hashes
+and parses those same bytes; it has no page or subtree delivery capability.
 
 | Contract family | Intended responsibility | Status |
 | --- | --- | --- |

--- a/docs/contracts/plumber-graph-read-v1.md
+++ b/docs/contracts/plumber-graph-read-v1.md
@@ -23,6 +23,17 @@ served through a Plumber-owned session port. It returns opaque graph and source
 revision bindings only. It serves no page or subtree payload and creates no
 external consumer compatibility claim.
 
+Issue #568 hardens that internal slice. Its private adapter validates and reads
+one explicit source snapshot with a 1,048,576-byte (1 MiB) ceiling before
+Parser invocation, binds pre/post `lstat` and descriptor `fstat` device, inode,
+and size identities, and rejects symlink, non-regular, or replacement races.
+It hashes the exact admitted bytes, decodes UTF-8 explicitly, and calls
+Parser's in-memory `parse()` on that same snapshot. Read, decode, size, and
+Parser failures are bounded Plumber errors with no path or graph-content
+disclosure. The
+Plumber-owned reader also supports idempotent close and an optional injected
+monotonic deadline; closed and expired sessions reject every operation.
+
 The canonical artifact is repository-owned and transport-neutral:
 
 - [schema](../../contracts/plumber.graph.read/v1/schema.json)

--- a/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
+++ b/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
@@ -64,10 +64,11 @@ This decision defines ownership, not a shipped runtime capability. The public
 contract artifact must be transport-neutral and contain versioned schemas,
 synthetic fixtures, and a compatibility test kit before a consumer is wired.
 The internal OG identity-only `GraphSessionReadPort` uses only an explicit
-Parser source, opaque identity, session binding, and source revision. Page and
-complete ordered subtree reads remain feature-off until the artifact and the
-selected source profile qualify bounded payloads, failure semantics, and
-consumer compatibility.
+Parser source, one byte-bounded UTF-8 snapshot, opaque identity, session
+binding, source revision, and Plumber-owned close/monotonic-expiry lifecycle.
+Page and complete ordered subtree reads remain feature-off until the artifact
+and the selected source profile qualify bounded payloads, failure semantics,
+and consumer compatibility.
 
 For OG, Plumber may call Parser behind its internal boundary. For DB, Plumber
 may add an adapter only after an exact official host capability qualifies; no

--- a/src/agent/og_parser_identity_adapter.py
+++ b/src/agent/og_parser_identity_adapter.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import stat
+from contextlib import suppress
 from pathlib import Path, PurePosixPath
 
 from logseq_matryca_parser import LogosParser
 
-from ..graph.markdown_io import read_graph_page_text
 from ..graph.path_sandbox import resolved_graph_root
 from ..graph.ports.session_read import OgGraphIdentityPort
 from ..graph.session_read_models import GraphSessionReadError, GraphSourceIdentity
 from ..rag.matryca_hooks import resolve_logseq_page_md
+
+MAX_OG_IDENTITY_SNAPSHOT_BYTES = 1024 * 1024
 
 
 def _validated_page_title(page_title: str) -> str:
@@ -27,6 +31,56 @@ def _opaque_digest(value: str | bytes) -> str:
     return hashlib.sha256(raw).hexdigest()[:32]
 
 
+def _file_identity(metadata: os.stat_result) -> tuple[int, int, int]:
+    """Return the device, inode, and size binding for one regular source file."""
+    return (metadata.st_dev, metadata.st_ino, metadata.st_size)
+
+
+def _require_regular_source(metadata: os.stat_result) -> None:
+    """Reject links and non-regular files before they can become an identity source."""
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GraphSessionReadError("OG snapshot source rejected")
+
+
+def _read_bounded_snapshot(page_path: Path) -> bytes:
+    """Read one stable, bounded snapshot through a descriptor bound to its lstat identity."""
+    descriptor = -1
+    try:
+        before = page_path.lstat()
+        _require_regular_source(before)
+        if before.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES:
+            raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(page_path, flags)
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            descriptor_metadata = os.fstat(handle.fileno())
+            _require_regular_source(descriptor_metadata)
+            if _file_identity(before) != _file_identity(descriptor_metadata):
+                raise GraphSessionReadError("OG snapshot changed during read")
+            if descriptor_metadata.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES:
+                raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
+            snapshot = handle.read(MAX_OG_IDENTITY_SNAPSHOT_BYTES + 1)
+        after = page_path.lstat()
+        _require_regular_source(after)
+    except GraphSessionReadError:
+        raise
+    except OSError as exc:
+        raise GraphSessionReadError("OG snapshot read rejected") from exc
+    finally:
+        if descriptor != -1:
+            with suppress(OSError):
+                os.close(descriptor)
+    if (
+        len(snapshot) > MAX_OG_IDENTITY_SNAPSHOT_BYTES
+        or after.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES
+    ):
+        raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
+    if _file_identity(descriptor_metadata) != _file_identity(after):
+        raise GraphSessionReadError("OG snapshot changed during read")
+    return snapshot
+
+
 class ParserOgIdentityAdapter(OgGraphIdentityPort):
     """Use the locked public Parser API without exposing its objects past this edge."""
 
@@ -37,19 +91,25 @@ class ParserOgIdentityAdapter(OgGraphIdentityPort):
             raise GraphSessionReadError("OG graph root unavailable")
         try:
             page_path = resolve_logseq_page_md(root, title)
-            source_text = read_graph_page_text(page_path, root)
+            snapshot = _read_bounded_snapshot(page_path)
+        except GraphSessionReadError:
+            raise
         except (OSError, ValueError) as exc:
             raise GraphSessionReadError("OG page resolution rejected") from exc
         try:
-            parsed_page = LogosParser().parse_page_file(str(page_path))
+            source_text = snapshot.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GraphSessionReadError("OG snapshot decoding rejected") from exc
+        try:
+            parsed_page = LogosParser().parse(source_text, page_title=title)
         except Exception as exc:
             raise GraphSessionReadError("OG Parser identity read failed") from exc
         if parsed_page is None:
             raise GraphSessionReadError("OG Parser returned no page")
         return GraphSourceIdentity(
             graph_id=_opaque_digest(str(root)),
-            source_revision=_opaque_digest(source_text),
+            source_revision=hashlib.sha256(snapshot).hexdigest(),
         )
 
 
-__all__ = ["ParserOgIdentityAdapter"]
+__all__ = ["MAX_OG_IDENTITY_SNAPSHOT_BYTES", "ParserOgIdentityAdapter"]

--- a/src/graph/ports/session_read.py
+++ b/src/graph/ports/session_read.py
@@ -23,5 +23,9 @@ class GraphSessionReadPort(Protocol):
         """Return identity only when the caller presents the active graph binding."""
         ...
 
+    def close(self) -> None:
+        """Close this Plumber-owned session; repeated close calls are harmless."""
+        ...
+
 
 __all__ = ["GraphSessionReadPort", "OgGraphIdentityPort"]

--- a/src/graph/session_read_models.py
+++ b/src/graph/session_read_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from enum import StrEnum
+from math import isfinite
 from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -28,6 +29,7 @@ class GraphSessionState(StrEnum):
 
     ACTIVE = "active"
     CLOSED = "closed"
+    EXPIRED = "expired"
 
 
 class _OpaqueIdentityModel(BaseModel):
@@ -61,15 +63,30 @@ class GraphSession(_OpaqueIdentityModel):
     mode: Literal["og"] = "og"
     capabilities: frozenset[GraphReadCapability]
     state: GraphSessionState = GraphSessionState.ACTIVE
+    expires_at_monotonic: float | None = None
+
+    @field_validator("expires_at_monotonic")
+    @classmethod
+    def _validate_expiry(cls, value: float | None) -> float | None:
+        if value is not None and not isfinite(value):
+            raise ValueError("must be a finite monotonic deadline")
+        return value
 
     @classmethod
-    def from_source(cls, *, session_id: str, source: GraphSourceIdentity) -> GraphSession:
+    def from_source(
+        cls,
+        *,
+        session_id: str,
+        source: GraphSourceIdentity,
+        expires_at_monotonic: float | None = None,
+    ) -> GraphSession:
         """Create the only session shape admitted by the OG identity slice."""
         return cls(
             id=session_id,
             graph_id=source.graph_id,
             source_revision=source.source_revision,
             capabilities=frozenset({GraphReadCapability.GRAPH_IDENTIFY}),
+            expires_at_monotonic=expires_at_monotonic,
         )
 
 

--- a/src/graph/session_read_service.py
+++ b/src/graph/session_read_service.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from time import monotonic
+
 from .ports.session_read import GraphSessionReadPort
 from .session_read_models import (
     GraphIdentityResponse,
@@ -16,15 +19,21 @@ from .session_read_models import (
 class GraphSessionReadService(GraphSessionReadPort):
     """Serve one active, bound graph identity without selecting a source or transport."""
 
-    def __init__(self, session: GraphSession) -> None:
+    def __init__(self, session: GraphSession, *, clock: Callable[[], float] = monotonic) -> None:
         self._session = session
+        self._clock = clock
+        self._state = session.state
+
+    def close(self) -> None:
+        """Close an active session once; a terminal session stays terminal."""
+        if self._state is GraphSessionState.ACTIVE:
+            self._state = GraphSessionState.CLOSED
 
     def identify(self, *, session_id: str, graph_id: str) -> GraphIdentityResponse:
         """Return a content-free identity response or reject an invalid session binding."""
         if session_id != self._session.id:
             raise GraphSessionReadError("session binding rejected")
-        if self._session.state is not GraphSessionState.ACTIVE:
-            raise GraphSessionReadError("session is not active")
+        self._require_active_session()
         if graph_id != self._session.graph_id:
             raise GraphSessionReadError("foreign graph binding rejected")
         if GraphReadCapability.GRAPH_IDENTIFY not in self._session.capabilities:
@@ -35,6 +44,18 @@ class GraphSessionReadService(GraphSessionReadPort):
             source_revision=self._session.source_revision,
             result=GraphIdentityResult(graph_id=self._session.graph_id),
         )
+
+    def _require_active_session(self) -> None:
+        if self._state is GraphSessionState.CLOSED:
+            raise GraphSessionReadError("session is closed")
+        if self._state is GraphSessionState.EXPIRED:
+            raise GraphSessionReadError("session expired")
+        if self._state is not GraphSessionState.ACTIVE:
+            raise GraphSessionReadError("session is not active")
+        deadline = self._session.expires_at_monotonic
+        if deadline is not None and self._clock() >= deadline:
+            self._state = GraphSessionState.EXPIRED
+            raise GraphSessionReadError("session expired")
 
 
 __all__ = ["GraphSessionReadService"]

--- a/tests/test_og_identity_session_read.py
+++ b/tests/test_og_identity_session_read.py
@@ -24,6 +24,14 @@ class _FixedOgIdentitySource(OgGraphIdentityPort):
         return GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha")
 
 
+class _MonotonicClock:
+    def __init__(self, now: float) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
 def test_consumer_receives_only_plumber_owned_identity_response() -> None:
     """Breaks if Parser data crosses GraphSessionReadPort's public boundary."""
     session = GraphSession.from_source(
@@ -68,6 +76,38 @@ def test_composition_binds_consumer_reader_to_parser_normalized_identity() -> No
     assert response.result.graph_id == "graph-alpha"
 
 
+def test_close_is_idempotent_and_rejects_every_later_identity_read() -> None:
+    """Breaks if a closed Plumber session can resume serving graph identity."""
+    session = GraphSession.from_source(
+        session_id="session-alpha",
+        source=GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha"),
+    )
+    reader = GraphSessionReadService(session)
+
+    close = getattr(reader, "close", None)
+    assert callable(close)
+    close()
+    close()
+
+    with pytest.raises(GraphSessionReadError, match="session is closed"):
+        reader.identify(session_id="session-alpha", graph_id="graph-alpha")
+
+
+def test_expiry_rejects_identity_at_exact_injected_monotonic_deadline() -> None:
+    """Breaks if expiry depends on wall time or permits the deadline instant."""
+    clock = _MonotonicClock(10.0)
+    assert "expires_at_monotonic" in GraphSession.model_fields
+    session = GraphSession.from_source(
+        session_id="session-alpha",
+        source=GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha"),
+        expires_at_monotonic=10.0,
+    )
+    reader = GraphSessionReadService(session, clock=clock)
+
+    with pytest.raises(GraphSessionReadError, match="session expired"):
+        reader.identify(session_id="session-alpha", graph_id="graph-alpha")
+
+
 def test_identity_rejects_foreign_graph_binding() -> None:
     """Breaks if a session can serve an identity for another graph."""
     session = GraphSession.from_source(
@@ -77,6 +117,34 @@ def test_identity_rejects_foreign_graph_binding() -> None:
 
     with pytest.raises(GraphSessionReadError, match="foreign graph binding"):
         GraphSessionReadService(session).identify(session_id="session-alpha", graph_id="graph-beta")
+
+
+def test_identity_rejects_unknown_session_binding() -> None:
+    """Breaks if a valid graph identity accepts an unissued session identifier."""
+    session = GraphSession.from_source(
+        session_id="session-alpha",
+        source=GraphSourceIdentity(graph_id="graph-alpha", source_revision="revision-alpha"),
+    )
+
+    with pytest.raises(GraphSessionReadError, match="session binding rejected"):
+        GraphSessionReadService(session).identify(
+            session_id="session-unknown", graph_id="graph-alpha"
+        )
+
+
+def test_identity_rejects_session_without_identify_capability() -> None:
+    """Breaks if an unsupported session implicitly receives graph.identify authority."""
+    session = GraphSession(
+        id="session-alpha",
+        graph_id="graph-alpha",
+        source_revision="revision-alpha",
+        capabilities=frozenset(),
+    )
+
+    with pytest.raises(GraphSessionReadError, match="graph.identify capability unavailable"):
+        GraphSessionReadService(session).identify(
+            session_id="session-alpha", graph_id="graph-alpha"
+        )
 
 
 def test_identity_rejects_closed_session() -> None:
@@ -89,7 +157,7 @@ def test_identity_rejects_closed_session() -> None:
         state=GraphSessionState.CLOSED,
     )
 
-    with pytest.raises(GraphSessionReadError, match="session is not active"):
+    with pytest.raises(GraphSessionReadError, match="session is closed"):
         GraphSessionReadService(session).identify(
             session_id="session-alpha", graph_id="graph-alpha"
         )

--- a/tests/test_og_parser_identity_adapter.py
+++ b/tests/test_og_parser_identity_adapter.py
@@ -3,37 +3,273 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import stat
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+from src.agent import og_parser_identity_adapter
 from src.agent.og_parser_identity_adapter import ParserOgIdentityAdapter
 from src.graph.session_read_models import GraphSessionReadError
 
 
-def test_parser_adapter_returns_opaque_plumber_identity_for_one_safe_page(
+def test_parser_receives_exact_admitted_snapshot_from_one_source_read(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Breaks if adapter leaks Parser objects or derives identity outside selected OG source."""
+    """Breaks if identity hashes different bytes or Parser opens the selected source again."""
     pages = tmp_path / "pages"
     pages.mkdir()
     page = pages / "Selected.md"
-    page.write_text("- root\n", encoding="utf-8")
+    snapshot = "- caf\u00e9\n".encode("utf-8")
+    page.write_bytes(snapshot)
+    source_read_count = 0
+    parser_inputs: list[tuple[str, str]] = []
+    original_os_open = cast(Any, os.open)
 
     class _ParsedPage:
         title = "Selected"
 
     class _Parser:
         def parse_page_file(self, path: str) -> _ParsedPage:
-            assert path == str(page)
+            with Path(path).open("rb") as handle:
+                handle.read()
             return _ParsedPage()
 
-    monkeypatch.setattr("src.agent.og_parser_identity_adapter.LogosParser", _Parser)
+        def parse(self, text: str, page_title: str = "untitled") -> _ParsedPage:
+            parser_inputs.append((text, page_title))
+            return _ParsedPage()
+
+    def _counting_open(path: str | Path, *args: Any, **kwargs: Any) -> Any:
+        nonlocal source_read_count
+        if Path(path) == page:
+            source_read_count += 1
+        return original_os_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+    monkeypatch.setattr(os, "open", _counting_open)
 
     identity = ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
 
-    assert identity.graph_id == hashlib.sha256(str(tmp_path.resolve()).encode()).hexdigest()[:32]
-    assert identity.source_revision == hashlib.sha256(b"- root\n").hexdigest()[:32]
+    assert parser_inputs == [("- caf\u00e9\n", "Selected")]
+    assert source_read_count == 1
+    assert identity.source_revision == hashlib.sha256(snapshot).hexdigest()
+
+
+def test_adapter_rejects_oversize_snapshot_before_parser_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if a page over the hard byte ceiling reaches Parser."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / "Selected.md").write_bytes(b"x" * (1024 * 1024 + 1))
+
+    class _Parser:
+        def parse(self, text: str, page_title: str = "untitled") -> None:
+            raise AssertionError("oversize snapshot reached Parser")
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot exceeds byte ceiling"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+
+def test_adapter_rejects_non_regular_source_before_descriptor_open_or_parser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if a FIFO-like source can reach descriptor open or Parser on any platform."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    page = pages / "Selected.md"
+    page.write_bytes(b"- root\n")
+    original_lstat = Path.lstat
+    opened = False
+
+    class _Parser:
+        def parse(self, text: str, page_title: str = "untitled") -> None:
+            raise AssertionError("non-regular source reached Parser")
+
+    def _fifo_like_lstat(path: Path) -> os.stat_result:
+        metadata = original_lstat(path)
+        if path == page:
+            return os.stat_result((stat.S_IFIFO | stat.S_IRUSR, *metadata[1:]))
+        return metadata
+
+    def _unexpected_open(*args: Any, **kwargs: Any) -> Any:
+        nonlocal opened
+        opened = True
+        raise AssertionError("non-regular source reached descriptor open")
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+    monkeypatch.setattr(Path, "lstat", _fifo_like_lstat)
+    monkeypatch.setattr(os, "open", _unexpected_open)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot source rejected"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+    assert not opened
+
+
+def test_adapter_rejects_snapshot_that_grows_during_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if post-read size growth can validate a stale identity snapshot."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    page = pages / "Selected.md"
+    page.write_bytes(b"- root\n")
+    original_fdopen = cast(Any, os.fdopen)
+    grew = False
+
+    class _ParsedPage:
+        title = "Selected"
+
+    class _Parser:
+        def parse_page_file(self, path: str) -> _ParsedPage:
+            return _ParsedPage()
+
+        def parse(self, text: str, page_title: str = "untitled") -> _ParsedPage:
+            return _ParsedPage()
+
+    class _GrowingRead:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> _GrowingRead:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return self._handle.__exit__(*args)
+
+        def read(self, *args: Any) -> str | bytes:
+            nonlocal grew
+            snapshot = cast(str | bytes, self._handle.read(*args))
+            if not grew:
+                grew = True
+                raw = snapshot.encode("utf-8") if isinstance(snapshot, str) else snapshot
+                page.write_bytes(raw + b"x")
+            return snapshot
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._handle, name)
+
+    def _growing_fdopen(fd: int, *args: Any, **kwargs: Any) -> Any:
+        return _GrowingRead(original_fdopen(fd, *args, **kwargs))
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+    monkeypatch.setattr(os, "fdopen", _growing_fdopen)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot changed during read"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+
+def test_adapter_rejects_same_size_external_symlink_swapped_after_containment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if an external symlink can replace the validated regular page before open."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    page = pages / "Selected.md"
+    page.write_bytes(b"- root\n")
+    external = tmp_path / "external.md"
+    external.write_bytes(b"- next\n")
+    original_os_open = cast(Any, os.open)
+    swapped = False
+
+    class _Parser:
+        def parse(self, text: str, page_title: str = "untitled") -> None:
+            raise AssertionError("external symlink reached Parser")
+
+    def _swap_to_symlink_then_open(path: str | Path, *args: Any, **kwargs: Any) -> Any:
+        nonlocal swapped
+        if Path(path) == page and not swapped:
+            swapped = True
+            page.unlink()
+            page.symlink_to(external)
+        return original_os_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+    monkeypatch.setattr(os, "open", _swap_to_symlink_then_open)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot") as exc_info:
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+    assert "external.md" not in str(exc_info.value)
+
+
+def test_adapter_rejects_same_size_replacement_inode_after_descriptor_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if a same-size pathname replacement can pass post-read verification."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    page = pages / "Selected.md"
+    page.write_bytes(b"- root\n")
+    replacement = tmp_path / "replacement.md"
+    replacement.write_bytes(b"- next\n")
+    original_fdopen = cast(Any, os.fdopen)
+    replaced = False
+
+    class _Parser:
+        def parse(self, text: str, page_title: str = "untitled") -> None:
+            raise AssertionError("replaced source reached Parser")
+
+    class _ReplaceOnRead:
+        def __init__(self, handle: Any) -> None:
+            self._handle = handle
+
+        def __enter__(self) -> _ReplaceOnRead:
+            self._handle.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return self._handle.__exit__(*args)
+
+        def read(self, *args: Any) -> bytes:
+            nonlocal replaced
+            snapshot = cast(bytes, self._handle.read(*args))
+            if not replaced:
+                replaced = True
+                os.replace(replacement, page)
+            return snapshot
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._handle, name)
+
+    def _replace_after_read(fd: int, *args: Any, **kwargs: Any) -> Any:
+        return _ReplaceOnRead(original_fdopen(fd, *args, **kwargs))
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+    monkeypatch.setattr(os, "fdopen", _replace_after_read)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot changed during read"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
+
+
+def test_adapter_rejects_invalid_utf8_snapshot_before_parser_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Breaks if invalid UTF-8 is replaced or reaches Parser as altered text."""
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    (pages / "Selected.md").write_bytes(b"\xff")
+
+    class _Parser:
+        def parse(self, text: str, page_title: str = "untitled") -> None:
+            raise AssertionError("invalid UTF-8 snapshot reached Parser")
+
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _Parser)
+
+    with pytest.raises(GraphSessionReadError, match="OG snapshot decoding rejected"):
+        ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")
 
 
 def test_parser_adapter_rejects_path_traversal_before_parsing(tmp_path: Path) -> None:
@@ -52,10 +288,13 @@ def test_parser_adapter_normalizes_parser_failures_to_a_closed_boundary_error(
     (pages / "Selected.md").write_text("- root\n", encoding="utf-8")
 
     class _FailingParser:
-        def parse_page_file(self, path: str) -> None:
+        def parse_page_file(self, path: str) -> object:
+            return object()
+
+        def parse(self, text: str, page_title: str = "untitled") -> None:
             raise RuntimeError("parser internals")
 
-    monkeypatch.setattr("src.agent.og_parser_identity_adapter.LogosParser", _FailingParser)
+    monkeypatch.setattr(og_parser_identity_adapter, "LogosParser", _FailingParser)
 
     with pytest.raises(GraphSessionReadError, match="OG Parser identity read failed"):
         ParserOgIdentityAdapter().identify_og_graph(tmp_path, "Selected")


### PR DESCRIPTION
## Summary

- read, hash, and parse one descriptor-bound OG snapshot
- enforce a 1 MiB ceiling, strict UTF-8, regular-file identity, and symlink/replacement rejection
- add idempotent session close and deterministic monotonic expiry
- add adversarial and lifecycle tests

## Verification

- focused exact-head suite: 18 passed
- `make ci`
- independent Luna review: GREEN after closing TOCTOU and non-regular coverage findings
- remote tree matches the locally reviewed tree

## Boundaries

No content response, transport, DB, Shadow, UI, CLI/MCP, mutation, events, dependency/lock, or release change. Same-inode, same-size in-place mutation remains a freshness/OCC concern; Parser input and source hash nevertheless remain the same admitted snapshot.

Closes #568