### PR TITLE
feat(graph): admit Parser 1.9 topology sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Added
+
+- **Bounded internal OG topology slice** — require `logseq-matryca-parser`
+  1.9.0 and build one complete, content-free `plumber.graph.topology/v1`
+  projection from Plumber-captured Markdown through Parser's public
+  `LogseqGraph.from_snapshot_pages()` factory. The slice is session-bound and
+  rejects unresolved block references, title collisions, and source, node, or
+  edge limit failures; it adds no endpoint, CLI/MCP surface, consumer wiring,
+  Logseq DB path, or qualification claim. Refs #490.
+
 ### Changed
 
 - **Immutable static consumer packages** — add content-free

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -19,8 +19,11 @@ consumer-compatibility surface.
 That internal slice admits one explicit UTF-8 snapshot up to 1 MiB, then hashes
 and parses those same bytes; it has no page or subtree delivery capability.
 `plumber.graph.topology/v1` additionally has a static, transport-neutral schema
-and synthetic fixture artifact. It is complete-only and read-session-bound; it
-creates no graph scan, Parser adapter, consumer wiring, or transport surface.
+and synthetic fixture artifact. Its internal OG slice is complete-only and
+read-session-bound: Plumber captures one bounded graph-wide source set, selects
+Parser 1.9 internally, and projects its in-memory snapshot graph to opaque
+topology values. It creates no endpoint, CLI/MCP surface, consumer wiring, or
+Logseq DB support.
 `plumber.consumer.package/v1` additionally has static, immutable product-profile
 packages for Trama and Brain. They bind only intended contract vocabulary to
 checked-in static bytes; they create no runtime consumer support or topology
@@ -29,7 +32,7 @@ qualification.
 | Contract family | Intended responsibility | Status |
 | --- | --- | --- |
 | [`plumber.graph.read/v1`](plumber-graph-read-v1.md) | Session-bound identity, page, and complete ordered subtree reads. | Static artifact; identity-only internal OG slice. |
-| [`plumber.graph.topology/v1`](plumber-graph-topology-v1.md) | Complete, derived structural topology for consumers. | Static artifact; feature-off. |
+| [`plumber.graph.topology/v1`](plumber-graph-topology-v1.md) | Complete, derived structural topology for consumers. | Static artifact; internal OG slice; no external transport or consumer qualification. |
 | [`plumber.consumer.package/v1`](plumber-consumer-package-v1.md) | Immutable static contract-intention packages for Trama and Brain. | Static artifact; unqualified. |
 | `plumber.control/v1` | Bounded operator configuration and gardening commands. | Reserved; feature-off. |
 | `plumber.host.navigate/v1` | Explicit host navigation request, never implicit UI control. | Reserved; feature-off. |
@@ -47,7 +50,13 @@ profile, and consumer profile pass the recorded admission gate.
 opaque session, graph, and source revision vocabulary of `plumber.graph.read/v1`.
 It has no partial-success response, textual payload, host locator, or durable
 identifier claim. Its static fixture attestation does not qualify OG, DB,
-Parser, Shadow, Trama, Brain, or a consumer transport.
+Shadow, Trama, Brain, or a consumer transport. The internal OG slice separately
+admits no more than 1,024 Markdown sources / 16 MiB, constructs exactly one
+Parser `LogseqGraph.from_snapshot_pages()` result from those captured bytes, and
+rejects unresolved block references, title collisions, or node and edge counts
+above the v1 profile limits. It emits reference edges only from explicitly
+resolved Parser wikilinks and block references. It still does not qualify an
+external consumer or transport.
 
 `plumber.consumer.package/v1` records static consumer intent for Trama and
 Brain against exact schema and canonical consumer-profile hashes. Its

--- a/docs/contracts/plumber-graph-topology-v1.md
+++ b/docs/contracts/plumber-graph-topology-v1.md
@@ -12,11 +12,26 @@ owner: core-runtime
 
 ## Status
 
-`plumber.graph.topology/v1` is a **proposed, feature-off** public contract for
-complete, content-free structural graph topology. This artifact defines static
-interoperability inputs only. It creates no endpoint, CLI command, MCP tool,
-Logseq DB support, Parser runtime adapter, Shadow use, consumer wiring, or
-graph scan.
+`plumber.graph.topology/v1` is a **proposed public contract** for complete,
+content-free structural graph topology. Its checked-in artifact remains static
+interoperability input only: it creates no endpoint, CLI command, MCP tool,
+Logseq DB support, Shadow use, consumer wiring, or public transport.
+
+The internal OG implementation slice separately selects Parser 1.9 behind
+Plumber's adapter boundary. Plumber captures at most 1,024 regular Markdown
+sources / 16 MiB, hashes those exact bytes into one source revision, then calls
+`LogseqGraph.from_snapshot_pages()` once. It projects that in-memory graph to
+opaque nodes and reference edges, and rejects node or edge counts above the
+v1 1,024 / 4,096 limits. Parser strict-reference and strict-title-collision
+validation reject incomplete or ambiguous source graphs before projection. The
+projection accepts only explicitly resolved Parser wikilinks and block
+references. Parser's page-level `refs` is an aggregate of block convenience
+references plus property-derived wikilinks, tags, and block references; v1
+excludes it entirely because that aggregate loses the source semantics required
+for a structural edge. It likewise does not infer topology from Parser `tags`
+or node convenience `refs` fields. It never reopens source pages through
+Parser. This is not a consumer
+qualification, external endpoint, or Logseq DB capability.
 
 The canonical artifact is repository-owned and transport-neutral:
 
@@ -35,8 +50,9 @@ foreign graph, terminal session, or revision mismatch fails closed.
 
 This does not make `plumber.graph.read/v1` page or subtree delivery usable.
 `GraphReadPort` remains the filesystem/Shadow repository port; it is not a
-public session or topology port. The current internal OG identity slice serves
-one explicit page identity only and cannot serve graph-wide topology.
+public session or topology port. The internal OG topology slice retains the
+same Plumber-owned close and expiry lifecycle as identity reads and returns no
+page or subtree payload.
 
 ## Contract shape
 
@@ -70,10 +86,11 @@ do not claim cryptographic derivation, native-ID reuse, cross-graph
 linkability, or stability across a different source revision.
 
 Trama and Brain may consume a future qualified Plumber topology contract only.
-They do not import Parser or access Logseq directly. For OG, a future Plumber
-adapter may select Parser internally, then project Parser-owned structures into
-Plumber-owned values. It must separately qualify one coherent bounded
-graph-wide snapshot and revision; this static artifact does not qualify it.
+They do not import Parser or access Logseq directly. For OG, Plumber's internal
+adapter now selects Parser 1.9 and projects Parser-owned structures into
+Plumber-owned values from one coherent bounded source revision. The static
+artifact and internal slice still do not qualify Trama, Brain, DB support, or
+an external consumer transport.
 
 ## Canonical fixture catalogue
 

--- a/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
+++ b/docs/decisions/2026-09-05-plumber-logseq-gateway-authority.md
@@ -42,7 +42,7 @@ UI owner, while Plumber retains its bounded Operator Console. No LENS source or 
 | OG Markdown parsing | Parser, selected by Plumber | Parser owns parsing; legacy/experimental LENS remains compatible only during its deprecation window. |
 | OG and Shadow repository reads | Plumber `GraphReadPort` | `GraphReadPort remains filesystem/Shadow-only`; it is not a session or DB port. |
 | Logseq DB host access | Plumber | A future adapter may use only a qualified **Logseq DB official host surface**. |
-| Consumer graph reads | Plumber `GraphSessionReadPort` | Internal OG identity-only runtime exists; page/subtree and external transport remain feature-off. |
+| Consumer graph reads | Plumber `GraphSessionReadPort` | Internal OG identity and complete opaque topology slices exist; page/subtree and external transport remain feature-off. |
 | Graph and control contracts | Plumber | `plumber.graph.read/v1`, `plumber.graph.topology/v1`, `plumber.control/v1`, and `plumber.host.navigate/v1`. |
 | Product intelligence and graph UI | Trama | Consumer implementation over published Plumber contracts. |
 | Optional analysis consumer | Brain | Consumer implementation over published Plumber contracts. |
@@ -66,6 +66,11 @@ synthetic fixtures, and a compatibility test kit before a consumer is wired.
 The internal OG identity-only `GraphSessionReadPort` uses only an explicit
 Parser source, one byte-bounded UTF-8 snapshot, opaque identity, session
 binding, source revision, and Plumber-owned close/monotonic-expiry lifecycle.
+The internal complete-topology slice captures one bounded graph-wide OG source
+set and calls Parser 1.9 `LogseqGraph.from_snapshot_pages()` once; it projects
+only opaque structural values from explicitly resolved wikilinks and block
+references. It fails closed for unresolved block references, title collisions,
+and values above its declared bounds.
 Page and complete ordered subtree reads remain feature-off until the artifact
 and the selected source profile qualify bounded payloads, failure semantics,
 and consumer compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 dependencies = [
-    "logseq-matryca-parser>=1.7.1,<2.0.0",
+    "logseq-matryca-parser>=1.9.0,<2.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "loguru>=0.7.0,<1.0.0",

--- a/src/agent/og_parser_identity_adapter.py
+++ b/src/agent/og_parser_identity_adapter.py
@@ -42,13 +42,17 @@ def _require_regular_source(metadata: os.stat_result) -> None:
         raise GraphSessionReadError("OG snapshot source rejected")
 
 
-def _read_bounded_snapshot(page_path: Path) -> bytes:
+def _read_bounded_snapshot(
+    page_path: Path,
+    *,
+    max_bytes: int = MAX_OG_IDENTITY_SNAPSHOT_BYTES,
+) -> bytes:
     """Read one stable, bounded snapshot through a descriptor bound to its lstat identity."""
     descriptor = -1
     try:
         before = page_path.lstat()
         _require_regular_source(before)
-        if before.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES:
+        if before.st_size > max_bytes:
             raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
         flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         descriptor = os.open(page_path, flags)
@@ -58,9 +62,9 @@ def _read_bounded_snapshot(page_path: Path) -> bytes:
             _require_regular_source(descriptor_metadata)
             if _file_identity(before) != _file_identity(descriptor_metadata):
                 raise GraphSessionReadError("OG snapshot changed during read")
-            if descriptor_metadata.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES:
+            if descriptor_metadata.st_size > max_bytes:
                 raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
-            snapshot = handle.read(MAX_OG_IDENTITY_SNAPSHOT_BYTES + 1)
+            snapshot = handle.read(max_bytes + 1)
         after = page_path.lstat()
         _require_regular_source(after)
     except GraphSessionReadError:
@@ -71,10 +75,7 @@ def _read_bounded_snapshot(page_path: Path) -> bytes:
         if descriptor != -1:
             with suppress(OSError):
                 os.close(descriptor)
-    if (
-        len(snapshot) > MAX_OG_IDENTITY_SNAPSHOT_BYTES
-        or after.st_size > MAX_OG_IDENTITY_SNAPSHOT_BYTES
-    ):
+    if len(snapshot) > max_bytes or after.st_size > max_bytes:
         raise GraphSessionReadError("OG snapshot exceeds byte ceiling")
     if _file_identity(descriptor_metadata) != _file_identity(after):
         raise GraphSessionReadError("OG snapshot changed during read")

--- a/src/agent/og_parser_topology_adapter.py
+++ b/src/agent/og_parser_topology_adapter.py
@@ -1,0 +1,206 @@
+"""Private Parser 1.9 adapter for one bounded, complete OG topology snapshot."""
+
+from __future__ import annotations
+
+import hashlib
+import stat
+from pathlib import Path
+
+from logseq_matryca_parser.graph import LogseqGraph, SnapshotPage
+from logseq_matryca_parser.logos_core import LogseqNode, LogseqPage
+
+from ..graph.path_sandbox import resolved_graph_root
+from ..graph.ports.session_read import OgGraphTopologyPort
+from ..graph.session_read_models import GraphSessionReadError
+from ..graph.session_topology_models import (
+    GraphTopologyNode,
+    GraphTopologyProvenance,
+    GraphTopologyReference,
+    GraphTopologyResult,
+    OgTopologySourceSnapshot,
+)
+from .og_parser_identity_adapter import _opaque_digest, _read_bounded_snapshot
+
+MAX_OG_TOPOLOGY_SNAPSHOT_PAGES = 1024
+MAX_OG_TOPOLOGY_SNAPSHOT_BYTES = 16 * 1024 * 1024
+MAX_OG_TOPOLOGY_SNAPSHOT_PAGE_BYTES = 1024 * 1024
+MAX_OG_TOPOLOGY_NODES = 1024
+MAX_OG_TOPOLOGY_EDGES = 4096
+
+
+def _opaque_topology_token(*parts: str) -> str:
+    digest = hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()[:32]
+    return f"topology-{digest}"
+
+
+def _regular_markdown_paths(root: Path) -> tuple[tuple[str, Path], ...]:
+    """Discover only regular ``pages/`` and ``journals/`` Markdown candidates."""
+    candidates: list[tuple[str, Path]] = []
+    try:
+        for directory_name in ("pages", "journals"):
+            directory = root / directory_name
+            try:
+                directory_metadata = directory.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(directory_metadata.st_mode) or not stat.S_ISDIR(
+                directory_metadata.st_mode
+            ):
+                raise GraphSessionReadError("OG topology source rejected")
+            for path in directory.rglob("*.md"):
+                if stat.S_ISREG(path.lstat().st_mode):
+                    candidates.append((path.relative_to(root).as_posix(), path))
+    except OSError as exc:
+        raise GraphSessionReadError("OG topology discovery rejected") from exc
+    candidates.sort(key=lambda item: item[0])
+    if len(candidates) > MAX_OG_TOPOLOGY_SNAPSHOT_PAGES:
+        raise GraphSessionReadError("OG topology page limit exceeded")
+    return tuple(candidates)
+
+
+def _capture_snapshot_pages(root: Path) -> tuple[tuple[SnapshotPage, ...], str]:
+    """Capture one bounded source set before Parser performs any graph construction."""
+    captured: list[SnapshotPage] = []
+    revision = hashlib.sha256()
+    total_bytes = 0
+    for logical_path, path in _regular_markdown_paths(root):
+        snapshot = _read_bounded_snapshot(path, max_bytes=MAX_OG_TOPOLOGY_SNAPSHOT_PAGE_BYTES)
+        total_bytes += len(snapshot)
+        if total_bytes > MAX_OG_TOPOLOGY_SNAPSHOT_BYTES:
+            raise GraphSessionReadError("OG topology byte limit exceeded")
+        try:
+            text = snapshot.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GraphSessionReadError("OG topology decoding rejected") from exc
+        logical_bytes = logical_path.encode("utf-8")
+        revision.update(len(logical_bytes).to_bytes(4, "big"))
+        revision.update(logical_bytes)
+        revision.update(len(snapshot).to_bytes(8, "big"))
+        revision.update(snapshot)
+        captured.append(SnapshotPage(logical_path=logical_path, text=text))
+    return tuple(captured), revision.hexdigest()
+
+
+def _append_node(
+    *,
+    nodes: list[GraphTopologyNode],
+    node_ids: dict[str, str],
+    source_revision: str,
+    parser_node: LogseqNode,
+    parent_id: str,
+    ordinal: int,
+) -> None:
+    node_id = _opaque_topology_token(source_revision, "block", parser_node.uuid)
+    node_ids[parser_node.uuid] = node_id
+    nodes.append(GraphTopologyNode(id=node_id, kind="block", parent_id=parent_id, ordinal=ordinal))
+    for child_ordinal, child in enumerate(parser_node.children):
+        _append_node(
+            nodes=nodes,
+            node_ids=node_ids,
+            source_revision=source_revision,
+            parser_node=child,
+            parent_id=node_id,
+            ordinal=child_ordinal,
+        )
+
+
+def _canonical_pages(graph: LogseqGraph) -> tuple[LogseqPage, ...]:
+    """Use Parser's in-memory snapshot graph but select a deterministic page order."""
+    return tuple(sorted(graph.iter_canonical_pages(), key=lambda page: page.source_path or ""))
+
+
+def _project_topology(graph: LogseqGraph, source_revision: str) -> GraphTopologyResult:
+    """Project Parser-owned values into bounded Plumber-owned opaque topology values."""
+    pages = _canonical_pages(graph)
+    page_ids = {
+        page.title: _opaque_topology_token(source_revision, "page", page.source_path or page.title)
+        for page in pages
+    }
+    nodes: list[GraphTopologyNode] = []
+    node_ids: dict[str, str] = {}
+    for page_ordinal, page in enumerate(pages):
+        page_id = page_ids[page.title]
+        nodes.append(
+            GraphTopologyNode(id=page_id, kind="page", parent_id=None, ordinal=page_ordinal)
+        )
+        for child_ordinal, child in enumerate(page.root_nodes):
+            _append_node(
+                nodes=nodes,
+                node_ids=node_ids,
+                source_revision=source_revision,
+                parser_node=child,
+                parent_id=page_id,
+                ordinal=child_ordinal,
+            )
+    if len(nodes) > MAX_OG_TOPOLOGY_NODES:
+        raise GraphSessionReadError("OG topology node limit exceeded")
+
+    edges: set[tuple[str, str]] = set()
+
+    def add_page_reference(source_id: str, reference: str) -> None:
+        target = graph.get_page(reference)
+        if target is not None and target.title in page_ids:
+            edges.add((source_id, page_ids[target.title]))
+
+    def add_block_references(source_id: str, parser_node: LogseqNode) -> None:
+        for reference in parser_node.wikilinks:
+            add_page_reference(source_id, reference)
+        for reference in parser_node.block_refs:
+            target = graph.get_node_by_embed_ref(reference)
+            if target is not None and target.uuid in node_ids:
+                edges.add((source_id, node_ids[target.uuid]))
+        for child in parser_node.children:
+            child_id = node_ids[child.uuid]
+            add_block_references(child_id, child)
+
+    for page in pages:
+        page_id = page_ids[page.title]
+        for child in page.root_nodes:
+            add_block_references(node_ids[child.uuid], child)
+
+    if len(edges) > MAX_OG_TOPOLOGY_EDGES:
+        raise GraphSessionReadError("OG topology edge limit exceeded")
+    ordered_edges = tuple(
+        GraphTopologyReference(source_id=source_id, target_id=target_id)
+        for source_id, target_id in sorted(edges)
+    )
+    return GraphTopologyResult(
+        topology_id=_opaque_topology_token(source_revision, "graph"),
+        nodes=tuple(nodes),
+        edges=ordered_edges,
+        provenance=GraphTopologyProvenance(source_revision=source_revision),
+    )
+
+
+class ParserOgTopologyAdapter(OgGraphTopologyPort):
+    """Build a complete topology only from Plumber-captured bytes and Parser's public API."""
+
+    def snapshot_og_graph(self, graph_root: Path) -> OgTopologySourceSnapshot:
+        root = resolved_graph_root(graph_root)
+        if not root.is_dir():
+            raise GraphSessionReadError("OG graph root unavailable")
+        snapshot_pages, source_revision = _capture_snapshot_pages(root)
+        try:
+            graph = LogseqGraph.from_snapshot_pages(
+                root,
+                snapshot_pages,
+                strict_refs=True,
+                strict_title_collisions=True,
+            )
+        except Exception as exc:
+            raise GraphSessionReadError("OG Parser topology read failed") from exc
+        return OgTopologySourceSnapshot(
+            graph_id=_opaque_digest(str(root)),
+            source_revision=source_revision,
+            topology=_project_topology(graph, source_revision),
+        )
+
+
+__all__ = [
+    "MAX_OG_TOPOLOGY_EDGES",
+    "MAX_OG_TOPOLOGY_NODES",
+    "MAX_OG_TOPOLOGY_SNAPSHOT_BYTES",
+    "MAX_OG_TOPOLOGY_SNAPSHOT_PAGE_BYTES",
+    "MAX_OG_TOPOLOGY_SNAPSHOT_PAGES",
+    "ParserOgTopologyAdapter",
+]

--- a/src/agent/og_topology_session_composition.py
+++ b/src/agent/og_topology_session_composition.py
@@ -1,0 +1,55 @@
+"""Composition root for one internal, complete OG topology session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from ..graph.ports.session_read import GraphSessionReadPort, OgGraphTopologyPort
+from ..graph.session_read_models import (
+    GraphReadCapability,
+    GraphSession,
+    GraphSourceIdentity,
+    GraphTopologyCapability,
+)
+from ..graph.session_read_service import GraphSessionReadService
+from .og_parser_topology_adapter import ParserOgTopologyAdapter
+
+
+@dataclass(frozen=True, slots=True)
+class OgGraphTopologySessionReader:
+    """One consumer-ready reader plus its explicit active topology session descriptor."""
+
+    session: GraphSession
+    reader: GraphSessionReadPort
+
+
+def create_og_topology_session_reader(
+    graph_root: Path,
+    *,
+    topology_source: OgGraphTopologyPort | None = None,
+) -> OgGraphTopologySessionReader:
+    """Bind one Parser-built, graph-wide OG snapshot to a Plumber-owned session."""
+    source = topology_source or ParserOgTopologyAdapter()
+    snapshot = source.snapshot_og_graph(graph_root)
+    session = GraphSession.from_source(
+        session_id=uuid4().hex,
+        source=GraphSourceIdentity(
+            graph_id=snapshot.graph_id,
+            source_revision=snapshot.source_revision,
+        ),
+        capabilities=frozenset(
+            {
+                GraphReadCapability.GRAPH_IDENTIFY,
+                GraphTopologyCapability.GRAPH_TOPOLOGY_SNAPSHOT_COMPLETE,
+            }
+        ),
+    )
+    return OgGraphTopologySessionReader(
+        session=session,
+        reader=GraphSessionReadService(session, topology=snapshot.topology),
+    )
+
+
+__all__ = ["OgGraphTopologySessionReader", "create_og_topology_session_reader"]

--- a/src/graph/ports/__init__.py
+++ b/src/graph/ports/__init__.py
@@ -1,6 +1,6 @@
 """Graph layer ports (protocols) for v2 read/write adapters."""
 
 from .read import GraphReadPort
-from .session_read import GraphSessionReadPort, OgGraphIdentityPort
+from .session_read import GraphSessionReadPort, OgGraphIdentityPort, OgGraphTopologyPort
 
-__all__ = ["GraphReadPort", "GraphSessionReadPort", "OgGraphIdentityPort"]
+__all__ = ["GraphReadPort", "GraphSessionReadPort", "OgGraphIdentityPort", "OgGraphTopologyPort"]

--- a/src/graph/ports/session_read.py
+++ b/src/graph/ports/session_read.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Protocol
 
 from ..session_read_models import GraphIdentityResponse, GraphSourceIdentity
+from ..session_topology_models import GraphTopologyResponse, OgTopologySourceSnapshot
 
 
 class OgGraphIdentityPort(Protocol):
@@ -16,6 +17,14 @@ class OgGraphIdentityPort(Protocol):
         ...
 
 
+class OgGraphTopologyPort(Protocol):
+    """Internal source boundary implemented by Plumber's OG Parser topology adapter."""
+
+    def snapshot_og_graph(self, graph_root: Path) -> OgTopologySourceSnapshot:
+        """Return one complete content-free topology bound to a Plumber-captured source revision."""
+        ...
+
+
 class GraphSessionReadPort(Protocol):
     """Consumer boundary for the current identity-only Plumber session slice."""
 
@@ -23,9 +32,13 @@ class GraphSessionReadPort(Protocol):
         """Return identity only when the caller presents the active graph binding."""
         ...
 
+    def topology_snapshot(self, *, session_id: str, graph_id: str) -> GraphTopologyResponse:
+        """Return complete structural topology only for an active, bound OG snapshot session."""
+        ...
+
     def close(self) -> None:
         """Close this Plumber-owned session; repeated close calls are harmless."""
         ...
 
 
-__all__ = ["GraphSessionReadPort", "OgGraphIdentityPort"]
+__all__ = ["GraphSessionReadPort", "OgGraphIdentityPort", "OgGraphTopologyPort"]

--- a/src/graph/session_read_models.py
+++ b/src/graph/session_read_models.py
@@ -24,6 +24,12 @@ class GraphReadCapability(StrEnum):
     GRAPH_IDENTIFY = "graph.identify"
 
 
+class GraphTopologyCapability(StrEnum):
+    """Only graph-wide topology operation admitted by the v1 runtime slice."""
+
+    GRAPH_TOPOLOGY_SNAPSHOT_COMPLETE = "graph.topology.snapshot.complete"
+
+
 class GraphSessionState(StrEnum):
     """Lifecycle states that may be exposed by an identity-only session."""
 
@@ -61,7 +67,7 @@ class GraphSession(_OpaqueIdentityModel):
     graph_id: str
     source_revision: str
     mode: Literal["og"] = "og"
-    capabilities: frozenset[GraphReadCapability]
+    capabilities: frozenset[GraphReadCapability | GraphTopologyCapability]
     state: GraphSessionState = GraphSessionState.ACTIVE
     expires_at_monotonic: float | None = None
 
@@ -79,13 +85,14 @@ class GraphSession(_OpaqueIdentityModel):
         session_id: str,
         source: GraphSourceIdentity,
         expires_at_monotonic: float | None = None,
+        capabilities: frozenset[GraphReadCapability | GraphTopologyCapability] | None = None,
     ) -> GraphSession:
         """Create the only session shape admitted by the OG identity slice."""
         return cls(
             id=session_id,
             graph_id=source.graph_id,
             source_revision=source.source_revision,
-            capabilities=frozenset({GraphReadCapability.GRAPH_IDENTIFY}),
+            capabilities=capabilities or frozenset({GraphReadCapability.GRAPH_IDENTIFY}),
             expires_at_monotonic=expires_at_monotonic,
         )
 
@@ -120,4 +127,5 @@ __all__ = [
     "GraphSessionReadError",
     "GraphSessionState",
     "GraphSourceIdentity",
+    "GraphTopologyCapability",
 ]

--- a/src/graph/session_read_service.py
+++ b/src/graph/session_read_service.py
@@ -13,16 +13,28 @@ from .session_read_models import (
     GraphSession,
     GraphSessionReadError,
     GraphSessionState,
+    GraphTopologyCapability,
+)
+from .session_topology_models import (
+    GraphTopologyResponse,
+    GraphTopologyResult,
 )
 
 
 class GraphSessionReadService(GraphSessionReadPort):
     """Serve one active, bound graph identity without selecting a source or transport."""
 
-    def __init__(self, session: GraphSession, *, clock: Callable[[], float] = monotonic) -> None:
+    def __init__(
+        self,
+        session: GraphSession,
+        *,
+        clock: Callable[[], float] = monotonic,
+        topology: GraphTopologyResult | None = None,
+    ) -> None:
         self._session = session
         self._clock = clock
         self._state = session.state
+        self._topology = topology
 
     def close(self) -> None:
         """Close an active session once; a terminal session stays terminal."""
@@ -43,6 +55,26 @@ class GraphSessionReadService(GraphSessionReadPort):
             graph_id=self._session.graph_id,
             source_revision=self._session.source_revision,
             result=GraphIdentityResult(graph_id=self._session.graph_id),
+        )
+
+    def topology_snapshot(self, *, session_id: str, graph_id: str) -> GraphTopologyResponse:
+        """Return one complete, content-free topology or reject an invalid session binding."""
+        if session_id != self._session.id:
+            raise GraphSessionReadError("session binding rejected")
+        self._require_active_session()
+        if graph_id != self._session.graph_id:
+            raise GraphSessionReadError("foreign graph binding rejected")
+        if (
+            GraphTopologyCapability.GRAPH_TOPOLOGY_SNAPSHOT_COMPLETE
+            not in self._session.capabilities
+            or self._topology is None
+        ):
+            raise GraphSessionReadError("graph topology capability unavailable")
+        return GraphTopologyResponse(
+            session_id=self._session.id,
+            graph_id=self._session.graph_id,
+            source_revision=self._session.source_revision,
+            result=self._topology,
         )
 
     def _require_active_session(self) -> None:

--- a/src/graph/session_topology_models.py
+++ b/src/graph/session_topology_models.py
@@ -1,0 +1,153 @@
+"""Plumber-owned, content-free values for one complete OG topology snapshot."""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .session_read_models import CONTRACT_ID, SCHEMA_VERSION
+
+TOPOLOGY_CONTRACT_ID: Final[Literal["plumber.graph.topology/v1"]] = "plumber.graph.topology/v1"
+TOPOLOGY_SCHEMA_VERSION: Final[Literal[1]] = 1
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+
+def _validate_opaque_id(value: str) -> str:
+    if len(value) > 128 or not _OPAQUE_ID.fullmatch(value):
+        raise ValueError("must be a bounded opaque identifier")
+    return value
+
+
+class _TopologyModel(BaseModel):
+    """Reject undeclared fields from every topology boundary value."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class GraphTopologyNode(_TopologyModel):
+    """One opaque, content-free page or block position in canonical preorder."""
+
+    id: str
+    kind: Literal["page", "block"]
+    parent_id: str | None
+    ordinal: int = Field(ge=0)
+
+    @field_validator("id", "parent_id")
+    @classmethod
+    def _validate_ids(cls, value: str | None) -> str | None:
+        return _validate_opaque_id(value) if value is not None else None
+
+
+class GraphTopologyReference(_TopologyModel):
+    """One declared, non-containment structural reference."""
+
+    source_id: str
+    target_id: str
+    kind: Literal["reference"] = "reference"
+
+    @field_validator("source_id", "target_id")
+    @classmethod
+    def _validate_ids(cls, value: str) -> str:
+        return _validate_opaque_id(value)
+
+
+class GraphTopologyProvenance(_TopologyModel):
+    """Bind a topology result to the exact Plumber graph-read source revision."""
+
+    kind: Literal["derived-structural"] = "derived-structural"
+    source_contract_id: Literal["plumber.graph.read/v1"] = CONTRACT_ID
+    source_schema_version: Literal[1] = SCHEMA_VERSION
+    source_revision: str
+
+    @field_validator("source_revision")
+    @classmethod
+    def _validate_source_revision(cls, value: str) -> str:
+        return _validate_opaque_id(value)
+
+
+class GraphTopologyResult(_TopologyModel):
+    """Complete, bounded topology with no Markdown, path, title, or native ID fields."""
+
+    topology_id: str
+    complete: Literal[True] = True
+    nodes: tuple[GraphTopologyNode, ...] = Field(max_length=1024)
+    edges: tuple[GraphTopologyReference, ...] = Field(max_length=4096)
+    provenance: GraphTopologyProvenance
+
+    @field_validator("topology_id")
+    @classmethod
+    def _validate_topology_id(cls, value: str) -> str:
+        return _validate_opaque_id(value)
+
+    @model_validator(mode="after")
+    def _validate_canonical_preorder(self) -> GraphTopologyResult:
+        """Reject non-complete structural values before any consumer service receives them."""
+        seen: dict[str, GraphTopologyNode] = {}
+        next_ordinal: dict[str | None, int] = {}
+        for node in self.nodes:
+            if node.id in seen:
+                raise ValueError("topology node identifiers must be unique")
+            if node.kind == "page" and node.parent_id is not None:
+                raise ValueError("topology page nodes must be roots")
+            if node.kind == "block" and node.parent_id is None:
+                raise ValueError("topology block nodes require a parent")
+            if node.parent_id is not None and node.parent_id not in seen:
+                raise ValueError("topology nodes must use canonical preorder")
+            expected = next_ordinal.get(node.parent_id, 0)
+            if node.ordinal != expected:
+                raise ValueError("topology sibling ordinals must be contiguous")
+            next_ordinal[node.parent_id] = expected + 1
+            seen[node.id] = node
+        for edge in self.edges:
+            if edge.source_id not in seen or edge.target_id not in seen:
+                raise ValueError("topology references must target declared topology nodes")
+        edge_keys = tuple((edge.kind, edge.source_id, edge.target_id) for edge in self.edges)
+        if edge_keys != tuple(sorted(set(edge_keys))):
+            raise ValueError("topology references must use canonical lexical order")
+        return self
+
+
+class GraphTopologyResponse(_TopologyModel):
+    """Plumber-owned successful response for one active, bound topology session."""
+
+    contract_id: Literal["plumber.graph.topology/v1"] = TOPOLOGY_CONTRACT_ID
+    schema_version: Literal[1] = TOPOLOGY_SCHEMA_VERSION
+    session_id: str
+    graph_id: str
+    source_revision: str
+    operation: Literal["graph.topology.snapshot.complete"] = "graph.topology.snapshot.complete"
+    outcome: Literal["pass"] = "pass"
+    reason: Literal["og-parser-snapshot"] = "og-parser-snapshot"
+    result: GraphTopologyResult
+
+    @field_validator("session_id", "graph_id", "source_revision")
+    @classmethod
+    def _validate_ids(cls, value: str) -> str:
+        return _validate_opaque_id(value)
+
+
+class OgTopologySourceSnapshot(_TopologyModel):
+    """Internal adapter result, normalized before any consumer-facing service receives it."""
+
+    graph_id: str
+    source_revision: str
+    topology: GraphTopologyResult
+
+    @field_validator("graph_id", "source_revision")
+    @classmethod
+    def _validate_ids(cls, value: str) -> str:
+        return _validate_opaque_id(value)
+
+
+__all__ = [
+    "GraphTopologyNode",
+    "GraphTopologyProvenance",
+    "GraphTopologyReference",
+    "GraphTopologyResponse",
+    "GraphTopologyResult",
+    "OgTopologySourceSnapshot",
+    "TOPOLOGY_CONTRACT_ID",
+    "TOPOLOGY_SCHEMA_VERSION",
+]

--- a/tests/test_ast_cache_bounded_parse.py
+++ b/tests/test_ast_cache_bounded_parse.py
@@ -17,8 +17,6 @@ from src.graph.bounded_ast_graph import (
 )
 from src.graph.bounded_page_parse import get_bounded_page_parse_worker
 
-from tests.a_cli_01_generator import generate_pathological_page
-
 
 @pytest.fixture(autouse=True)
 def _clean_cache_and_worker() -> Iterator[None]:
@@ -84,13 +82,20 @@ def test_bootstrap_failure_does_not_publish_partial_graph(
     assert str(tmp_path) not in rendered
 
 
-def test_real_pathological_page_is_bounded_without_partial_publication(
+def test_bounded_timeout_does_not_publish_partial_graph(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
     _write_page(tmp_path, "Alpha.md", "- ordinary\n")
-    _write_page(tmp_path, "Pathological.md", generate_pathological_page())
+    timed_out = _write_page(tmp_path, "TimedOut.md", "- controlled timeout\n")
+    from src.graph.bounded_ast_graph import parse_graph_page_bounded as real_parse
+
+    def _parse(path: Path, graph_root: Path) -> BoundedGraphPageResult:
+        if path == timed_out:
+            return _failure()
+        return real_parse(path, graph_root)
+
+    monkeypatch.setattr("src.graph.ast_cache.parse_graph_page_bounded", _parse)
     cache = GraphAstCache(tmp_path)
 
     with pytest.raises(GraphAstParseError) as caught:
@@ -100,7 +105,7 @@ def test_real_pathological_page_is_bounded_without_partial_publication(
     assert caught.value.failure.error == "timeout"
     assert cache._graph is None
     rendered = str(caught.value)
-    assert "Pathological.md" not in rendered
+    assert "TimedOut.md" not in rendered
     assert str(tmp_path) not in rendered
 
 

--- a/tests/test_bounded_page_parse.py
+++ b/tests/test_bounded_page_parse.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import multiprocessing as mp
 import os
 import random
 import signal
@@ -26,11 +27,7 @@ from src.graph.bounded_page_parse import (
     reset_bounded_page_parse_worker_for_tests,
 )
 
-from tests.a_cli_01_generator import (
-    PATHOLOGICAL_PAGE_LINE_COUNT,
-    generate_control_page,
-    generate_pathological_page,
-)
+from tests.a_cli_01_generator import generate_control_page
 
 
 @pytest.fixture(autouse=True)
@@ -53,6 +50,39 @@ def _pid_alive(pid: int) -> bool:
 def _page_raw(page: Any) -> str:
     raw = getattr(page, "raw_content", None)
     return raw if isinstance(raw, str) else ""
+
+
+def _controlled_hanging_worker(
+    in_q: Any,
+    out_q: Any,
+) -> None:
+    """Test-only child that deterministically exceeds the parent's deadline."""
+    del out_q
+    if in_q.get() is not None:
+        time.sleep(30.0)
+
+
+def _install_controlled_hanging_worker(worker: BoundedPageParseWorker) -> None:
+    """Install a spawn child behind the real worker lifecycle for timeout tests.
+
+    Parser performance is intentionally not used as a timeout trigger: Parser
+    1.9 correctly completes the historic pathological fixture quickly.  This
+    controlled child keeps the production queue, deadline, terminate, discard,
+    and recycle paths under test without making a parser latency claim.
+    """
+    context = mp.get_context("spawn")
+    in_q = context.Queue(maxsize=1)
+    out_q = context.Queue(maxsize=1)
+    proc = context.Process(
+        target=_controlled_hanging_worker,
+        args=(in_q, out_q),
+        name="matryca-bounded-page-parse-test-hang",
+        daemon=True,
+    )
+    proc.start()
+    worker._in_q = in_q  # noqa: SLF001 - controlled worker-lifecycle seam
+    worker._out_q = out_q  # noqa: SLF001 - controlled worker-lifecycle seam
+    worker._proc = proc  # noqa: SLF001 - controlled worker-lifecycle seam
 
 
 def _daemon_pool_parse_probe(text: str) -> dict[str, object]:
@@ -123,12 +153,12 @@ def test_invalid_mode_rejected_without_silent_logos() -> None:
     assert result.page is None
 
 
-def test_pathological_page_times_out_and_kills_worker() -> None:
-    text = generate_pathological_page()
-    assert text.count("\n") == PATHOLOGICAL_PAGE_LINE_COUNT
+def test_controlled_hanging_child_times_out_and_kills_worker() -> None:
+    """The real worker must kill a deterministic overrun child."""
     worker = BoundedPageParseWorker()
     try:
-        result = worker.parse_text(text, mode="logos", timeout_s=3.0)
+        _install_controlled_hanging_worker(worker)
+        result = worker.parse_text("- controlled timeout\n", mode="logos", timeout_s=3.0)
         assert result.ok is False
         assert result.timed_out is True
         assert result.error == "timeout"
@@ -301,11 +331,8 @@ def test_parse_result_repr_excludes_page_and_sensitive_text() -> None:
 def test_timeout_then_healthy_parse_gets_new_pid() -> None:
     worker = BoundedPageParseWorker()
     try:
-        timed = worker.parse_text(
-            generate_pathological_page(),
-            mode="logos",
-            timeout_s=3.0,
-        )
+        _install_controlled_hanging_worker(worker)
+        timed = worker.parse_text("- controlled timeout\n", mode="logos", timeout_s=3.0)
         assert timed.timed_out is True
         assert worker.pid is None
 
@@ -375,11 +402,8 @@ def test_worker_crash_recovers_bounded() -> None:
 def test_no_stale_result_after_timeout() -> None:
     worker = BoundedPageParseWorker()
     try:
-        timed = worker.parse_text(
-            generate_pathological_page(),
-            mode="logos",
-            timeout_s=3.0,
-        )
+        _install_controlled_hanging_worker(worker)
+        timed = worker.parse_text("- controlled timeout\n", mode="logos", timeout_s=3.0)
         assert timed.timed_out is True
         next_text = "- fresh after timeout no stale MARKER-9911\n"
         nxt = worker.parse_text(next_text, mode="logos", timeout_s=15.0)

--- a/tests/test_og_topology_session_read.py
+++ b/tests/test_og_topology_session_read.py
@@ -1,0 +1,195 @@
+"""Behavior specification for the bounded OG topology session slice."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from logseq_matryca_parser import LogosParser
+from pydantic import ValidationError
+from src.graph.session_read_models import GraphSessionReadError
+
+
+def _write_page(root: Path, relative_path: str, markdown: str) -> None:
+    page_path = root / relative_path
+    page_path.parent.mkdir(parents=True, exist_ok=True)
+    page_path.write_text(markdown, encoding="utf-8")
+
+
+def test_og_topology_uses_one_complete_parser_snapshot_without_content_leakage(
+    tmp_path: Path,
+) -> None:
+    """Breaks if topology reopens source files or exposes Parser or Markdown values."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    _write_page(
+        tmp_path,
+        "pages/Alpha.md",
+        "- alpha [[Beta]]\n"
+        "  id:: 11111111-1111-1111-1111-111111111111\n"
+        "  - child ((22222222-2222-2222-2222-222222222222))\n"
+        "    id:: 33333333-3333-3333-3333-333333333333\n",
+    )
+    _write_page(
+        tmp_path,
+        "pages/Beta.md",
+        "- beta\n  id:: 22222222-2222-2222-2222-222222222222\n",
+    )
+
+    binding = create_og_topology_session_reader(tmp_path)
+    response = binding.reader.topology_snapshot(
+        session_id=binding.session.id,
+        graph_id=binding.session.graph_id,
+    )
+
+    assert response.contract_id == "plumber.graph.topology/v1"
+    assert response.operation == "graph.topology.snapshot.complete"
+    assert response.source_revision == binding.session.source_revision
+    assert response.result.complete is True
+    assert len(response.result.nodes) == 5
+    assert [node.ordinal for node in response.result.nodes if node.parent_id is None] == [0, 1]
+    assert response.result.edges
+    rendered = response.model_dump_json()
+    assert "Alpha" not in rendered
+    assert "Beta" not in rendered
+    assert "alpha" not in rendered
+    assert "pages/" not in rendered
+    assert "11111111-1111-1111-1111-111111111111" not in rendered
+
+
+def test_topology_values_reject_noncanonical_parentage_before_service_delivery() -> None:
+    """Breaks if a future adapter can pass a partial or out-of-order topology to consumers."""
+    from src.graph.session_topology_models import (
+        GraphTopologyNode,
+        GraphTopologyProvenance,
+        GraphTopologyResult,
+    )
+
+    with pytest.raises(ValidationError, match="canonical preorder"):
+        GraphTopologyResult(
+            topology_id="topology-alpha",
+            nodes=(
+                GraphTopologyNode(
+                    id="block-alpha", kind="block", parent_id="page-alpha", ordinal=0
+                ),
+                GraphTopologyNode(id="page-alpha", kind="page", parent_id=None, ordinal=0),
+            ),
+            edges=(),
+            provenance=GraphTopologyProvenance(source_revision="revision-alpha"),
+        )
+
+
+def test_topology_values_reject_reference_to_undeclared_node() -> None:
+    """Breaks if a response can claim a structural reference outside its complete node set."""
+    from src.graph.session_topology_models import (
+        GraphTopologyNode,
+        GraphTopologyProvenance,
+        GraphTopologyReference,
+        GraphTopologyResult,
+    )
+
+    with pytest.raises(ValidationError, match="declared topology nodes"):
+        GraphTopologyResult(
+            topology_id="topology-alpha",
+            nodes=(GraphTopologyNode(id="page-alpha", kind="page", parent_id=None, ordinal=0),),
+            edges=(GraphTopologyReference(source_id="page-alpha", target_id="node-missing"),),
+            provenance=GraphTopologyProvenance(source_revision="revision-alpha"),
+        )
+
+
+def test_topology_values_reject_noncanonical_reference_order() -> None:
+    """Breaks if the service can expose a nondeterministic complete topology order."""
+    from src.graph.session_topology_models import (
+        GraphTopologyNode,
+        GraphTopologyProvenance,
+        GraphTopologyReference,
+        GraphTopologyResult,
+    )
+
+    with pytest.raises(ValidationError, match="canonical lexical order"):
+        GraphTopologyResult(
+            topology_id="topology-alpha",
+            nodes=(
+                GraphTopologyNode(id="page-alpha", kind="page", parent_id=None, ordinal=0),
+                GraphTopologyNode(id="page-beta", kind="page", parent_id=None, ordinal=1),
+            ),
+            edges=(
+                GraphTopologyReference(source_id="page-beta", target_id="page-alpha"),
+                GraphTopologyReference(source_id="page-alpha", target_id="page-beta"),
+            ),
+            provenance=GraphTopologyProvenance(source_revision="revision-alpha"),
+        )
+
+
+def test_og_topology_rejects_symlinked_source_directory(tmp_path: Path) -> None:
+    """Breaks if the graph-wide capture can traverse outside its selected OG root."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _write_page(outside, "Secret.md", "- must not become graph input\n")
+    (tmp_path / "pages").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(GraphSessionReadError, match="source rejected"):
+        create_og_topology_session_reader(tmp_path)
+
+
+def test_og_topology_rejects_unresolved_block_reference(tmp_path: Path) -> None:
+    """Breaks if an incomplete graph can be projected as a complete topology."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    _write_page(
+        tmp_path,
+        "pages/Alpha.md",
+        "- unresolved ((11111111-1111-1111-1111-111111111111))\n",
+    )
+
+    with pytest.raises(GraphSessionReadError, match="OG Parser topology read failed"):
+        create_og_topology_session_reader(tmp_path)
+
+
+def test_og_topology_rejects_title_collision(tmp_path: Path) -> None:
+    """Breaks if one canonical page identity can hide a second physical source page."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    _write_page(tmp_path, "pages/Alpha.md", "title:: Same\n- alpha\n")
+    _write_page(tmp_path, "pages/Beta.md", "title:: Same\n- beta\n")
+
+    with pytest.raises(GraphSessionReadError, match="OG Parser topology read failed"):
+        create_og_topology_session_reader(tmp_path)
+
+
+def test_og_topology_does_not_promote_parser_tags_or_refs_to_structural_edges(
+    tmp_path: Path,
+) -> None:
+    """Breaks if Parser convenience fields infer topology semantics beyond explicit references."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    _write_page(tmp_path, "pages/Alpha.md", "- tagged #Beta\n")
+    _write_page(tmp_path, "pages/Beta.md", "- beta\n")
+
+    binding = create_og_topology_session_reader(tmp_path)
+    response = binding.reader.topology_snapshot(
+        session_id=binding.session.id,
+        graph_id=binding.session.graph_id,
+    )
+
+    assert response.result.edges == ()
+
+
+def test_og_topology_excludes_aggregate_page_property_refs(tmp_path: Path) -> None:
+    """Page ``refs`` merges properties and block fields, so it has no v1 edge meaning."""
+    from src.agent.og_topology_session_composition import create_og_topology_session_reader
+
+    property_markdown = "related:: [[Beta]]\n- alpha\n"
+    assert LogosParser().parse(property_markdown).refs == ["Beta"]
+    _write_page(tmp_path, "pages/Alpha.md", property_markdown)
+    _write_page(tmp_path, "pages/Beta.md", "- beta\n")
+
+    binding = create_og_topology_session_reader(tmp_path)
+    response = binding.reader.topology_snapshot(
+        session_id=binding.session.id,
+        graph_id=binding.session.graph_id,
+    )
+
+    assert response.result.edges == ()

--- a/tests/test_shadow_bounded_parse.py
+++ b/tests/test_shadow_bounded_parse.py
@@ -19,7 +19,6 @@ from src.graph.bounded_page_parse import (
     BoundedParseResult,
     ParseMode,
     content_hash16,
-    parse_page_text_bounded,
 )
 from src.graph.post_write import PageWrittenEvent
 from src.shadow.bootstrap import (
@@ -35,8 +34,6 @@ from src.shadow.health import ShadowHealthState, resolve_shadow_health
 from src.shadow.meta import META_LAST_SYNC_ERROR, get_meta
 from src.shadow.runtime_state import reset_shadow_runtime_state_for_tests
 from src.shadow.sync import _on_shadow_page_written, sync_page_into_connection, sync_page_to_shadow
-
-from tests.a_cli_01_generator import generate_pathological_page
 
 
 @pytest.fixture(autouse=True)
@@ -241,18 +238,39 @@ def test_shadow_source_contains_no_direct_stack_machine_parser_call() -> None:
     )
 
 
-def test_real_pathological_page_rolls_back_full_rebuild_with_bounded_error(
+def test_bounded_timeout_rolls_back_full_rebuild_with_bounded_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    warm = parse_page_text_bounded("- warm\n", mode="stack", timeout_s=15)
-    assert warm.ok
-    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
     root = _graph(tmp_path)
     _write_page(root, "Alpha.md", "- ordinary\n")
-    _write_page(root, "Pathological.md", generate_pathological_page())
+    timed_out = "- controlled timeout\n"
+    _write_page(root, "TimedOut.md", timed_out)
 
-    with pytest.raises(ShadowPageParseError):
+    from src.graph.bounded_page_parse import parse_page_text_bounded as real_parse
+
+    def _parse(
+        text: str,
+        *,
+        mode: ParseMode = "logos",
+        page_title: str = "Page",
+        tab_size: int = 2,
+        timeout_s: float | None = None,
+    ) -> BoundedParseResult:
+        if text == timed_out:
+            return _failed_parse(text)
+        return real_parse(
+            text,
+            mode=mode,
+            page_title=page_title,
+            tab_size=tab_size,
+            timeout_s=timeout_s,
+        )
+
+    with (
+        patch("src.graph.bounded_ast_graph.parse_page_text_bounded", side_effect=_parse),
+        pytest.raises(ShadowPageParseError),
+    ):
         rebuild_shadow_from_graph(root)
 
     conn = open_shadow_db(root)
@@ -262,22 +280,45 @@ def test_real_pathological_page_rolls_back_full_rebuild_with_bounded_error(
     finally:
         conn.close()
     assert "category=timeout" in error
-    assert "Pathological.md" not in error
+    assert "TimedOut.md" not in error
     assert str(root) not in error
     assert resolve_shadow_health(root) is ShadowHealthState.ERROR
 
 
-def test_real_pathological_incremental_keeps_last_good_page(
+def test_bounded_timeout_incremental_keeps_last_good_page(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     root = _graph(tmp_path)
     page = _write_page(root, "Alpha.md", "- last good content\n")
     rebuild_shadow_from_graph(root)
-    monkeypatch.setenv("MATRYCA_PAGE_PARSE_TIMEOUT_S", "2")
-    page.write_text(generate_pathological_page(), encoding="utf-8")
+    timed_out = "- controlled timeout\n"
+    page.write_text(timed_out, encoding="utf-8")
 
-    with pytest.raises(ShadowPageParseError):
+    from src.graph.bounded_page_parse import parse_page_text_bounded as real_parse
+
+    def _parse(
+        text: str,
+        *,
+        mode: ParseMode = "logos",
+        page_title: str = "Page",
+        tab_size: int = 2,
+        timeout_s: float | None = None,
+    ) -> BoundedParseResult:
+        if text == timed_out:
+            return _failed_parse(text)
+        return real_parse(
+            text,
+            mode=mode,
+            page_title=page_title,
+            tab_size=tab_size,
+            timeout_s=timeout_s,
+        )
+
+    with (
+        patch("src.graph.bounded_ast_graph.parse_page_text_bounded", side_effect=_parse),
+        pytest.raises(ShadowPageParseError),
+    ):
         sync_page_to_shadow(root, page)
 
     conn = open_shadow_db(root)

--- a/uv.lock
+++ b/uv.lock
@@ -1009,16 +1009,16 @@ wheels = [
 
 [[package]]
 name = "logseq-matryca-parser"
-version = "1.7.1"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/0f/34989f1ede555f54c2789e67f014fc31131e7369593a6e07e894bfb1f2d4/logseq_matryca_parser-1.7.1.tar.gz", hash = "sha256:ba45f10b620a801308722a825da000a3519e3955e8e81ab36d05550a84858ec0", size = 870339, upload-time = "2026-08-08T04:52:31.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/4d/8dd015325ebd774d96a89a4f40ef5475340d0394f7d00d91e77269d083d5/logseq_matryca_parser-1.9.0.tar.gz", hash = "sha256:acbca0c477d6c31db75cd7078baf7c52e572a0a2272d2a8f9e47d238e2a49799", size = 1128967, upload-time = "2026-09-06T02:34:12.823Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/a9/4372c18d76ec264d52bc6c5196c595fd993b2b751699316719b849a22244/logseq_matryca_parser-1.7.1-py3-none-any.whl", hash = "sha256:6c5f1d96857c27a99ac852d3a7766521ff89641f67cf27de22c160b6cb810901", size = 82351, upload-time = "2026-08-08T04:52:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b3/2d7a046dbaf931ac870026cf9bc14fc9a8e339613b7de42f65d3d16ece7f/logseq_matryca_parser-1.9.0-py3-none-any.whl", hash = "sha256:d9e67b493439b44aa233beb0a783ca8cb07b394ac10eaafe7ae4eab9c0242fe6", size = 89404, upload-time = "2026-09-06T02:34:10.942Z" },
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ requires-dist = [
     { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "ijson", specifier = ">=3.5.0" },
     { name = "instructor", specifier = ">=1.7.0,<2.0.0" },
-    { name = "logseq-matryca-parser", specifier = ">=1.7.1,<2.0.0" },
+    { name = "logseq-matryca-parser", specifier = ">=1.9.0,<2.0.0" },
     { name = "loguru", specifier = ">=0.7.0,<1.0.0" },
     { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0,<3.0.0" },


### PR DESCRIPTION
## Summary

- Admit Logseq Matryca Parser 1.9.0 through its public immutable snapshot API.
- Add bounded Logseq OG topology projection and opaque session lifecycle inside Plumber.
- Replace parser-speed-dependent timeout tests with deterministic lifecycle tests.
- Define topology v1 semantics: only explicit node wikilinks and block references become edges.

## Architecture and scope

The flow remains `Logseq OG -> Parser -> Plumber`. Plumber owns `plumber.graph.*`; Parser only parses captured Markdown bytes. This pull request adds no public transport, CLI/MCP endpoint, Logseq DB path, Shadow DB path, Trama/Brain import, UI, or LENS code.

## Safety and compatibility

- Snapshot capture is bounded to 1,024 sources, 16 MiB total, and 1 MiB per source.
- Symlinked source directories are rejected.
- Parser runs with strict reference and title-collision checks.
- Session identifiers are opaque and topology responses contain no note bodies.
- Deadline termination, child recycling, queue discard, and stale-result prevention are tested deterministically.
- Aggregate page references, tags, and convenience `refs` are intentionally excluded from topology v1 because their origin cannot be distinguished safely.

## Verification

- Focused suite: 48 passed.
- Ruff formatting and lint: passed.
- Strict mypy: passed.
- Agent and documentation checks: passed.
- Fresh full `make -B ci`: passed on local source tree.
- Independent semantic review: GREEN.
- Remote commit tree matches the reviewed local tree exactly: `67ccefa91f8b4343c2d5821edae37c7c9aacd805`.
- GitHub reports the remote commit signature valid.

## Licensing

Independent adapter around the Parser 1.9.0 public API. No LENS UI code or external copyright-bearing contribution was copied or derived.

Closes #576
Refs #490
Refs #63
